### PR TITLE
Bump kopiur-operator to 0.6.0 and document CRD lifecycle

### DIFF
--- a/docs/domains/storage/kopiur-backup-architecture.md
+++ b/docs/domains/storage/kopiur-backup-architecture.md
@@ -188,7 +188,7 @@ or [`my-apps/home/project-nomad/mysql/`](https://github.com/mitchross/talos-argo
 
 ---
 
-## 6. Upstream 0.5.x notes (assessed 2026-07-04, updated 2026-07-06, chart pinned `0.5.2`)
+## 6. Upstream 0.5.x/0.6 notes (assessed 2026-07-04, updated 2026-07-06, chart pinned `0.6.0`)
 
 What changed upstream in 0.5.0–0.5.2 and how it lands here:
 
@@ -205,17 +205,21 @@ What changed upstream in 0.5.0–0.5.2 and how it lands here:
   restore there is **no consumer pod to inherit from**. Explicit
   data-owner uids in the stubs stay the rule
   (`kopiur-mover-permissions.md`).
-- **Chart refactor landed upstream** (#203 → PR #206, merged 2026-07-06;
-  ships in the next release, presumably 0.6). **Pre-verified against our
-  values (2026-07-06):** `installScope`, `webhook.failurePolicy`, and
-  `webhook.tls.mode` keep their exact paths; image tags still default to
-  `.Chart.AppVersion`; `failurePolicy: Ignore` confirmed in the render;
-  CRDs move from templated resources to Helm's native `crds/` dir, which
-  our Kustomize `includeCRDs: true` still renders. The ONLY migration step
-  at the 0.6 bump: delete the now-inert `installCRDs: true` line from
-  `kopiur-operator/values.yaml` (noted inline there). New in the render:
-  a leader-election Role/RoleBinding (leaderElection defaults on) — benign.
-  Renovate opens the bump PR but won't automerge it (renovate.json5 rule).
+- **0.6.0 = the breaking chart refactor** (#203 → #206), bumped here
+  2026-07-06. Our values keys (`installScope`, `webhook.failurePolicy`,
+  `webhook.tls.mode`) kept their paths; the inert `installCRDs` line was
+  deleted; images follow appVersion as before. New in the render: a
+  leader-election Role/RoleBinding — benign.
+  **⚠️ The upgrade that burned everyone else:** CRDs moved from templated
+  chart resources to Helm's native `crds/` dir, and Helm does NOT manage
+  `crds/` on upgrade — Flux HelmRelease users had the old templated CRDs
+  **deleted on upgrade, taking every kopiur CR with them**, then had to
+  force-reconcile them back (upstream Discord, 2026-07-06). **This repo's
+  render path is immune**: Kustomize runs `helm template --include-crds`,
+  which emits the same 8 CRDs before and after the move, so ArgoCD never
+  sees them leave the manifest (CRD-set continuity render-verified at the
+  bump). The load-bearing line is `includeCRDs: true` in
+  `kopiur-operator/kustomization.yaml` — never remove it.
 
 - **`copyMethod` now defaults to `Snapshot` upstream** (was `Direct`). We were
   already pinning `Snapshot` via the component — **keep the explicit pin**:

--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -24,7 +24,15 @@ helmCharts:
     # terminally fail backups (#201). Directly relevant: Longhorn under load
     # throws exactly those (DR doc "attach conflicts"); pre-0.5.2 they burned
     # the whole run until the next cron.
-    version: 0.5.2
+    # 0.6.0 (2026-07-06): the breaking chart refactor (#206) — pre-verified
+    # 2026-07-06 before release: our values keys keep their paths; CRDs moved
+    # from templated resources to Helm's native crds/ dir. That move DELETED
+    # CRDs (and every kopiur CR with them) for Flux HelmRelease users on
+    # upgrade — helm doesn't manage crds/ on upgrade. Our path is immune:
+    # helm template --include-crds (this includeCRDs: true) emits the same 8
+    # CRDs before and after, so ArgoCD never sees them leave the manifest.
+    # NEVER remove includeCRDs: true — it IS the CRD lifecycle here.
+    version: 0.6.0
     releaseName: kopiur
     namespace: kopiur-system
     includeCRDs: true

--- a/infrastructure/controllers/kopiur-operator/values.yaml
+++ b/infrastructure/controllers/kopiur-operator/values.yaml
@@ -9,10 +9,6 @@
 # chart bumps (nothing updated them). Pin image.*.digest before trusting
 # this for anything real.
 installScope: cluster # ClusterRole + ClusterRepository reconciliation
-installCRDs: true # 0.5.x: chart ships the CRDs as templates. The 0.6 chart
-# refactor (upstream #206) moves them to Helm's native crds/ dir and drops this
-# flag — DELETE this line when bumping to 0.6; kustomization includeCRDs: true
-# keeps rendering them either way (helm template --include-crds).
 webhook:
   failurePolicy: Ignore # deliberate (DR-safety): a kopiur outage must never gate CR creation
   tls:


### PR DESCRIPTION
## Summary

Upgrade kopiur-operator chart from 0.5.2 to 0.6.0, which includes a breaking refactor of CRD management. Document the upstream breaking change and verify our render path is immune to the CRD deletion issue that affected Flux HelmRelease users.

## Key Changes

- **Chart version bump**: 0.5.2 → 0.6.0 in `kustomization.yaml`
- **Removed obsolete config**: Deleted `installCRDs: true` from `values.yaml` (inert in 0.6.0, moved to Helm's native `crds/` directory)
- **Documented upstream breaking change**: Added detailed notes explaining:
  - CRDs moved from templated chart resources to Helm's native `crds/` directory
  - Flux HelmRelease users experienced CRD deletion on upgrade (taking all kopiur CRs with them)
  - Our ArgoCD + Kustomize render path is **immune**: `helm template --include-crds` emits the same 8 CRDs before and after the move, so ArgoCD never sees them leave the manifest
  - The load-bearing line is `includeCRDs: true` in `kopiur-operator/kustomization.yaml` — must never be removed
- **Pre-verified compatibility**: Confirmed our values keys (`installScope`, `webhook.failurePolicy`, `webhook.tls.mode`) kept their paths; images follow appVersion as before; new leader-election Role/RoleBinding is benign

## Implementation Details

The 0.6.0 refactor is a textbook example of why render-path matters in GitOps. Helm's native `crds/` directory is **not** managed on upgrade (by design — CRDs are cluster-scoped and Helm avoids accidental deletion). This broke Flux users who relied on Helm to manage CRD lifecycle. Our Kustomize path (`helm template --include-crds`) treats CRDs as regular templated resources, so the move is invisible to ArgoCD — CRD continuity is render-verified at the bump.

The `includeCRDs: true` line in `kustomization.yaml` is the critical safety mechanism here and must be preserved in all future maintenance.

https://claude.ai/code/session_01JKwipCZr2pDfQHSQwFwkcw