### PR TITLE
Bump kopiur 0.6.0 -> 0.7.0 (trivial: values unchanged, same CRDs)

### DIFF
--- a/docs/domains/storage/kopiur-backup-architecture.md
+++ b/docs/domains/storage/kopiur-backup-architecture.md
@@ -188,10 +188,17 @@ or [`my-apps/home/project-nomad/mysql/`](https://github.com/mitchross/talos-argo
 
 ---
 
-## 6. Upstream 0.5.x/0.6 notes (assessed 2026-07-04, updated 2026-07-06, chart pinned `0.6.0`)
+## 6. Upstream 0.5.x–0.7 notes (assessed 2026-07-04, updated 2026-07-07, chart pinned `0.7.0`)
 
-What changed upstream in 0.5.0–0.5.2 and how it lands here:
+What changed upstream in 0.5.0–0.7.0 and how it lands here:
 
+- **0.7.0 = a trivial bump for us** (2026-07-07). The chart's `values.yaml` is
+  byte-identical to 0.6.0, the `kubeVersion` floor is unchanged (`>=1.32.0-0`),
+  and the CRD set is the same 8. Its breaking changes are all internal Rust
+  dependency upgrades (kube 4.0, croner 3.0, reqwest/rand) plus the
+  `RepositoryReplication` sync-to credential fix (#200) — which we don't use
+  (no replication). Render-verified with our values: 20 objects, images at
+  `0.7.0`, `failurePolicy: Ignore` intact.
 - **0.5.2: transient VolumeSnapshot errors are retried, not terminal** (#201).
   Before, a Longhorn hiccup during CSI staging burned the whole backup run.
 - **Failed `Snapshot` CRs are terminal by design** — kopiur never retries a

--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -32,7 +32,11 @@ helmCharts:
     # helm template --include-crds (this includeCRDs: true) emits the same 8
     # CRDs before and after, so ArgoCD never sees them leave the manifest.
     # NEVER remove includeCRDs: true — it IS the CRD lifecycle here.
-    version: 0.6.0
+    # 0.7.0 (2026-07-07): trivial for us — values.yaml unchanged vs 0.6.0,
+    # same kubeVersion floor, same 8-CRD set. Breaking changes are all internal
+    # Rust dep bumps (kube 4.0, croner 3.0) + the RepositoryReplication cred fix
+    # (#200) which we don't use. Render-verified with our values.
+    version: 0.7.0
     releaseName: kopiur
     namespace: kopiur-system
     includeCRDs: true


### PR DESCRIPTION
0.7.0 shipped before 0.6.0 landed here, so this branch goes straight to 0.7.0. Trivial bump: the chart's values.yaml is byte-identical to 0.6.0, kubeVersion floor unchanged (>=1.32.0-0, our 1.36.2 covers it), same 8-CRD set. All 0.7.0 breaking changes are internal Rust deps (kube 4.0, croner 3.0, reqwest, rand) plus the RepositoryReplication sync-to credential fix (#200) which we don't use.

The 0.6.0 chart-refactor learnings (CRD move to crds/ dir, kubeVersion floor, includeCRDs as the CRD lifecycle) all still apply and stay documented — 0.7.0 inherits the refactored chart unchanged.

Render-verified with our values: 20 objects, 8 CRDs, images resolve
0.7.0, failurePolicy: Ignore intact. Section 6 updated.


Claude-Session: https://claude.ai/code/session_01JKwipCZr2pDfQHSQwFwkcw