### PR TITLE
karakeep: DR restore pin to last-good snapshot

### DIFF
--- a/my-apps/media/karakeep/kopiur/data-pvc.yaml
+++ b/my-apps/media/karakeep/kopiur/data-pvc.yaml
@@ -50,9 +50,17 @@ metadata:
   namespace: karakeep
 spec:
   source:
-    fromPolicy:
-      name: data-pvc
-      offset: 0 # 0 = latest snapshot for this policy's identity
+    # DR PIN (2026-07-08): offset:0 kept resolving to a phantom object
+    # (eb7ca5e…) left by failed backups after CSI snapshotting broke on
+    # 2026-07-02, so the populator errored "content not found". Pinned to the
+    # last verified-good snapshot (07-02 02:10 UTC, root k88cb…, restore-tested)
+    # to recover deterministically. Revert to fromPolicy/offset:0 once the
+    # restored volume is healthy and fresh backups are succeeding again.
+    identity:
+      username: data-pvc
+      hostname: karakeep
+      sourcePath: /pvc/data-pvc
+      snapshotID: c32606dfe053be73c2983b6039453115
   # repository, target.populator, policy.onMissingSnapshot ← component
   # mover securityContext (uid 1001) ← per-app patch in kustomization.yaml
   mover:


### PR DESCRIPTION
## What
Pins the karakeep `data-pvc` kopiur Restore to the last verified-good kopia snapshot `c32606` (2026-07-02 02:10 UTC) instead of `offset: 0`.

## Why (incident 2026-07-08)
- CSI/Longhorn snapshotting for `data-pvc` broke on **2026-07-02**; every kopiur backup since **failed** (silently, no alert).
- The failed-snapshot pileup (140 snapshots, 139 leaked attachment tickets) **faulted the single Longhorn replica** — unopenable (exit 61), Longhorn salvage impossible.
- Restoring from backup, kopiur `offset: 0` resolved to a **phantom object `eb7ca5e…`** left by a failed backup → populator errored `content not found`.
- The real snapshots are all intact; `c32606` **test-restored cleanly** (288 files / 14 MB incl. `db.db`).

## Follow-ups (tracked separately)
- Revert to `offset: 0` once the restored volume is healthy and fresh backups succeed.
- **Add alerting on kopiur backup failure** — this went unnoticed for ~5 days.
- Root-cause why CSI snapshots began failing on 07-02 (likely snapshot-count limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)