### PR TITLE
fix(network): pin loki-gateway + gateway-external LB IPs to stop IP squatting

### DIFF
--- a/infrastructure/networking/gateway/gw-external.yaml
+++ b/infrastructure/networking/gateway/gw-external.yaml
@@ -11,7 +11,12 @@ metadata:
     # External-DNS: Create CNAME records to vanillax.me instead of A records
     external-dns.alpha.kubernetes.io/target: "vanillax.me"
 spec:
-  # No addresses - Cilium will auto-assign, but external-DNS will use target annotation for CNAME
+  # Pinned LB IP: external traffic arrives via the Cloudflare tunnel (CNAME
+  # target above), but an unpinned gateway races pinned services for specific
+  # IPs on rebuild (it squatted project-zomboid's .51 after the 06-28 rebuild).
+  addresses:
+    - type: IPAddress
+      value: 192.168.10.49
   gatewayClassName: cilium
   listeners:
     - name: http

--- a/monitoring/loki-stack/values.yaml
+++ b/monitoring/loki-stack/values.yaml
@@ -117,6 +117,10 @@ gateway:
     type: Recreate
   service:
     type: LoadBalancer
+    # Pin the LB IP: unpinned services race pinned ones for specific IPs on
+    # rebuild (this one squatted wyze-bridge's .46 after the 06-28 rebuild).
+    annotations:
+      lbipam.cilium.io/ips: "192.168.10.48"
   resources:
     requests:
       cpu: 50m

--- a/my-apps/home/project-zomboid/service.yaml
+++ b/my-apps/home/project-zomboid/service.yaml
@@ -3,9 +3,12 @@ kind: Service
 metadata:
   name: project-zomboid
   namespace: project-zomboid
+  annotations:
+    # Router port-forwards target this IP. lbipam annotation replaces the
+    # deprecated spec.loadBalancerIP field.
+    lbipam.cilium.io/ips: "192.168.10.51"
 spec:
   type: LoadBalancer
-  loadBalancerIP: 192.168.10.51
   selector:
     app: project-zomboid
   ports:


### PR DESCRIPTION
Since the 06-28 rebuild, `project-zomboid` and `wyze-bridge` LoadBalancer Services have sat `<pending>` (ArgoCD: Progressing) with condition `already_allocated`:

- unpinned **loki-gateway** squatted wyze-bridge's declared **192.168.10.46**
- unpinned **gateway-external** squatted project-zomboid's declared **192.168.10.51**

LB-IPAM allocation order races on rebuild, so any service that *declares* a specific IP loses to a dynamic one that grabs it first. Fix: pin the two squatters to free pool IPs — loki-gateway → **.48**, gateway-external → **.49** (external ingress rides the Cloudflare tunnel CNAME, so the gateway's LAN IP is not referenced anywhere). Zomboid's pin also moves off the deprecated `spec.loadBalancerIP` field onto the `lbipam.cilium.io/ips` annotation.

After sync, Cilium reassigns the squatters and the two stuck services should claim their declared IPs within seconds. Router port-forwards for zomboid (16261/16262/27015 → .51) resume working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)