### PR TITLE
fix(cnpg-barman-plugin): co-locate with CNPG operator namespace

### DIFF
--- a/infrastructure/controllers/argocd/apps/custom-entrypoints/cnpg-barman-plugin-app.yaml
+++ b/infrastructure/controllers/argocd/apps/custom-entrypoints/cnpg-barman-plugin-app.yaml
@@ -1,7 +1,14 @@
 # CloudNativePG Barman Cloud Plugin — replaces deprecated native barmanObjectStore
 # (removed in CNPG 1.30.0). Standalone Application (not in infrastructure AppSet)
-# because the manifest targets cnpg-system namespace, not the Application basename.
-# Must be ready before any Cluster references a barman-cloud plugin.
+# because the manifest is namespace-co-located with the CNPG operator and
+# must be ready before any Cluster references a barman-cloud plugin.
+#
+# Destination namespace: must match the CNPG operator's namespace. CNPG
+# plugin discovery only finds Services within the operator's own namespace
+# (https://cloudnative-pg.io/plugin-barman-cloud/docs/next/installation/).
+# Operator runs in `cloudnative-pg` (per cloudnative-pg-operator-app.yaml),
+# so the plugin lands there too. The old install in `cnpg-system` had to be
+# cleaned up manually after this fix landed (see commit body).
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -20,7 +27,8 @@ spec:
     path: infrastructure/database/cnpg-barman-plugin
   destination:
     server: https://kubernetes.default.svc
-    namespace: cnpg-system
+    # Must equal the CNPG operator's namespace (plugin discovery requirement).
+    namespace: cloudnative-pg
   syncPolicy:
     automated:
       prune: true

--- a/infrastructure/database/cnpg-barman-plugin/kustomization.yaml
+++ b/infrastructure/database/cnpg-barman-plugin/kustomization.yaml
@@ -2,7 +2,7 @@
 #
 # Replaces the deprecated in-Cluster `spec.backup.barmanObjectStore` (removed
 # in CNPG 1.30.0). Provides the ObjectStore CRD and a plugin sidecar that the
-# CNPG operator reaches via gRPC over a cnpg-system/barman-cloud Service.
+# CNPG operator reaches via gRPC over a barman-cloud Service.
 #
 # Upstream: https://github.com/cloudnative-pg/plugin-barman-cloud
 # Pinned to v0.12.0 (2026-04-14). Bump the URL tag to upgrade.
@@ -10,9 +10,37 @@
 # Why URL instead of a vendored manifest.yaml: upstream doesn't publish a
 # Helm chart, and the raw manifest is ~1100 lines (mostly CRD OpenAPI
 # schema). Pulling from the tag keeps the repo lean and consistent with how
-# cilium/kyverno charts are fetched (remote reference, pinned version).
+# the cilium chart is fetched (remote reference, pinned version).
+#
+# CRITICAL: the plugin MUST be installed in the same namespace as the CNPG
+# operator. The CNPG operator's plugin discovery only finds Services within
+# its OWN namespace, regardless of the cnpg.io/pluginName label being set
+# correctly. We hit this 2026-05-07: plugin in cnpg-system, operator in
+# cloudnative-pg → operator silently failed to discover the plugin →
+# Cluster status: "wal archive plugin is not available:
+# barman-cloud.cloudnative-pg.io". Documented at
+# https://cloudnative-pg.io/plugin-barman-cloud/docs/next/installation/
+# ("The plugin must be installed in the same namespace as the CloudNativePG
+# operator").
+#
+# Solution: kustomize `namespace:` directive overrides metadata.namespace
+# on every namespaced resource the upstream manifest creates (Deployment,
+# Service, ServiceAccount, Role, RoleBinding, Issuer, Certificate). Subjects
+# of ClusterRoleBinding are also rewritten by kustomize. The Namespace kind
+# named `cnpg-system` in the upstream manifest is cluster-scoped and would
+# still be created; we patch it out below so we don't end up with an empty
+# cnpg-system ns.
+#
+# After the cutover, the OLD plugin Deployment/Service/Secrets in the
+# pre-existing cnpg-system namespace become dangling (ArgoCD no longer
+# tracks them since the App's destination changed). Clean up manually
+# after verifying the new plugin works:
+#   kubectl delete ns cnpg-system
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+# Co-locate with the CNPG operator. Discovery requires same-namespace.
+namespace: cloudnative-pg
 
 commonAnnotations:
   # Internal wave for resources inside the cnpg-barman-plugin Application.
@@ -22,3 +50,18 @@ commonAnnotations:
 
 resources:
   - https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v0.12.0/manifest.yaml
+
+patches:
+  # The upstream manifest creates a Namespace resource named `cnpg-system`.
+  # Strip it — we're co-located in cloudnative-pg now (see header). Without
+  # this strip, kustomize would still emit the Namespace (cluster-scoped
+  # kinds are not affected by the `namespace:` directive above).
+  - patch: |
+      $patch: delete
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: cnpg-system
+    target:
+      kind: Namespace
+      name: cnpg-system


### PR DESCRIPTION
## TL;DR

Fixes \`wal archive plugin is not available: barman-cloud.cloudnative-pg.io\` on temporal-database after the spec.plugins[] migration. Root cause: plugin in \`cnpg-system\`, operator in \`cloudnative-pg\`. CNPG plugin discovery is **hard-scoped to the operator's own namespace** — documented but easy to miss.

## Why this happened

The upstream barman-cloud-plugin install manifest defaults to namespace \`cnpg-system\` (matches its README's install command). This cluster's CNPG operator was installed via the helm chart with namespace \`cloudnative-pg\`. They never collided until the plugin became required (post spec.plugins[] migration).

Quoting the [official docs](https://cloudnative-pg.io/plugin-barman-cloud/docs/next/installation/):

> *The plugin must be installed in the same namespace as the CloudNativePG operator (typically \`cnpg-system\`).*

We had:
- Operator → \`cloudnative-pg\`
- Plugin   → \`cnpg-system\`

## What this commit does

Two file changes:

1. **\`infrastructure/database/cnpg-barman-plugin/kustomization.yaml\`** — add \`namespace: cloudnative-pg\` to override metadata.namespace on every namespaced resource the upstream manifest emits. Patch out the cluster-scoped \`Namespace cnpg-system\` so kustomize doesn't recreate the empty namespace.
2. **\`infrastructure/controllers/argocd/apps/custom-entrypoints/cnpg-barman-plugin-app.yaml\`** — Application \`destination.namespace\`: \`cnpg-system\` → \`cloudnative-pg\`.

## Diagnosis evidence

What we checked before this fix:
- Plugin pod Running, logs show \`"Starting plugin", name: "barman-cloud.cloudnative-pg.io", version: 0.12.0\` ✓
- Plugin Service has \`cnpg.io/pluginName=barman-cloud.cloudnative-pg.io\` label ✓
- TLS Secrets (\`barman-cloud-server-tls\`, \`barman-cloud-client-tls\`) exist ✓
- Operator's RBAC: \`kubectl auth can-i get secrets -n cnpg-system\` → yes ✓
- TCP connectivity from operator namespace to plugin Service:9090 → open ✓
- ObjectStore CR (\`temporal-objectstore\`) reconciles cleanly ✓
- Operator restart: done. Plugin controller starts. **Discovery still silently fails.** ✗

The cluster's status condition keeps reporting \`ContinuousArchivingFailing\` with message \`wal archive plugin is not available\`. The cause turned out to be namespace-scoped discovery, not RBAC, networking, or TLS.

## Post-merge cleanup (manual)

The pre-existing live \`cnpg-system\` namespace still has the OLD plugin Deployment/Service/Secrets. ArgoCD won't prune them because the App's destination changed — they're orphaned, not auto-deleted. After verifying the new plugin is healthy:

\`\`\`bash
# Confirm new plugin Deployment is Running in cloudnative-pg
kubectl get deploy -n cloudnative-pg barman-cloud

# Confirm temporal cluster reconciled successfully
kubectl get cluster temporal-database -n cloudnative-pg
# expect: Ready=True, ContinuousArchiving=True

# Manual cleanup of the dead namespace
kubectl delete ns cnpg-system
\`\`\`

## Validation steps after merge + ArgoCD sync

1. Sync the \`cnpg-barman-plugin\` Application
2. Wait for new \`barman-cloud-*\` pod in \`cloudnative-pg\` to become Running
3. The CNPG operator's plugin controller picks up the new Service automatically
4. \`temporal-database\` Cluster status flips to:
   - \`Ready: True\`
   - \`ContinuousArchiving: True\`
5. Trigger a manual backup:
   \`\`\`
   kubectl cnpg backup temporal-database -n cloudnative-pg \\
     --plugin barman-cloud.cloudnative-pg.io
   \`\`\`
6. Verify backup landed at the SAME RustFS path as the in-tree path used (\`serverName: temporal-database-v2\` is preserved bit-for-bit per commit \`86c30e3f\`).
7. After 24h of clean WAL archiving + scheduled backup completion: \`kubectl delete ns cnpg-system\`.

## Doesn't affect the other 3 clusters

immich/gitea/paperless are still on the deprecated \`spec.backup.barmanObjectStore\` shape (ArgoCD never synced them after temporal failed — canary discipline working as designed). Their migration to \`spec.plugins[]\` proceeds normally once temporal is verified green on the new plugin location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)