### PR TITLE
Trial: kopiur as a pvc-plumber/VolSync replacement (karakeep canary)

### DIFF
--- a/docs/domains/storage/kopiur-evaluation.md
+++ b/docs/domains/storage/kopiur-evaluation.md
@@ -1,0 +1,79 @@
+# kopiur evaluation — engine candidate for the backup path
+
+> Strategic companion to the operational [`docs/kopiur-trial.md`](../../kopiur-trial.md).
+> Captures the 2026-06-26 evaluation of **kopiur** (home-operations' Kopia-native
+> Rust backup operator) as a possible pvc-plumber/VolSync replacement: the fit
+> analysis, the community landscape, the maintainer conversation, the source-code
+> map, and the verified facts. Decision + trial status at the top.
+
+## TL;DR decision
+- **kopiur is a backup ENGINE + CRD API — effectively a VolSync replacement, NOT a pvc-plumber replacement.** pvc-plumber is a DX + governance layer (3 labels → generated `RS`/`RD`, `/audit` ledger, `needs-human-review`). kopiur has no equivalent DX/audit layer.
+- **The restore-before-bind "hold" is the Kubernetes Volume Populator contract** — provided by VolSync today and by kopiur's `Restore` populator. It is *not* a pvc-plumber feature; pvc-plumber only generates the VolSync objects. Confirmed verbatim (k8s docs): *"the PVC doesn't bind to the PV until it's fully populated… pods won't begin running until everything is ready."*
+- **Don't rip-replace pvc-plumber with kopiur.** You'd lose labels + `/audit` and adopt a pre-1.0 alpha. If you want kopiur's engine, keep a thin label→CRD layer on top (pvc-plumber, or a Kustomize/Helm component). The maintainer confirmed kopiur stays explicit by design ("own your PVC, use `existingClaim`"), so the convenience/safety layer is yours to own.
+- **Status:** trialing on the **karakeep** canary via PR #1489 (branch `claude/kopiur-trial`). See [`kopiur-trial.md`](../../kopiur-trial.md).
+
+## The 5-question fit comparison
+
+| # | Requirement (what pvc-plumber gives) | kopiur reality | Verdict |
+|---|---|---|---|
+| 1 | **Restore-before-bind** on recreate | Implemented (`target.populator` handshake, v0.4.7). PVC stays `Pending` until restored; `onMissingSnapshot: Continue` = restore-if-exists-else-fresh, `Fail` = hard stop. | ✅ **parity** (same K8s populator contract) |
+| 2 | **Zero-YAML, label-driven** backend | None. Explicit `SnapshotPolicy`+`SnapshotSchedule`+`Restore` per PVC (a `pvcSelector` covers multiple but you still author CRs). | ❌ **gap** — kopiur's core is the opposite |
+| 3 | **`/audit` ledger of the negative space** + exemptions | metrics/`doctor`/`status` report on kopiur's *own* resources only. No PVC-coverage map, no `needs-human-review`, no exemption-reason. Unconfigured PVCs are invisible. | ❌ **gap** |
+| 4 | **Node-local mover** (data gravity) | Per-PVC mover Job co-located on the PVC's node; Rust binary + kopia, ~70 MB. Controller never pulls data centrally. | ✅ **parity** — but bytes still move via **kopia**; "Rust" wins the *control plane*, not network throughput |
+| 5 | **Permissive blast radius** (operator down ≠ outage) | Validating+mutating webhooks, default `failurePolicy: Fail` — but rules target **only `kopiur.home-operations.com` CRDs**, never PVCs/Pods. App deploy is never blocked. | ⚠️ **not permissive, but ≪ your old PVC webhook**; only the DR `Restore`-CR path is gated (mitigate: early sync wave / `failurePolicy: Ignore`) |
+
+## Community landscape — who actually does restore-before-bind
+
+| Tool | Label/annotation-driven | Hold PVC until restored (populator) | Fit |
+|---|---|---|---|
+| **VolSync** | ❌ (you template `RS`/`RD`) | ✅ yes (`dataSourceRef → ReplicationDestination`) | the engine you run today; mature (`v0.16.0`, backube) |
+| **kopiur** | ❌ (explicit CRDs) | ✅ yes (`dataSourceRef → Restore`) | alpha (`0.4.x`, daily releases, AGPL, PRs declined) |
+| **Velero** | ✅ | ❌ restore is a separate step | reintroduces the blank-PVC race |
+| **K8up / Stash / Gemini** | ✅ | ❌ | backup-only / annotation-triggered delete+replace |
+
+**Only VolSync and kopiur implement the populator-hold.** Everything else backs up fine but restores as a separate imperative step — exactly the blank-PVC-then-corrupt race this whole system exists to prevent.
+
+## Why "just restore afterward" is not enough
+The hold matters because restore-after-the-fact is often **too late** — a one-way door once the app boots on an empty volume:
+1. **The good snapshot can already be gone** — the blank instance's *own* scheduled backup snapshots the empty state; retention ages out the real one. "Restore" then restores the blank.
+2. **Irreversible external side effects** — re-onboarding mints/rotates API keys + tokens (provider revokes the old ones). Restoring the old DB brings back revoked creds and drops the new ones — broken either way. (e.g. Sonarr's API key embedded across Prowlarr/Overseerr; HA OAuth tokens.)
+3. **Divergent writes** — the app wrote real data to the blank volume (moved files, queued work, new history); restoring the old DB loses it *and* desyncs from disk.
+4. **Lockout deadlock** — for auth-bearing apps (Vaultwarden, an IdP) the credential lived in the data you lost; "log in again" assumes a login that no longer exists.
+
+Sharpest example (used in the maintainer pitch): a **game-server world save** (Minecraft/Valheim/Zomboid) — irreplaceable, no "login," and the fresh-world backup overwrites the real one.
+
+## Maintainer conversation (home-operations Discord, 2026-06-26)
+Raised the GitOps "blank-PVC on recreate" problem as a question (not a pitch). Outcome:
+- bo0tzz (maintainer): the populator-hold is **the default behavior** when the PVC carries `dataSourceRef`. *"The whole concept of letting a chart own an important PVC is scary to me."*
+- m00n: *"just don't let the chart make the PVC, set it to an existing PVC"* (i.e. `existingClaim` + you own the PVC) — community-upvoted.
+- **Conclusion:** kopiur is **intentionally explicit** (own your PVC, wire `Restore`+`dataSourceRef` yourself). It will **not** own a label-driven auto-wiring / audit layer — same instinct that makes the maintainer dislike implicit PVC magic. **So that convenience+safety layer stays yours** (pvc-plumber, or a thin Kustomize/Helm component). The residual real gap: at ~30 hand-owned PVCs, *forgetting* the `dataSourceRef`/`Restore` on one is silent until a rebuild — which is exactly what a label-stamp prevents.
+
+## kopiur source map (Rust, `kube-rs`)
+The auto-hydrate mechanics **already exist**; the only missing piece is a label→`Restore`+`dataSourceRef` trigger, and `dataSourceRef` immutability constrains where it can live.
+
+| Capability | File : function |
+|---|---|
+| Populator handshake (pause-bind → prime PVC → rebind) | `crates/controller/src/restore/mod.rs` : `drive_populator_restore` → `ensure_prime_pvc` → `run_restore_mover` → `rebind_prime_to_consumer` → `finalize_populator` |
+| Snapshot resolution + `onMissingSnapshot` (`Continue`→`Empty`, `Fail`→`Failed`) | `restore/mod.rs` : `reconcile` / `resolve_snapshot`; `restore/plan.rs` : `populator_state` |
+| "Does a backup exist for this volume?" (by identity) | `crates/kopia/src/client/mod.rs` : `snapshot_list(filter)`; pick latest via `selection.rs` : `pick_offset` |
+| Execute restore | `kopia/src/client/mod.rs` : `snapshot_restore` / `snapshot_restore_with` |
+| **Trigger seam** for a label-driven mapper | `crates/controller/src/watch.rs` : `pvc_to_restores` (today matches `spec.dataSourceRef`); model a `pvc_labels_to_restores` on the existing selector mapper `policy_to_schedules` |
+| Webhook (CRD-only) | `crates/webhook/src/handlers.rs` : per-CRD handlers; **only `Snapshot` mutates**; **no PVC/Pod handler** |
+
+**The architectural constraint:** `dataSourceRef` is immutable and must exist **at PVC create time** (it's what makes K8s withhold binding). A label on a *bare* PVC can't trigger the hold — by the time a controller sees it, the default StorageClass already bound it empty. So label→`dataSourceRef` must happen at **render/admission time**, not in a post-bind controller. A PVC mutating webhook would do it but (a) breaks kopiur's CRD-only webhook scope, (b) puts a synchronous S3 check in the admission path (anti-pattern), (c) `failurePolicy` on PVCs is the exact SPOF pvc-plumber removed. **Design-compatible answer: render-time generation** (a `kubectl kopiur` / Helm-template helper, or pvc-plumber) — Git carries the `dataSourceRef`.
+
+## Verified kopiur facts (as of `0.4.13`, 2026-06)
+- **No published OCI/Helm-repo chart** — chart lives only at `deploy/helm/kopiur` (chart version `0.1.0`); render it via ArgoCD from the upstream **git tag** (`0.4.x`, no `v` prefix).
+- **CRDs (`v1alpha1`):** `Repository`, `ClusterRepository`, `SnapshotPolicy`, `Snapshot`, `SnapshotSchedule`, `Restore`, `Maintenance`, `RepositoryReplication`. (ADR-0003 still calls them `BackupConfig`/`Backup`/`BackupSchedule` — renamed; expect more CRD churn pre-1.0.)
+- **S3 backend:** `backend.s3.{bucket, prefix, endpoint, region}`, `endpoint` is a **bare `host:port`** (no scheme/slash), TLS-off is `tls.disableTls: true`. `ClusterRepository` secret refs **must** carry an explicit `namespace` (webhook-enforced).
+- **Creds Secret keys:** `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `KOPIA_PASSWORD`.
+- **Chart values:** `installScope` (`namespaced`|`cluster`), `installCRDs: true` (default), `webhook.failurePolicy: Fail` (default), `webhook.tls.mode: self` (self-signs at runtime — **no cert-manager hook Job**, ArgoCD-safe), per-image `image.{controller,webhook,mover}.tag/digest`.
+- **Mover:** statically-linked Rust binary + official kopia binary, distroless ~70 MB; reads a downward-API JSON work spec, streams `kopia --json`, PATCHes progress to `status`. Co-locates on the PVC's node for RWO (avoids Multi-Attach).
+- **Backend-down safety differs from ours:** kopiur uses a repository health-probe / preflight, **not** the `wait-for-rustfs` MutatingAdmissionPolicy (which only gates VolSync mover Jobs). Verify kopiur's preflight actually blocks a snapshot Job when RustFS is unreachable before trusting it.
+
+## Open items / next steps
+1. **Verify CRD field shapes** against the installed `0.4.13` chart (`kubectl explain`) — assembled here from upstream `main` examples.
+2. **Run the restore-before-bind drill** on karakeep (delete `data-pvc` → confirm `Pending` → restore → `Bound` with data). See `kopiur-trial.md`.
+3. **Decide:** replace vs hybrid vs keep. Current lean — **keep pvc-plumber + VolSync**; revisit kopiur as an engine swap *under* a thin label layer once it's past 1.0 / stops churning CRDs.
+4. If hybridizing: a Kustomize/Helm component that stamps `SnapshotPolicy`+`Schedule`+`Restore`+`dataSourceRef` from ~3 values restores the DX without the operator.
+5. Optional upstream **issue** (not PR — they're declined): `Restore`-scoped `failurePolicy` so DR isn't gated by operator cold-start.

--- a/docs/domains/storage/kopiur-evaluation.md
+++ b/docs/domains/storage/kopiur-evaluation.md
@@ -71,6 +71,23 @@ The auto-hydrate mechanics **already exist**; the only missing piece is a label�
 - **Mover:** statically-linked Rust binary + official kopia binary, distroless ~70 MB; reads a downward-API JSON work spec, streams `kopia --json`, PATCHes progress to `status`. Co-locates on the PVC's node for RWO (avoids Multi-Attach).
 - **Backend-down safety differs from ours:** kopiur uses a repository health-probe / preflight, **not** the `wait-for-rustfs` MutatingAdmissionPolicy (which only gates VolSync mover Jobs). Verify kopiur's preflight actually blocks a snapshot Job when RustFS is unreachable before trusting it.
 
+## Reference implementations (other clusters running kopiur)
+Two real-world Flux adoptions cross-checked our manifests and corrected several fields:
+- **onedr0p/home-ops #11012** ("chore: deploy kopiur", chart `0.2.0`) — installs the operator via an **OCI Helm chart** (`oci://ghcr.io/home-operations/…`, image digests pinned), a `ClusterRepository`, and a **reusable `components/kopiur` component** (SnapshotPolicy + SnapshotSchedule + deploy-or-restore PVC + passive Restore) composed per-app via `components:` + postBuild `APP=<app>`. Centralized mover defaults + `ttlSecondsAfterFinished`. Its migration steps match our drill (verify a Snapshot succeeded with non-zero files → scale down → delete PVC → reapply → populator hydrates → scale up).
+- **eleboucher/homelab** `garage/app/kopiur.yaml` — single-app form; confirmed the field shapes our first cut was missing.
+
+**Fields these corrected in our karakeep manifests (now applied):**
+| Field | Why it matters |
+|---|---|
+| `copyMethod: Snapshot` + `volumeSnapshotClassName: longhorn-snapclass` | CSI snapshots won't fire on Longhorn without them |
+| `credentialProjection.enabled: true` (policy + restore) | the mover in the app namespace can't reach the ClusterRepository creds otherwise |
+| `mover.securityContext {568/568/568}` | restored files get wrong ownership (karakeep is 568); kopiur can also `mover.inheritSecurityContextFrom` a workload |
+| Restore `source.fromPolicy` (vs `identity`) | simpler; what both reference repos use |
+| Schedule `concurrencyPolicy: Forbid` | no overlapping snapshot Jobs |
+
+- **Operator-install hint:** both use the **OCI chart** (`oci://ghcr.io/home-operations/…`) — cleaner than our git-tag render. Ours still renders from git tag `0.4.13` (deterministic app-version pin); switching to the OCI chart (that's the *chart* version, not the app version) is a follow-up once the exact registry path is confirmed.
+- **DX hint:** onedr0p's reusable component is the Flux analog of the Kustomize component to build for ArgoCD — stamp the whole bundle from ~2 values instead of hand-writing per PVC.
+
 ## Open items / next steps
 1. **Verify CRD field shapes** against the installed `0.4.13` chart (`kubectl explain`) — assembled here from upstream `main` examples.
 2. **Run the restore-before-bind drill** on karakeep (delete `data-pvc` → confirm `Pending` → restore → `Bound` with data). See `kopiur-trial.md`.

--- a/docs/kopiur-trial.md
+++ b/docs/kopiur-trial.md
@@ -1,10 +1,13 @@
 # kopiur trial — replacing pvc-plumber (branch `claude/kopiur-trial`)
 
-> **Status: scaffold, not yet applied.** This branch stands kopiur up *alongside*
-> pvc-plumber and converts **one canary app (karakeep)** off pvc-plumber labels and
-> onto explicit kopiur CRs. Nothing here deploys until you point an ArgoCD
-> Application at this branch (the existing apps sync from `main`). It is fully
-> reversible — delete the branch, or revert the karakeep PVCs.
+> **Status: open as PR #1489** (branch `claude/kopiur-trial`). Stands kopiur up
+> *alongside* pvc-plumber and converts **one canary app (karakeep)** off
+> pvc-plumber labels onto explicit kopiur CRs. Nothing deploys until the PR is
+> merged to `main` (Argo GitOps — no manual apply). Fully reversible: revert the PR.
+>
+> **Why this trial exists (the decision + analysis):** see
+> [`domains/storage/kopiur-evaluation.md`](domains/storage/kopiur-evaluation.md) —
+> fit verdict, community landscape, maintainer conversation, kopiur code map, verified facts.
 
 ## Why karakeep
 It's the DR-doc worked example: two RWO PVCs (`data-pvc` = SQLite bookmarks +

--- a/docs/kopiur-trial.md
+++ b/docs/kopiur-trial.md
@@ -32,14 +32,31 @@ Files edited: the two karakeep PVCs (de-fused, `dataSourceRef` repointed), names
    Assembled from upstream `deploy/examples` on `main`; reconcile any drift.
 3. **RustFS HTTP/TLS** — ✅ RESOLVED: `backend.s3.tls.disableTls: true` + bare `host:port` endpoint (vs `deploy/examples/backends/s3-minio-http.yaml`).
 4. **Secret keys** — ✅ RESOLVED: backend reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `KOPIA_PASSWORD` — exactly what the ESO writes.
-5. **CRDs via ArgoCD** — the chart ships CRDs as templates; SSA + large CRDs can be fiddly. If it fights you, `helm install kopiur deploy/helm/kopiur -n kopiur-system --create-namespace --set installScope=cluster` once by hand (kopiur's own quickstart) and keep only `infrastructure/controllers/kopiur/` in GitOps.
+5. **CRDs via ArgoCD** — the chart ships CRDs as templates (not a `crds/` dir), so ArgoCD applies them on sync. `ServerSideApply=true` (set on the operator app) renders them without the 256KB last-applied-config limit. No cert-manager hook (webhook tls.mode=self), so no API-server-wedge risk.
 
-## How to run the trial
-1. Add a throwaway ArgoCD Application pointing at this branch's `core-dependencies/` (or apply the two app manifests by hand). The operator (Wave 2) installs CRDs + webhook; config (Wave 3) creates the ClusterRepository.
-2. Watch kopiur create the repo and take the first karakeep snapshots:
-   `kubectl -n karakeep get snapshotpolicy,snapshotschedule,snapshot,restore`
-   `kubectl -n kopiur-system get clusterrepository`
-3. The first `Snapshot` captures karakeep's **current** data into the fresh repo (the live PVCs are already Bound; `dataSourceRef` is a no-op until recreate).
+## How to run the trial (pure GitOps — no CLI helm)
+Operator + config are ArgoCD Applications in this repo. The root app-of-apps
+syncs `main`, so on this branch instantiate the two Apps once; ArgoCD then
+GitOps-manages everything from the repo (the operator chart is rendered from
+the upstream git tag — there is no published OCI chart):
+
+```
+kubectl apply -f infrastructure/controllers/argocd/apps/core-dependencies/kopiur-operator-app.yaml
+kubectl apply -f infrastructure/controllers/argocd/apps/core-dependencies/kopiur-config-app.yaml
+```
+
+ArgoCD then renders the chart (Wave 2 → 7 CRDs + operator + webhook) and applies
+the ClusterRepository + ESO (Wave 3). Watch:
+```
+kubectl -n kopiur-system get pods,clusterrepository
+kubectl -n karakeep get snapshotpolicy,snapshotschedule,snapshot,restore
+```
+
+The karakeep CRs ride the existing my-apps AppSet once this lands on `main`. For
+the **branch** trial only, apply the karakeep overlay from a checkout (the AppSet
+won't discover a branch): `kubectl apply -k my-apps/media/karakeep`.
+The first `Snapshot` captures karakeep's **current** data into the fresh repo
+(live PVCs are Bound; `dataSourceRef` is a no-op until recreate).
 
 ## Cutover & the real test (restore-before-bind drill)
 `dataSourceRef` is **immutable**, so the live PVCs still point at the VolSync RD.

--- a/docs/kopiur-trial.md
+++ b/docs/kopiur-trial.md
@@ -1,0 +1,62 @@
+# kopiur trial — replacing pvc-plumber (branch `claude/kopiur-trial`)
+
+> **Status: scaffold, not yet applied.** This branch stands kopiur up *alongside*
+> pvc-plumber and converts **one canary app (karakeep)** off pvc-plumber labels and
+> onto explicit kopiur CRs. Nothing here deploys until you point an ArgoCD
+> Application at this branch (the existing apps sync from `main`). It is fully
+> reversible — delete the branch, or revert the karakeep PVCs.
+
+## Why karakeep
+It's the DR-doc worked example: two RWO PVCs (`data-pvc` = SQLite bookmarks +
+assets, `meilisearch-pvc` = search index), both previously pvc-plumber hourly.
+Non-critical, easy to drill.
+
+## What changed
+
+| Area | pvc-plumber (today) | kopiur (this branch) |
+|---|---|---|
+| Per-PVC config | 3 labels + `dataSourceRef → ReplicationDestination` | explicit `SnapshotPolicy` + `SnapshotSchedule` + `Restore`, `dataSourceRef → Restore` |
+| Operator | `infrastructure/controllers/pvc-plumber/` (Wave 2) | `core-dependencies/kopiur-operator-app.yaml` Helm (Wave 2) |
+| Repo config | `volsync-kopia-repository` ClusterES | `infrastructure/controllers/kopiur/` (ns + ESO + `ClusterRepository`, Wave 3) |
+| kopia repo | `s3://volsync-kopia/cluster` | `s3://volsync-kopia/kopiur-trial/` (**fresh, isolated**) |
+| Namespace gate | `pvc-plumber.io/managed-namespace` | removed (kopiur uses `allowedNamespaces` on the ClusterRepository) |
+
+Files added: `infrastructure/controllers/kopiur/*`, `core-dependencies/kopiur-{operator,config}-app.yaml`,
+`my-apps/media/karakeep/kopiur/{data-pvc,meilisearch-pvc}.yaml`.
+Files edited: the two karakeep PVCs (de-fused, `dataSourceRef` repointed), namespace, kustomization.
+
+## ⚠️ VERIFY before you apply (kopiur is pre-1.0 / alpha — CRD fields churn)
+1. **Chart tag** — `kopiur-operator-app.yaml` pins `targetRevision: "0.4.13"`. Confirm the tag format on the releases page (`0.4.13` vs `v0.4.13`).
+2. **CRD field names** — after the operator installs, run:
+   `kubectl explain clusterrepository.spec.backend.s3` · `snapshotpolicy.spec` · `restore.spec`.
+   I assembled these from the upstream `deploy/examples` on `main`; reconcile any drift.
+3. **RustFS HTTP/TLS** — `clusterrepository.yaml` sets `backend.s3.insecure: true` as a guess for "no TLS". The real field may be `disableTls` / an `http://` endpoint. RustFS here is plain HTTP on `:30292`.
+4. **Secret keys** — confirm the S3 backend reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (the ESO writes those). Adjust `externalsecret.yaml` if kopiur wants different keys.
+5. **CRDs via ArgoCD** — the chart ships CRDs as templates; SSA + large CRDs can be fiddly. If it fights you, `helm install kopiur deploy/helm/kopiur -n kopiur-system --create-namespace --set installScope=cluster` once by hand (kopiur's own quickstart) and keep only `infrastructure/controllers/kopiur/` in GitOps.
+
+## How to run the trial
+1. Add a throwaway ArgoCD Application pointing at this branch's `core-dependencies/` (or apply the two app manifests by hand). The operator (Wave 2) installs CRDs + webhook; config (Wave 3) creates the ClusterRepository.
+2. Watch kopiur create the repo and take the first karakeep snapshots:
+   `kubectl -n karakeep get snapshotpolicy,snapshotschedule,snapshot,restore`
+   `kubectl -n kopiur-system get clusterrepository`
+3. The first `Snapshot` captures karakeep's **current** data into the fresh repo (the live PVCs are already Bound; `dataSourceRef` is a no-op until recreate).
+
+## Cutover & the real test (restore-before-bind drill)
+`dataSourceRef` is **immutable**, so the live PVCs still point at the VolSync RD.
+The kopiur populator only proves out on **recreate**:
+1. Confirm at least one kopiur `Snapshot` for `karakeep/data-pvc` exists in the repo.
+2. Scale karakeep web to 0 → delete `data-pvc` → let ArgoCD recreate it from this branch.
+3. Expect: PVC sits **Pending** while `Restore/data-pvc-restore` populates it, then binds **with data**; karakeep starts on the real `gitea`-style SQLite (bookmarks intact). That `Pending`-until-restored is the whole point.
+4. ArgoCD diff on `/spec/dataSourceRef`: the per-PVC `ServerSideApply=false` annotation + the my-apps AppSet `ignoreDifferences` mask already handle the immutable-field compare (same mechanism pvc-plumber relied on).
+
+## Friction surfaced so far (the honest "how far I got")
+- **No shared repo with VolSync.** kopiur reads a *fresh* kopia repo, so it does **not** see your existing VolSync snapshots. Trial only protects data from its first kopiur snapshot forward. (A real migration would seed/copy, or run both until kopiur has history.)
+- **Per-PVC YAML is back.** Each volume is now ~30 lines of `SnapshotPolicy`+`Schedule`+`Restore` vs 3 labels — exactly the DX gap from the Discord thread. If kept, wrap it in a Kustomize component to stay DRY.
+- **Backend-down safety differs.** The `wait-for-rustfs` MAP gates *VolSync* mover Jobs; it does nothing for kopiur. Verify kopiur's repo health-probe / preflight actually blocks a snapshot Job when RustFS is unreachable, or you lose the "never snapshot over a black-holed backend" guarantee.
+- **Webhook `failurePolicy: Ignore`** is set for the trial so a kopiur outage can't gate `Restore` CR creation during a rebuild. Re-evaluate before trusting DR.
+
+## Rollback
+Nothing on `main` changed. To abandon: delete branch `claude/kopiur-trial`.
+To revert a partial live trial: restore pvc-plumber labels on the two karakeep PVCs,
+repoint `dataSourceRef` to `*-dst`, re-add `pvc-plumber.io/managed-namespace`, and
+delete the kopiur Applications + `infrastructure/controllers/kopiur/`.

--- a/docs/kopiur-trial.md
+++ b/docs/kopiur-trial.md
@@ -18,7 +18,7 @@ Non-critical, easy to drill.
 | Per-PVC config | 3 labels + `dataSourceRef → ReplicationDestination` | explicit `SnapshotPolicy` + `SnapshotSchedule` + `Restore`, `dataSourceRef → Restore` |
 | Operator | `infrastructure/controllers/pvc-plumber/` (Wave 2) | `core-dependencies/kopiur-operator-app.yaml` Helm (Wave 2) |
 | Repo config | `volsync-kopia-repository` ClusterES | `infrastructure/controllers/kopiur/` (ns + ESO + `ClusterRepository`, Wave 3) |
-| kopia repo | `s3://volsync-kopia/cluster` | `s3://volsync-kopia/kopiur-trial/` (**fresh, isolated**) |
+| kopia repo | `s3://volsync-kopia/cluster` | `s3://kopiur/` (**dedicated bucket, isolated**) |
 | Namespace gate | `pvc-plumber.io/managed-namespace` | removed (kopiur uses `allowedNamespaces` on the ClusterRepository) |
 
 Files added: `infrastructure/controllers/kopiur/*`, `core-dependencies/kopiur-{operator,config}-app.yaml`,

--- a/docs/kopiur-trial.md
+++ b/docs/kopiur-trial.md
@@ -26,12 +26,12 @@ Files added: `infrastructure/controllers/kopiur/*`, `core-dependencies/kopiur-{o
 Files edited: the two karakeep PVCs (de-fused, `dataSourceRef` repointed), namespace, kustomization.
 
 ## ⚠️ VERIFY before you apply (kopiur is pre-1.0 / alpha — CRD fields churn)
-1. **Chart tag** — `kopiur-operator-app.yaml` pins `targetRevision: "0.4.13"`. Confirm the tag format on the releases page (`0.4.13` vs `v0.4.13`).
+1. **Chart tag** — ✅ confirmed: tags are `0.4.x` (no `v`). `targetRevision: "0.4.13"` is correct.
 2. **CRD field names** — after the operator installs, run:
    `kubectl explain clusterrepository.spec.backend.s3` · `snapshotpolicy.spec` · `restore.spec`.
-   I assembled these from the upstream `deploy/examples` on `main`; reconcile any drift.
-3. **RustFS HTTP/TLS** — `clusterrepository.yaml` sets `backend.s3.insecure: true` as a guess for "no TLS". The real field may be `disableTls` / an `http://` endpoint. RustFS here is plain HTTP on `:30292`.
-4. **Secret keys** — confirm the S3 backend reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (the ESO writes those). Adjust `externalsecret.yaml` if kopiur wants different keys.
+   Assembled from upstream `deploy/examples` on `main`; reconcile any drift.
+3. **RustFS HTTP/TLS** — ✅ RESOLVED: `backend.s3.tls.disableTls: true` + bare `host:port` endpoint (vs `deploy/examples/backends/s3-minio-http.yaml`).
+4. **Secret keys** — ✅ RESOLVED: backend reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `KOPIA_PASSWORD` — exactly what the ESO writes.
 5. **CRDs via ArgoCD** — the chart ships CRDs as templates; SSA + large CRDs can be fiddly. If it fights you, `helm install kopiur deploy/helm/kopiur -n kopiur-system --create-namespace --set installScope=cluster` once by hand (kopiur's own quickstart) and keep only `infrastructure/controllers/kopiur/` in GitOps.
 
 ## How to run the trial

--- a/docs/kopiur-trial.md
+++ b/docs/kopiur-trial.md
@@ -34,29 +34,30 @@ Files edited: the two karakeep PVCs (de-fused, `dataSourceRef` repointed), names
 4. **Secret keys** — ✅ RESOLVED: backend reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `KOPIA_PASSWORD` — exactly what the ESO writes.
 5. **CRDs via ArgoCD** — the chart ships CRDs as templates (not a `crds/` dir), so ArgoCD applies them on sync. `ServerSideApply=true` (set on the operator app) renders them without the 256KB last-applied-config limit. No cert-manager hook (webhook tls.mode=self), so no API-server-wedge risk.
 
-## How to run the trial (pure GitOps — no CLI helm)
-Operator + config are ArgoCD Applications in this repo. The root app-of-apps
-syncs `main`, so on this branch instantiate the two Apps once; ArgoCD then
-GitOps-manages everything from the repo (the operator chart is rendered from
-the upstream git tag — there is no published OCI chart):
+## How to run the trial (pure GitOps — merge, don't apply)
+The operator + config Applications are wired into the root app-of-apps
+kustomization (`infrastructure/controllers/argocd/apps/kustomization.yaml`) and
+track `main`. **There is no `kubectl apply` step** — open a PR, merge to `main`,
+and Argo deploys it (this is a real deploy to the live cluster):
+- **Wave 2** `kopiur-operator` — renders the chart from the upstream git tag
+  `0.4.13` → installs the 7 CRDs + operator + webhook.
+- **Wave 3** `kopiur-config` — namespace + ESO + ClusterRepository.
+- **Wave 6** the my-apps AppSet re-renders karakeep with the kopiur CR bundle and
+  the repointed PVCs.
 
+Watch:
 ```
-kubectl apply -f infrastructure/controllers/argocd/apps/core-dependencies/kopiur-operator-app.yaml
-kubectl apply -f infrastructure/controllers/argocd/apps/core-dependencies/kopiur-config-app.yaml
-```
-
-ArgoCD then renders the chart (Wave 2 → 7 CRDs + operator + webhook) and applies
-the ClusterRepository + ESO (Wave 3). Watch:
-```
+kubectl get applications -n argocd | grep kopiur
 kubectl -n kopiur-system get pods,clusterrepository
 kubectl -n karakeep get snapshotpolicy,snapshotschedule,snapshot,restore
 ```
+The first `Snapshot` captures karakeep's current data into the fresh repo (live
+PVCs are Bound; `dataSourceRef` is a no-op until recreate — the drill below).
 
-The karakeep CRs ride the existing my-apps AppSet once this lands on `main`. For
-the **branch** trial only, apply the karakeep overlay from a checkout (the AppSet
-won't discover a branch): `kubectl apply -k my-apps/media/karakeep`.
-The first `Snapshot` captures karakeep's **current** data into the fresh repo
-(live PVCs are Bound; `dataSourceRef` is a no-op until recreate).
+> Merging deploys to the live cluster. pvc-plumber + VolSync stay untouched for
+> every other app; only karakeep moves. karakeep's VolSync backups stop on merge
+> (labels gone) and kopiur's begin once the repo is healthy — the manual karakeep
+> backup covers the gap. Roll back by reverting the PR.
 
 ## Cutover & the real test (restore-before-bind drill)
 `dataSourceRef` is **immutable**, so the live PVCs still point at the VolSync RD.

--- a/infrastructure/controllers/argocd/apps/core-dependencies/kopiur-config-app.yaml
+++ b/infrastructure/controllers/argocd/apps/core-dependencies/kopiur-config-app.yaml
@@ -15,7 +15,7 @@ spec:
   project: infrastructure
   source:
     repoURL: https://github.com/mitchross/talos-argocd-proxmox.git
-    targetRevision: claude/kopiur-trial # TRIAL branch; point at main when promoted
+    targetRevision: main # deploys once merged — Argo GitOps, no manual apply
     path: infrastructure/controllers/kopiur
   destination:
     server: https://kubernetes.default.svc

--- a/infrastructure/controllers/argocd/apps/core-dependencies/kopiur-config-app.yaml
+++ b/infrastructure/controllers/argocd/apps/core-dependencies/kopiur-config-app.yaml
@@ -1,0 +1,37 @@
+# kopiur GitOps config (TRIAL) — namespace, ESO credentials, ClusterRepository.
+# Wave 3: after the operator + CRDs exist (Wave 2), before app CRs (my-apps
+# Wave 6). The ClusterRepository CRD must be installed before this app syncs.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kopiur-config
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/manifest-generate-paths: infrastructure/controllers/kopiur
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  source:
+    repoURL: https://github.com/mitchross/talos-argocd-proxmox.git
+    targetRevision: claude/kopiur-trial # TRIAL branch; point at main when promoted
+    path: infrastructure/controllers/kopiur
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kopiur-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 15s
+        factor: 2
+        maxDuration: 5m

--- a/infrastructure/controllers/argocd/apps/core-dependencies/kopiur-operator-app.yaml
+++ b/infrastructure/controllers/argocd/apps/core-dependencies/kopiur-operator-app.yaml
@@ -1,19 +1,22 @@
-# kopiur operator (TRIAL) — Helm chart rendered straight from the upstream
-# repo. Wave 2, same level as pvc-plumber: the operator serves the volume
-# populator AND its admission webhook, so it must be healthy before any app
-# PVC carrying a kopiur dataSourceRef is created (DR cold-start ordering).
+# kopiur operator (TRIAL) — pure GitOps, no CLI / no local helm.
 #
-# This installs the kopiur CRDs (chart ships them as templates).
+# kopiur publishes NO OCI/Helm-repo chart (it lives only at deploy/helm/kopiur
+# in the upstream repo, chart version 0.1.0). So ArgoCD renders the chart
+# straight from the upstream git repo pinned to the 0.4.13 release tag, and
+# installs the 7 CRDs + operator + webhook. Images are pinned to 0.4.13 too
+# (the chart's appVersion default is not trusted for a tag-rendered chart).
 #
-# VERIFY before sync:
-#   - targetRevision tag format (0.4.x vs v0.4.x) — check the releases page.
-#   - kopiur is pre-1.0 and ships breaking CRD changes; pin and re-verify on bumps.
-#   - webhook.failurePolicy is set to Ignore for the trial so a kopiur outage
-#     can never gate Restore-CR creation. Flip to Fail once you trust it.
-#   - ALTERNATIVE: skip this Application and `helm install kopiur deploy/helm/kopiur
-#     -n kopiur-system --create-namespace --set installScope=cluster` once by hand
-#     (kopiur's own quickstart). GitOps-managing an alpha chart's CRDs is the
-#     friction point — see docs/kopiur-trial.md.
+# Wave 2: same level as pvc-plumber. The operator serves the volume populator
+# AND its webhook, so it must be healthy before any PVC carrying a kopiur
+# dataSourceRef is created (DR cold-start ordering).
+#
+# ArgoCD-safety: webhook.tls.mode=self → the operator self-signs its serving
+# cert at runtime. No cert-manager Certificate, no Helm hook cert Job (the
+# pattern that wedges API server under ArgoCD). webhook.failurePolicy=Ignore
+# for the trial so a kopiur outage can never gate Restore-CR creation.
+#
+# Pre-1.0 / alpha: pin the tag and re-verify CRDs on every bump. Pin image
+# DIGESTS (image.*.digest) before trusting this for anything real.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -27,14 +30,24 @@ spec:
   project: infrastructure
   source:
     repoURL: https://github.com/home-operations/kopiur.git
-    targetRevision: "0.4.13" # VERIFY tag format
+    targetRevision: "0.4.13"
     path: deploy/helm/kopiur
     helm:
       releaseName: kopiur
       valuesObject:
-        installScope: cluster
+        installScope: cluster # ClusterRole + ClusterRepository reconciliation
+        installCRDs: true # chart ships the 7 CRDs as templates
+        image:
+          controller:
+            tag: "0.4.13"
+          webhook:
+            tag: "0.4.13"
+          mover:
+            tag: "0.4.13"
         webhook:
           failurePolicy: Ignore # trial: never gate CR creation on operator health
+          tls:
+            mode: self # self-signed at runtime — no cert-manager / no hook Job
   destination:
     server: https://kubernetes.default.svc
     namespace: kopiur-system
@@ -45,7 +58,7 @@ spec:
       allowEmpty: false
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true
+      - ServerSideApply=true # required — renders large CRDs without the 256KB annotation limit
     retry:
       limit: 5
       backoff:

--- a/infrastructure/controllers/argocd/apps/core-dependencies/kopiur-operator-app.yaml
+++ b/infrastructure/controllers/argocd/apps/core-dependencies/kopiur-operator-app.yaml
@@ -1,0 +1,54 @@
+# kopiur operator (TRIAL) — Helm chart rendered straight from the upstream
+# repo. Wave 2, same level as pvc-plumber: the operator serves the volume
+# populator AND its admission webhook, so it must be healthy before any app
+# PVC carrying a kopiur dataSourceRef is created (DR cold-start ordering).
+#
+# This installs the kopiur CRDs (chart ships them as templates).
+#
+# VERIFY before sync:
+#   - targetRevision tag format (0.4.x vs v0.4.x) — check the releases page.
+#   - kopiur is pre-1.0 and ships breaking CRD changes; pin and re-verify on bumps.
+#   - webhook.failurePolicy is set to Ignore for the trial so a kopiur outage
+#     can never gate Restore-CR creation. Flip to Fail once you trust it.
+#   - ALTERNATIVE: skip this Application and `helm install kopiur deploy/helm/kopiur
+#     -n kopiur-system --create-namespace --set installScope=cluster` once by hand
+#     (kopiur's own quickstart). GitOps-managing an alpha chart's CRDs is the
+#     friction point — see docs/kopiur-trial.md.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kopiur-operator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  source:
+    repoURL: https://github.com/home-operations/kopiur.git
+    targetRevision: "0.4.13" # VERIFY tag format
+    path: deploy/helm/kopiur
+    helm:
+      releaseName: kopiur
+      valuesObject:
+        installScope: cluster
+        webhook:
+          failurePolicy: Ignore # trial: never gate CR creation on operator health
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kopiur-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 15s
+        factor: 2
+        maxDuration: 5m

--- a/infrastructure/controllers/argocd/apps/kustomization.yaml
+++ b/infrastructure/controllers/argocd/apps/kustomization.yaml
@@ -22,6 +22,11 @@ resources:
   # same sync wave — the MAP gates mover Jobs; pvc-plumber observes PVCs.
   - core-dependencies/pvc-plumber-app.yaml
   - core-dependencies/volsync-backup-cluster-app.yaml
+  # kopiur TRIAL — parallel to pvc-plumber (Wave 2 operator, Wave 3 config).
+  # Evaluating kopiur as a VolSync/pvc-plumber replacement; karakeep is the
+  # canary. Remove these two lines to back the trial out. See docs/kopiur-trial.md.
+  - core-dependencies/kopiur-operator-app.yaml
+  - core-dependencies/kopiur-config-app.yaml
 
   # Custom entrypoints: standalone apps kept out of AppSets for ordering or render reasons.
   - custom-entrypoints/cnpg-barman-plugin-app.yaml

--- a/infrastructure/controllers/kopiur/clusterrepository.yaml
+++ b/infrastructure/controllers/kopiur/clusterrepository.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/clusterrepository_v1alpha1.json
 # Cluster-wide kopia repository for kopiur — the engine equivalent of the
 # VolSync `volsync-kopia-repository` secret, but as a first-class CR.
 #

--- a/infrastructure/controllers/kopiur/clusterrepository.yaml
+++ b/infrastructure/controllers/kopiur/clusterrepository.yaml
@@ -11,11 +11,13 @@
 # volsync-kopia only. If denied, widen the RustFS bucket policy (or use admin creds).
 # Endpoint is the S3 API port :30292 (NOT the console :30293).
 #
-# VERIFY (kopiur is alpha — field names churn):
-#   kubectl explain clusterrepository.spec.backend.s3
-#   - the HTTP/TLS-off field for RustFS may be `insecure`, `disableTls`, or an
-#     http:// endpoint scheme. RustFS here is plain HTTP on :30292.
-#   - confirm secretRef requires `namespace` (webhook-enforced for cluster scope).
+# Field shapes confirmed vs deploy/examples/backends/s3-minio-http.yaml:
+#   - TLS-off for plain-HTTP RustFS is `tls.disableTls: true`.
+#   - endpoint is a BARE host:port (no scheme, no trailing slash).
+#   - the creds Secret carries AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY /
+#     KOPIA_PASSWORD (exactly what externalsecret.yaml writes).
+#   - cluster-scoped secretRef MUST carry an explicit `namespace` (webhook-enforced).
+# Still verify against the INSTALLED chart: kubectl explain clusterrepository.spec
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: ClusterRepository
 metadata:
@@ -27,7 +29,8 @@ spec:
       prefix: "" # dedicated bucket — kopia repo lives at the bucket root
       endpoint: 192.168.10.133:30292
       region: us-east-1
-      insecure: true # VERIFY field name — RustFS is plain HTTP (no TLS)
+      tls:
+        disableTls: true # RustFS is plain HTTP — confirmed vs s3-minio-http.yaml
       auth:
         secretRef:
           name: kopiur-rustfs

--- a/infrastructure/controllers/kopiur/clusterrepository.yaml
+++ b/infrastructure/controllers/kopiur/clusterrepository.yaml
@@ -1,10 +1,15 @@
 # Cluster-wide kopia repository for kopiur — the engine equivalent of the
 # VolSync `volsync-kopia-repository` secret, but as a first-class CR.
 #
-# ISOLATION: new bucket prefix `kopiur-trial/` in the existing RustFS bucket.
+# ISOLATION: dedicated `kopiur` bucket on RustFS (created 2026-06-26).
 # This is a FRESH kopia repo (create.enabled: true) — it does NOT read the
 # VolSync repo at s3://volsync-kopia/cluster. So the proven backup path is
 # untouched, and karakeep's first kopiur snapshot captures its CURRENT data.
+#
+# ⚠️ ACCESS: confirm the rustfs workload key (rustfs-workload-access-key) has
+# read/write on the `kopiur` bucket — the existing policy may scope it to
+# volsync-kopia only. If denied, widen the RustFS bucket policy (or use admin creds).
+# Endpoint is the S3 API port :30292 (NOT the console :30293).
 #
 # VERIFY (kopiur is alpha — field names churn):
 #   kubectl explain clusterrepository.spec.backend.s3
@@ -18,8 +23,8 @@ metadata:
 spec:
   backend:
     s3:
-      bucket: volsync-kopia
-      prefix: kopiur-trial/
+      bucket: kopiur
+      prefix: "" # dedicated bucket — kopia repo lives at the bucket root
       endpoint: 192.168.10.133:30292
       region: us-east-1
       insecure: true # VERIFY field name — RustFS is plain HTTP (no TLS)

--- a/infrastructure/controllers/kopiur/clusterrepository.yaml
+++ b/infrastructure/controllers/kopiur/clusterrepository.yaml
@@ -1,0 +1,39 @@
+# Cluster-wide kopia repository for kopiur — the engine equivalent of the
+# VolSync `volsync-kopia-repository` secret, but as a first-class CR.
+#
+# ISOLATION: new bucket prefix `kopiur-trial/` in the existing RustFS bucket.
+# This is a FRESH kopia repo (create.enabled: true) — it does NOT read the
+# VolSync repo at s3://volsync-kopia/cluster. So the proven backup path is
+# untouched, and karakeep's first kopiur snapshot captures its CURRENT data.
+#
+# VERIFY (kopiur is alpha — field names churn):
+#   kubectl explain clusterrepository.spec.backend.s3
+#   - the HTTP/TLS-off field for RustFS may be `insecure`, `disableTls`, or an
+#     http:// endpoint scheme. RustFS here is plain HTTP on :30292.
+#   - confirm secretRef requires `namespace` (webhook-enforced for cluster scope).
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: cluster-kopia
+spec:
+  backend:
+    s3:
+      bucket: volsync-kopia
+      prefix: kopiur-trial/
+      endpoint: 192.168.10.133:30292
+      region: us-east-1
+      insecure: true # VERIFY field name — RustFS is plain HTTP (no TLS)
+      auth:
+        secretRef:
+          name: kopiur-rustfs
+          namespace: kopiur-system
+  encryption:
+    passwordSecretRef:
+      name: kopiur-rustfs
+      namespace: kopiur-system
+      key: KOPIA_PASSWORD
+  create:
+    enabled: true
+  allowedNamespaces:
+    list:
+      - karakeep

--- a/infrastructure/controllers/kopiur/externalsecret.yaml
+++ b/infrastructure/controllers/kopiur/externalsecret.yaml
@@ -1,0 +1,43 @@
+# kopiur cluster kopia credentials — mirrors the VolSync ClusterES, but as a
+# plain ExternalSecret scoped to kopiur-system (kopiur's ClusterRepository
+# secretRef carries an explicit namespace, so no per-namespace fan-out needed).
+#
+# Reuses the SAME 1Password `rustfs` item as VolSync: same workload S3 keys,
+# same kopia password. The kopiur repo is isolated from the VolSync repo by a
+# DIFFERENT bucket prefix (kopiur-trial/), so sharing the password is safe —
+# a kopia repo is identified by (location + password), and the location differs.
+#
+# VERIFY: confirm kopiur's S3 backend reads AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY
+# (standard names). If the chart expects different keys, adjust the template below.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-rustfs
+  namespace: kopiur-system
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: kopiur-rustfs
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        KOPIA_PASSWORD: "{{ .password }}"
+        AWS_ACCESS_KEY_ID: "{{ .accessKey }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .secretKey }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: rustfs
+        property: kopia_password
+    - secretKey: accessKey
+      remoteRef:
+        key: rustfs
+        property: rustfs-workload-access-key
+    - secretKey: secretKey
+      remoteRef:
+        key: rustfs
+        property: rustfs-workload-secret-key

--- a/infrastructure/controllers/kopiur/kustomization.yaml
+++ b/infrastructure/controllers/kopiur/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# kopiur GitOps-managed config (NOT the operator itself — that's the Helm
+# Application at core-dependencies/kopiur-operator-app.yaml).
+# Synced by core-dependencies/kopiur-config-app.yaml at Wave 3, after the
+# operator + CRDs land at Wave 2.
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - clusterrepository.yaml

--- a/infrastructure/controllers/kopiur/namespace.yaml
+++ b/infrastructure/controllers/kopiur/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kopiur-system
+  labels:
+    app.kubernetes.io/part-of: infrastructure
+    # NOT pvc-plumber-managed. kopiur owns its own CRDs here; this namespace
+    # holds the operator, webhook, and the cluster kopia credentials.

--- a/my-apps/media/karakeep/karakeep/pvc-data.yaml
+++ b/my-apps/media/karakeep/karakeep/pvc-data.yaml
@@ -19,13 +19,9 @@ metadata:
     app: karakeep
     type: data-storage
     restore-policy: "strict"
-    # Gate 3 handoff (2026-05-29): the v4 write fuse opts this PVC into
-    # pvc-plumber v4.0.0 operator management at tier=hourly (preserves the
-    # prior inline hourly cadence). The operator creates/repairs RS/data-pvc
-    # + RD/data-pvc-dst as managed-by=pvc-plumber.
-    pvc-plumber.io/enabled: "true"
-    pvc-plumber.io/manage-volsync: "true"
-    pvc-plumber.io/tier: "hourly"
+    # kopiur TRIAL (claude/kopiur-trial): de-fused from pvc-plumber. Backup +
+    # restore are now driven by the kopiur CR bundle in ../kopiur/data-pvc.yaml
+    # (SnapshotPolicy + SnapshotSchedule + Restore). No operator labels here.
 spec:
   accessModes:
   - ReadWriteOnce
@@ -33,17 +29,16 @@ spec:
     requests:
       storage: 10Gi
   storageClassName: longhorn
-  # Static dataSourceRef → ReplicationDestination/data-pvc-dst. On PVC
-  # re-creation (DR / namespace recreate), VolSync's volume populator reads
-  # the latest snapshot from the shared kopia repo and binds this PVC with
-  # restored data. No-op while the PVC is already Bound. The RS/RD targeted
-  # here are operator-managed by pvc-plumber v4.0.0 (Gate 3, 2026-05-29):
-  # this PVC carries the v4 write fuse, so the operator creates and repairs
-  # ReplicationSource/data-pvc + ReplicationDestination/data-pvc-dst (and
-  # recreates either within seconds if deleted) via its RS/RD watch. The
-  # operator-generated mover runs as 568:568:568 (was 1001 inline); fsGroup
-  # handles snapshot-clone read access. See git history (v4 cutover doc, pruned 2026-06-13).
+  # kopiur populator: on PVC re-creation, kopiur's Restore/data-pvc-restore
+  # holds this PVC in Pending and restores the latest snapshot for identity
+  # karakeep/data-pvc before binding. No-op while already Bound.
+  #
+  # ⚠️ dataSourceRef is IMMUTABLE. The LIVE PVC still points at the VolSync
+  # RD, so this change only takes effect on RECREATE (the restore drill).
+  # Until then ArgoCD flags a diff on /spec/dataSourceRef — the existing
+  # ServerSideApply=false annotation + the AppSet ignoreDifferences mask
+  # handle it. See docs/kopiur-trial.md "Cutover".
   dataSourceRef:
-    apiGroup: volsync.backube
-    kind: ReplicationDestination
-    name: data-pvc-dst
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: data-pvc-restore

--- a/my-apps/media/karakeep/kopiur/data-pvc.yaml
+++ b/my-apps/media/karakeep/kopiur/data-pvc.yaml
@@ -1,12 +1,9 @@
-# kopiur backend for karakeep data-pvc (the SQLite DB + assets — the bookmarks).
-# Replaces the pvc-plumber label fuse with the explicit CR bundle. The PVC's
-# dataSourceRef → Restore/data-pvc-restore holds binding until restore.
-#
-# Field shapes cross-checked against two working examples:
-#   - eleboucher/homelab  garage/app/kopiur.yaml
-#   - onedr0p/home-ops    #11012 (components/kopiur)
-# and kopiur deploy/examples/18-inherit-security-context.yaml (mover SC).
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+# kopiur backend for karakeep data-pvc (the SQLite DB + assets — the bookmarks).
+# Replaces the pvc-plumber label fuse; the PVC's dataSourceRef → Restore holds
+# binding until restore. Field shapes cross-checked vs eleboucher/homelab,
+# onedr0p/home-ops#11012, and kopiur example 18 (mover securityContext).
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
@@ -36,6 +33,7 @@ spec:
       runAsGroup: 568
       fsGroup: 568
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotSchedule
 metadata:
@@ -49,6 +47,7 @@ spec:
     concurrencyPolicy: Forbid # no overlapping snapshot Jobs
     runOnCreate: false
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: Restore
 metadata:

--- a/my-apps/media/karakeep/kopiur/data-pvc.yaml
+++ b/my-apps/media/karakeep/kopiur/data-pvc.yaml
@@ -1,0 +1,60 @@
+# kopiur backend for karakeep data-pvc (the SQLite DB + assets — the bookmarks).
+# Replaces the pvc-plumber label fuse: instead of 3 labels generating RS/RD,
+# this is the explicit CR bundle (policy + schedule + restore). The PVC's
+# dataSourceRef → Restore/data-pvc-restore is what holds binding until restore.
+#
+# identity (username/hostname) keys the snapshot in S3 and ties policy→restore,
+# so the populator finds THIS volume's backup. Mirrors VolSync's ns/pvc keying.
+#
+# VERIFY field names against the installed chart: kubectl explain snapshotpolicy.spec
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: data-pvc
+  namespace: karakeep
+spec:
+  repository:
+    kind: ClusterRepository
+    name: cluster-kopia
+  sources:
+    - pvc:
+        name: data-pvc
+  identity:
+    username: data-pvc
+    hostname: karakeep
+  retention:
+    keepHourly: 24
+    keepDaily: 7
+    keepWeekly: 4
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: data-pvc-hourly
+  namespace: karakeep
+spec:
+  policyRef:
+    name: data-pvc
+  schedule:
+    cron: "10 * * * *" # preserves the prior hourly cadence (minute 10)
+    jitter: 5m
+    runOnCreate: false
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: data-pvc-restore
+  namespace: karakeep
+spec:
+  repository:
+    kind: ClusterRepository
+    name: cluster-kopia
+  source:
+    identity:
+      username: data-pvc
+      hostname: karakeep
+  target:
+    populator: {} # passive volume populator — consumed by the PVC's dataSourceRef
+  policy:
+    onMissingSnapshot: Continue # backup exists → restore-before-bind · none → fresh

--- a/my-apps/media/karakeep/kopiur/data-pvc.yaml
+++ b/my-apps/media/karakeep/kopiur/data-pvc.yaml
@@ -1,12 +1,11 @@
 # kopiur backend for karakeep data-pvc (the SQLite DB + assets — the bookmarks).
-# Replaces the pvc-plumber label fuse: instead of 3 labels generating RS/RD,
-# this is the explicit CR bundle (policy + schedule + restore). The PVC's
-# dataSourceRef → Restore/data-pvc-restore is what holds binding until restore.
+# Replaces the pvc-plumber label fuse with the explicit CR bundle. The PVC's
+# dataSourceRef → Restore/data-pvc-restore holds binding until restore.
 #
-# identity (username/hostname) keys the snapshot in S3 and ties policy→restore,
-# so the populator finds THIS volume's backup. Mirrors VolSync's ns/pvc keying.
-#
-# VERIFY field names against the installed chart: kubectl explain snapshotpolicy.spec
+# Field shapes cross-checked against two working examples:
+#   - eleboucher/homelab  garage/app/kopiur.yaml
+#   - onedr0p/home-ops    #11012 (components/kopiur)
+# and kopiur deploy/examples/18-inherit-security-context.yaml (mover SC).
 ---
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
@@ -14,6 +13,10 @@ metadata:
   name: data-pvc
   namespace: karakeep
 spec:
+  copyMethod: Snapshot # CSI VolumeSnapshot (Longhorn) — matches the old VolSync RS
+  volumeSnapshotClassName: longhorn-snapclass
+  credentialProjection:
+    enabled: true # project the ClusterRepository creds into the mover Job here
   repository:
     kind: ClusterRepository
     name: cluster-kopia
@@ -27,6 +30,11 @@ spec:
     keepHourly: 24
     keepDaily: 7
     keepWeekly: 4
+  mover:
+    securityContext: # karakeep data is 568 (pvc-plumber's mover normalized to 568)
+      runAsUser: 568
+      runAsGroup: 568
+      fsGroup: 568
 ---
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotSchedule
@@ -38,7 +46,7 @@ spec:
     name: data-pvc
   schedule:
     cron: "10 * * * *" # preserves the prior hourly cadence (minute 10)
-    jitter: 5m
+    concurrencyPolicy: Forbid # no overlapping snapshot Jobs
     runOnCreate: false
 ---
 apiVersion: kopiur.home-operations.com/v1alpha1
@@ -50,11 +58,18 @@ spec:
   repository:
     kind: ClusterRepository
     name: cluster-kopia
+  credentialProjection:
+    enabled: true
   source:
-    identity:
-      username: data-pvc
-      hostname: karakeep
+    fromPolicy:
+      name: data-pvc
+      offset: 0 # 0 = latest snapshot for this policy's identity
   target:
     populator: {} # passive volume populator — consumed by the PVC's dataSourceRef
   policy:
     onMissingSnapshot: Continue # backup exists → restore-before-bind · none → fresh
+  mover:
+    securityContext: # restored files owned by 568
+      runAsUser: 568
+      runAsGroup: 568
+      fsGroup: 568

--- a/my-apps/media/karakeep/kopiur/meilisearch-pvc.yaml
+++ b/my-apps/media/karakeep/kopiur/meilisearch-pvc.yaml
@@ -1,0 +1,53 @@
+# kopiur backend for karakeep meilisearch-pvc (the search index).
+# Rebuildable in principle, but it was pvc-plumber-managed hourly, so we keep
+# parity here. Same bundle shape as data-pvc.yaml.
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: meilisearch-pvc
+  namespace: karakeep
+spec:
+  repository:
+    kind: ClusterRepository
+    name: cluster-kopia
+  sources:
+    - pvc:
+        name: meilisearch-pvc
+  identity:
+    username: meilisearch-pvc
+    hostname: karakeep
+  retention:
+    keepHourly: 24
+    keepDaily: 7
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: meilisearch-pvc-hourly
+  namespace: karakeep
+spec:
+  policyRef:
+    name: meilisearch-pvc
+  schedule:
+    cron: "25 * * * *"
+    jitter: 5m
+    runOnCreate: false
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: meilisearch-pvc-restore
+  namespace: karakeep
+spec:
+  repository:
+    kind: ClusterRepository
+    name: cluster-kopia
+  source:
+    identity:
+      username: meilisearch-pvc
+      hostname: karakeep
+  target:
+    populator: {}
+  policy:
+    onMissingSnapshot: Continue

--- a/my-apps/media/karakeep/kopiur/meilisearch-pvc.yaml
+++ b/my-apps/media/karakeep/kopiur/meilisearch-pvc.yaml
@@ -1,7 +1,7 @@
-# kopiur backend for karakeep meilisearch-pvc (the search index).
-# Same corrected bundle shape as data-pvc.yaml (copyMethod + snapshot class +
-# credentialProjection + mover SC), cross-checked vs eleboucher/onedr0p.
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+# kopiur backend for karakeep meilisearch-pvc (the search index). Same corrected
+# bundle shape as data-pvc.yaml; cross-checked vs eleboucher / onedr0p.
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
@@ -30,6 +30,7 @@ spec:
       runAsGroup: 568
       fsGroup: 568
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotSchedule
 metadata:
@@ -43,6 +44,7 @@ spec:
     concurrencyPolicy: Forbid
     runOnCreate: false
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: Restore
 metadata:

--- a/my-apps/media/karakeep/kopiur/meilisearch-pvc.yaml
+++ b/my-apps/media/karakeep/kopiur/meilisearch-pvc.yaml
@@ -1,6 +1,6 @@
 # kopiur backend for karakeep meilisearch-pvc (the search index).
-# Rebuildable in principle, but it was pvc-plumber-managed hourly, so we keep
-# parity here. Same bundle shape as data-pvc.yaml.
+# Same corrected bundle shape as data-pvc.yaml (copyMethod + snapshot class +
+# credentialProjection + mover SC), cross-checked vs eleboucher/onedr0p.
 ---
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
@@ -8,6 +8,10 @@ metadata:
   name: meilisearch-pvc
   namespace: karakeep
 spec:
+  copyMethod: Snapshot
+  volumeSnapshotClassName: longhorn-snapclass
+  credentialProjection:
+    enabled: true
   repository:
     kind: ClusterRepository
     name: cluster-kopia
@@ -20,6 +24,11 @@ spec:
   retention:
     keepHourly: 24
     keepDaily: 7
+  mover:
+    securityContext:
+      runAsUser: 568
+      runAsGroup: 568
+      fsGroup: 568
 ---
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotSchedule
@@ -31,7 +40,7 @@ spec:
     name: meilisearch-pvc
   schedule:
     cron: "25 * * * *"
-    jitter: 5m
+    concurrencyPolicy: Forbid
     runOnCreate: false
 ---
 apiVersion: kopiur.home-operations.com/v1alpha1
@@ -43,11 +52,18 @@ spec:
   repository:
     kind: ClusterRepository
     name: cluster-kopia
+  credentialProjection:
+    enabled: true
   source:
-    identity:
-      username: meilisearch-pvc
-      hostname: karakeep
+    fromPolicy:
+      name: meilisearch-pvc
+      offset: 0
   target:
     populator: {}
   policy:
     onMissingSnapshot: Continue
+  mover:
+    securityContext:
+      runAsUser: 568
+      runAsGroup: 568
+      fsGroup: 568

--- a/my-apps/media/karakeep/kustomization.yaml
+++ b/my-apps/media/karakeep/kustomization.yaml
@@ -16,6 +16,9 @@ resources:
 - meilisearch/deployment-meilisearch.yaml
 - meilisearch/service-meilisearch.yaml
 - meilisearch/pvc-meilisearch.yaml
+# kopiur backend (TRIAL) — replaces pvc-plumber labels with explicit CRs
+- kopiur/data-pvc.yaml
+- kopiur/meilisearch-pvc.yaml
 
 configMapGenerator:
   - name: karakeep-configuration

--- a/my-apps/media/karakeep/meilisearch/pvc-meilisearch.yaml
+++ b/my-apps/media/karakeep/meilisearch/pvc-meilisearch.yaml
@@ -10,13 +10,8 @@ metadata:
     app: karakeep
     type: meilisearch-storage
     restore-policy: "strict"
-    # Gate 3 handoff (2026-05-29): v4 write fuse opts this PVC into
-    # pvc-plumber v4.0.0 operator management at tier=hourly. Operator
-    # creates/repairs RS/meilisearch-pvc + RD/meilisearch-pvc-dst as
-    # managed-by=pvc-plumber; mover normalizes to 568:568:568 (was 1001).
-    pvc-plumber.io/enabled: "true"
-    pvc-plumber.io/manage-volsync: "true"
-    pvc-plumber.io/tier: "hourly"
+    # kopiur TRIAL (claude/kopiur-trial): de-fused from pvc-plumber. Backup +
+    # restore now driven by ../kopiur/meilisearch-pvc.yaml.
 spec:
   accessModes:
   - ReadWriteOnce
@@ -24,13 +19,9 @@ spec:
     requests:
       storage: 10Gi
   storageClassName: longhorn
-  # Static dataSourceRef → ReplicationDestination/meilisearch-pvc-dst. The
-  # RS/RD are operator-managed by pvc-plumber v4.0.0 (Gate 3, 2026-05-29):
-  # this PVC carries the v4 write fuse, so the operator creates and repairs
-  # ReplicationSource/meilisearch-pvc + ReplicationDestination/
-  # meilisearch-pvc-dst (and recreates either within seconds if deleted)
-  # via its RS/RD watch. No-op while the PVC is already Bound.
+  # kopiur populator (see ../kopiur/meilisearch-pvc.yaml). Immutable — takes
+  # effect on recreate. ArgoCD diff handled as for data-pvc.
   dataSourceRef:
-    apiGroup: volsync.backube
-    kind: ReplicationDestination
-    name: meilisearch-pvc-dst
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: meilisearch-pvc-restore

--- a/my-apps/media/karakeep/namespace.yaml
+++ b/my-apps/media/karakeep/namespace.yaml
@@ -3,10 +3,11 @@ kind: Namespace
 metadata:
   name: karakeep
   labels:
+    # kopiur TRIAL (claude/kopiur-trial): pvc-plumber.io/managed-namespace
+    # REMOVED — karakeep is now driven by kopiur CRs (see ./kopiur/). With the
+    # PVC fuse labels also gone, pvc-plumber GCs karakeep's RS/RD and ignores
+    # the namespace. privileged-movers kept (harmless; still fans out the
+    # volsync secret, unused by kopiur) — drop it once the cutover is proven.
     volsync.backube/privileged-movers: "true"
-    # pvc-plumber v4.0.1 namespace write gate: opts this namespace in to
-    # operator-managed VolSync writes. Required (alongside the PVC fuse
-    # labels) before the operator will create/update/delete RS/RD here.
-    pvc-plumber.io/managed-namespace: "true"
   annotations:
     volsync.backube/privileged-movers: "true"


### PR DESCRIPTION
## What
Stands up **kopiur** (Kopia-native Rust backup operator) **alongside** pvc-plumber and converts one canary app — **karakeep** — off pvc-plumber labels onto explicit kopiur CRs. Purpose: evaluate retiring pvc-plumber/VolSync. Full runbook: `docs/kopiur-trial.md`.

## What deploys on merge (pure GitOps — no `kubectl apply`)
Both Applications are wired into the root app-of-apps and track `main`:
- **Wave 2 — `kopiur-operator`**: renders the chart from the upstream git tag `0.4.13` (no OCI chart exists) → installs the 7 CRDs + operator + webhook. `installScope=cluster`, images pinned `0.4.13`, `webhook.tls.mode=self` (self-signed — **no** cert-manager hook), `webhook.failurePolicy=Ignore`.
- **Wave 3 — `kopiur-config`**: `kopiur-system` ns + ESO (reuses the `rustfs` 1Password item) + `ClusterRepository` on a **dedicated, isolated `kopiur` bucket** (`tls.disableTls`, S3 API `:30292`).
- **Wave 6 — my-apps AppSet**: re-renders karakeep with `SnapshotPolicy`+`SnapshotSchedule`+`Restore` per PVC and repoints `dataSourceRef` → kopiur `Restore`.

## Safety / blast radius
- pvc-plumber + VolSync are **untouched** for every other app; only karakeep moves.
- Fresh isolated bucket — the proven `volsync-kopia` repo is never read or written.
- karakeep's VolSync backups stop on merge (labels removed); kopiur's begin once the repo is healthy. A manual karakeep backup was taken to cover the gap.

## ⚠️ Alpha caveat (read before merge)
kopiur is pre-1.0; the CRD field shapes here were assembled from upstream `deploy/examples` on `main` and partially verified (tag format, `tls.disableTls`, secret keys all confirmed). The remaining unknowns can only be checked once the CRDs are installed. After merge:
```
kubectl explain clusterrepository.spec.backend.s3
kubectl explain snapshotpolicy.spec ; kubectl explain restore.spec
kubectl get applications -n argocd | grep kopiur   # any Degraded?
```
Any field drift shows as a `kopiur-config`/karakeep sync error (isolated, `failurePolicy=Ignore`) and is fixable with a follow-up commit — it does not affect pvc-plumber/VolSync.

## The real test
`dataSourceRef` is immutable, so the populator only proves out on **recreate**: after a kopiur `Snapshot` lands, scale karakeep to 0, delete `data-pvc`, let Argo recreate it → it should sit `Pending` while kopiur restores, then bind **with data**. That restore-before-bind is the whole point. Steps in `docs/kopiur-trial.md` → "Cutover & the real test".

## Rollback
Revert this PR — pvc-plumber + VolSync resume ownership of karakeep on the next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwRMENwK649GXhEtFFL56T)_