### PR TITLE
Bump kopiur 0.6.0 → 0.7.0

### DIFF
--- a/docs/domains/storage/kopiur-backup-architecture.md
+++ b/docs/domains/storage/kopiur-backup-architecture.md
@@ -188,10 +188,17 @@ or [`my-apps/home/project-nomad/mysql/`](https://github.com/mitchross/talos-argo
 
 ---
 
-## 6. Upstream 0.5.x/0.6 notes (assessed 2026-07-04, updated 2026-07-06, chart pinned `0.6.0`)
+## 6. Upstream 0.5.x–0.7 notes (assessed 2026-07-04, updated 2026-07-07, chart pinned `0.7.0`)
 
-What changed upstream in 0.5.0–0.5.2 and how it lands here:
+What changed upstream in 0.5.0–0.7.0 and how it lands here:
 
+- **0.7.0 = a trivial bump for us** (2026-07-07). The chart's `values.yaml` is
+  byte-identical to 0.6.0, the `kubeVersion` floor is unchanged (`>=1.32.0-0`),
+  and the CRD set is the same 8. Its breaking changes are all internal Rust
+  dependency upgrades (kube 4.0, croner 3.0, reqwest/rand) plus the
+  `RepositoryReplication` sync-to credential fix (#200) — which we don't use
+  (no replication). Render-verified with our values: 20 objects, images at
+  `0.7.0`, `failurePolicy: Ignore` intact.
 - **0.5.2: transient VolumeSnapshot errors are retried, not terminal** (#201).
   Before, a Longhorn hiccup during CSI staging burned the whole backup run.
 - **Failed `Snapshot` CRs are terminal by design** — kopiur never retries a

--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -32,7 +32,11 @@ helmCharts:
     # helm template --include-crds (this includeCRDs: true) emits the same 8
     # CRDs before and after, so ArgoCD never sees them leave the manifest.
     # NEVER remove includeCRDs: true — it IS the CRD lifecycle here.
-    version: 0.6.0
+    # 0.7.0 (2026-07-07): trivial for us — values.yaml unchanged vs 0.6.0,
+    # same kubeVersion floor, same 8-CRD set. Breaking changes are all internal
+    # Rust dep bumps (kube 4.0, croner 3.0) + the RepositoryReplication cred fix
+    # (#200) which we don't use. Render-verified with our values.
+    version: 0.7.0
     releaseName: kopiur
     namespace: kopiur-system
     includeCRDs: true


### PR DESCRIPTION
## Summary

Bumps the kopiur operator chart 0.6.0 → 0.7.0 (main is already on 0.6.0). This is a **trivial bump** — the only file change is the version pin plus a doc note.

## Why it's low-risk

Verified 0.7.0 against 0.6.0 upstream:
- **`values.yaml` is byte-identical** to 0.6.0 — none of our values keys move.
- **`kubeVersion` floor unchanged** (`>=1.32.0-0`) — our `kubeVersion: "1.36.2"` still covers it.
- **Same 8-CRD set** — diffed, identical (the only CRD file touched is `repositoryreplications`, schema slimmed; we don't use replication).
- Every 0.7.0 breaking change is either an internal Rust dependency bump (kube 4.0, croner 3.0, reqwest, rand — invisible to consumers) or the `RepositoryReplication` sync-to credential fix (#200), which this repo doesn't use.

The 0.6.0 chart-refactor safeguards (CRDs live in Helm's native `crds/` dir, rendered via `includeCRDs: true`; the `kubeVersion` field) all still apply — 0.7.0 inherits the refactored chart unchanged, so they stay documented in §6.

## Verification
- Chart packaged as upstream release.yaml does (`--version/--app-version 0.7.0`), templated with the repo's actual values.yaml: **20 objects, 8 CRDs**, images resolve `kopiur-{controller,webhook,mover}:0.7.0`, `webhook.failurePolicy: Ignore` intact.

## Post-merge check
- `kubectl -n kopiur-system get deploy -o jsonpath='{range .items[*]}{.spec.template.spec.containers[*].image}{"\n"}{end}'` — both pods should show `:0.7.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKwipCZr2pDfQHSQwFwkcw

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKwipCZr2pDfQHSQwFwkcw)_