### PR TITLE
bootstrap: pin ArgoCD chart to 9.5.19 to match GitOps

### DIFF
--- a/scripts/bootstrap-argocd.sh
+++ b/scripts/bootstrap-argocd.sh
@@ -113,7 +113,7 @@ echo ""
 echo "⎈ Installing ArgoCD via Helm..."
 if ! helm upgrade --install argocd argo-cd \
   --repo https://argoproj.github.io/argo-helm \
-  --version 9.5.17 \
+  --version 9.5.19 \
   --namespace argocd \
   --values "$ROOT_DIR/infrastructure/controllers/argocd/values.yaml" \
   --wait \


### PR DESCRIPTION
## Problem
GitOps manages the argo-cd Helm chart at **9.5.19** (bumped in #1365), but `scripts/bootstrap-argocd.sh` still installed **9.5.17**. `scripts/validate-argocd-apps.sh` *Check 5* enforces that the bootstrap pin and the GitOps-managed version match, so the **ArgoCD Structure Validation** check was failing on *every* PR with:

```
ERROR: Bootstrap installs ArgoCD chart 9.5.17 but GitOps manages 9.5.19
```

A fresh bootstrap would also immediately self-upgrade ArgoCD after install.

## Fix
Bump the bootstrap `--version` pin `9.5.17 → 9.5.19`. One line.

## Verification
`bash scripts/validate-argocd-apps.sh` Check 5 now reports:
```
OK: Bootstrap and self-managed ArgoCD chart versions match (9.5.19)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)