### PR TITLE
fix(ai): stop llama-cpp router thrash — default Perplexica + OpenWebUI to shared qwen3.6-nothink

### DIFF
--- a/my-apps/ai/open-webui/open-webui-configmap.env
+++ b/my-apps/ai/open-webui/open-webui-configmap.env
@@ -1,7 +1,7 @@
 OPENAI_API_BASE_URL=http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1
 OPENAI_API_KEY=sk-required
 ENABLE_OLLAMA_API=false
-DEFAULT_MODELS=qwen3.6 - qwen3.6-35b-a3b
+DEFAULT_MODELS=qwen3.6-nothink - qwen3.6-35b-a3b-nothink
 WHITELISTED_MODELS=
 VISION_MODELS=qwen3.6 - qwen3.6-35b-a3b
 CONTEXT_WINDOW=65536

--- a/my-apps/ai/perplexica/config.json
+++ b/my-apps/ai/perplexica/config.json
@@ -21,13 +21,13 @@
         "baseURL": "http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1"
       },
       "chatModels": [
-        { "name": "Qwen 3.6 (longctx, 256K) — recommended", "key": "qwen3.6-longctx - qwen3.6-35b-a3b-longctx" },
+        { "name": "Qwen 3.6 (nothink, fast) — recommended", "key": "qwen3.6-nothink - qwen3.6-35b-a3b-nothink" },
         { "name": "Qwen 3.6 (think)",              "key": "qwen3.6 - qwen3.6-35b-a3b" },
-        { "name": "Qwen 3.6 (nothink, fast)",      "key": "qwen3.6-nothink - qwen3.6-35b-a3b-nothink" },
         { "name": "Gemma 4 31B dense (think)",     "key": "gemma4-31b - gemma4-31b" },
         { "name": "Gemma 4 31B dense (nothink)",   "key": "gemma4-31b-nothink - gemma4-31b-nothink" },
         { "name": "Qwen 3.5 Uncensored (think)",   "key": "uncensored - qwen3.5-uncensored" },
-        { "name": "Qwen 3.5 Uncensored (nothink)", "key": "nothink-uncensored - qwen3.5-uncensored-nothink" }
+        { "name": "Qwen 3.5 Uncensored (nothink)", "key": "nothink-uncensored - qwen3.5-uncensored-nothink" },
+        { "name": "Qwen 3.6 (longctx 256K) — DUAL-CARD ONLY, ~4x slower TTFT on single 3090", "key": "qwen3.6-longctx - qwen3.6-35b-a3b-longctx" }
       ],
       "embeddingModels": []
     }


### PR DESCRIPTION
## Root cause

Perplexica/Vane searches stalled or returned `500 "model … failed to load"`. Root cause is **llama-cpp router instance thrash under `--models-max 1`**, not per-token speed.

- The router keys a resident child process by **preset**, not by GGUF file. `qwen3.6` (think), `qwen3.6-nothink`, and `qwen3.6-longctx` are **separate llama-server instances**. think and nothink even share the *same* GGUF **and** the *same* `--ctx-size 65536` — they differ only in sampling/template flags (`--temp 1.0`+`enable_thinking:true` vs `--temp 0.7`+`enable_thinking:false`) — yet the router still runs them as distinct processes. `longctx` additionally differs by `--ctx-size 262144`.
- With `--models-max 1`, only one child can be resident. Every switch between presets force-unloads one and reloads the other — a ~22GB `--no-mmap` GGUF read off NFS (~16s warm in this test, 30–90s cold).
- If a load is still in-flight when a different preset is requested, the LRU evictor force-kills it → caller gets `500 "model … failed to load"`. That is the "stall".

### Live proof (instance test, this PR)

Resident child was `nothink`. Fired a **think** request:

```
ensure_model: name=qwen3.6 - qwen3.6-35b-a3b is not loaded, loading...
unload_lru: models_max limit reached, removing LRU name=qwen3.6-nothink - qwen3.6-35b-a3b-nothink
```

…and the reverse on the next nothink request. Both directions cost **~16s** (think→nothink 16.2s, nothink→think 16.6–17.0s) for the full GGUF reload; a resident reply is sub-second. Warm A/B (identical 35,425-tok prompt, both pre-warmed) showed `nothink` ≈ `longctx` on speed (~15.4s prefill / ~58 tok/s) — confirming the cost is purely reload thrash, not the model.

## The fix

Two configs were defaulting to a *non-shared* instance and thrashing against the `nothink` daily driver every other app uses:

1. **Perplexica** (`my-apps/ai/perplexica/config.json`) — defaulted to `qwen3.6-longctx` (256K, dual-card territory). Reordered seed `chatModels[]` so `qwen3.6-nothink - qwen3.6-35b-a3b-nothink` is `chatModels[0]`; `longctx` demoted to last with a "DUAL-CARD ONLY" warning label (kept selectable for manual deep runs).
2. **OpenWebUI** (`my-apps/ai/open-webui/open-webui-configmap.env`) — `DEFAULT_MODELS` was `qwen3.6` (think), a separate instance. Repointed to `qwen3.6-nothink - qwen3.6-35b-a3b-nothink`. `TASK_MODEL`/`TASK_MODEL_EXTERNAL` left as-is (already nothink).

Result: all daily traffic (Perplexica, OpenWebUI chat + tasks, and other clients) shares **one resident `nothink` instance** → no evictions, no reloads, no 500s.

`--models-max` unchanged. KV stays symmetric q8_0/q8_0. vLLM not enabled.

## ⚠️ localStorage caveat (Perplexica)

Vane stores the active model in **browser `localStorage["chatModelKey"]`**, falling back to `chatModels[0]` **only when empty**. The seed reorder only changes the default for **fresh sessions / new browsers**. Any existing browser already has `chatModelKey` pinned to `longctx` and **must switch the model once in the Vane UI** (or clear site storage) for this fix to take effect.

## Was OpenWebUI also repointed?

**Yes.** The instance test proved think and nothink are separate instances, so per the plan OpenWebUI's `DEFAULT_MODELS` was repointed to the shared nothink driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)