### PR TITLE
feat(energy): TOU cost model + per-device share + weekly/monthly/yearly trends

### DIFF
--- a/monitoring/prometheus-stack/homelab-power-dashboard.yaml
+++ b/monitoring/prometheus-stack/homelab-power-dashboard.yaml
@@ -40,7 +40,7 @@ data:
               "decimals": 1
             }
           },
-          "gridPos": { "h": 6, "w": 8, "x": 0, "y": 1 },
+          "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
           "id": 2,
           "options": {
             "colorMode": "value",
@@ -49,7 +49,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "title": "Homelab — Total Power Now",
+          "title": "Total Power Now",
           "type": "stat",
           "targets": [
             {
@@ -67,29 +67,29 @@ data:
               "thresholds": {
                 "steps": [
                   { "color": "green", "value": null },
-                  { "color": "yellow", "value": 1 },
-                  { "color": "orange", "value": 3 }
+                  { "color": "yellow", "value": 0.23 },
+                  { "color": "red", "value": 0.28 }
                 ]
               },
-              "unit": "kwatth",
-              "decimals": 2
+              "unit": "currencyUSD",
+              "decimals": 4
             }
           },
-          "gridPos": { "h": 6, "w": 8, "x": 8, "y": 1 },
+          "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
           "id": 3,
           "options": {
             "colorMode": "value",
-            "graphMode": "area",
+            "graphMode": "none",
             "reduceOptions": { "calcs": ["lastNotNull"] },
             "textMode": "auto",
             "wideLayout": true
           },
-          "title": "Energy Today",
+          "title": "Current Rate ($/kWh)",
           "type": "stat",
           "targets": [
             {
-              "expr": "homeassistant_sensor_energy_kwh{entity=\"sensor.homelab_total_energy_today\"}",
-              "legendFormat": "kWh",
+              "expr": "homeassistant_sensor_unit_usd_kwh{entity=\"sensor.current_electricity_rate\"}",
+              "legendFormat": "Rate",
               "refId": "A"
             }
           ]
@@ -111,7 +111,7 @@ data:
               "decimals": 2
             }
           },
-          "gridPos": { "h": 6, "w": 8, "x": 16, "y": 1 },
+          "gridPos": { "h": 6, "w": 6, "x": 12, "y": 1 },
           "id": 4,
           "options": {
             "colorMode": "value",
@@ -120,11 +120,47 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "title": "Cost Today ($0.21/kWh)",
+          "title": "Cost Today",
           "type": "stat",
           "targets": [
             {
-              "expr": "homeassistant_sensor_unit_usd{entity=\"sensor.homelab_cost_today\"}",
+              "expr": "homeassistant_sensor_unit_usd{entity=\"sensor.homelab_cost_daily\"}",
+              "legendFormat": "USD",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 15 },
+                  { "color": "orange", "value": 30 },
+                  { "color": "red", "value": 50 }
+                ]
+              },
+              "unit": "currencyUSD",
+              "decimals": 2
+            }
+          },
+          "gridPos": { "h": 6, "w": 6, "x": 18, "y": 1 },
+          "id": 5,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "title": "Cost This Month",
+          "type": "stat",
+          "targets": [
+            {
+              "expr": "homeassistant_sensor_unit_usd{entity=\"sensor.homelab_cost_monthly\"}",
               "legendFormat": "USD",
               "refId": "A"
             }
@@ -133,7 +169,76 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
-          "id": 5,
+          "id": 6,
+          "title": "Share of homelab draw",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "unit": "watt",
+              "decimals": 1
+            }
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+          "id": 7,
+          "options": {
+            "pieType": "donut",
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": ["value", "percent"]
+            },
+            "tooltip": { "mode": "multi" }
+          },
+          "title": "Power Share — Per Plug",
+          "type": "piechart",
+          "targets": [
+            {
+              "expr": "homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_current_consumption\"}",
+              "legendFormat": "{{friendly_name}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "unit": "percent",
+              "decimals": 1,
+              "min": 0,
+              "max": 100,
+              "custom": { "displayMode": "gradient" }
+            }
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+          "id": 8,
+          "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "showUnfilled": true,
+            "valueMode": "color"
+          },
+          "title": "Percent of Homelab Total",
+          "type": "bargauge",
+          "targets": [
+            {
+              "expr": "homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_current_consumption\"} / scalar(homeassistant_sensor_power_w{entity=\"sensor.homelab_total_power\"}) * 100",
+              "legendFormat": "{{friendly_name}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 },
+          "id": 9,
           "title": "Per-plug power",
           "type": "row"
         },
@@ -147,8 +252,8 @@ data:
               "custom": { "displayMode": "gradient" }
             }
           },
-          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
-          "id": 6,
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 17 },
+          "id": 10,
           "options": {
             "orientation": "horizontal",
             "displayMode": "gradient",
@@ -160,7 +265,7 @@ data:
           "type": "bargauge",
           "targets": [
             {
-              "expr": "homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_smart_plug_current_consumption\"}",
+              "expr": "homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_current_consumption\"}",
               "legendFormat": "{{friendly_name}}",
               "refId": "A"
             }
@@ -179,8 +284,8 @@ data:
               }
             }
           },
-          "gridPos": { "h": 10, "w": 24, "x": 0, "y": 16 },
-          "id": 7,
+          "gridPos": { "h": 9, "w": 24, "x": 0, "y": 25 },
+          "id": 11,
           "options": {
             "tooltip": { "mode": "multi", "sort": "desc" },
             "legend": {
@@ -193,39 +298,7 @@ data:
           "type": "timeseries",
           "targets": [
             {
-              "expr": "homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_smart_plug_current_consumption\"}",
-              "legendFormat": "{{friendly_name}}",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "watt",
-              "custom": {
-                "fillOpacity": 10,
-                "lineWidth": 2,
-                "spanNulls": false
-              }
-            }
-          },
-          "gridPos": { "h": 10, "w": 24, "x": 0, "y": 26 },
-          "id": 8,
-          "options": {
-            "tooltip": { "mode": "multi", "sort": "desc" },
-            "legend": {
-              "displayMode": "table",
-              "placement": "right",
-              "calcs": ["mean", "max", "lastNotNull"]
-            }
-          },
-          "title": "Per-Plug Power Over Time",
-          "type": "timeseries",
-          "targets": [
-            {
-              "expr": "homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_smart_plug_current_consumption\"}",
+              "expr": "homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_current_consumption\"}",
               "legendFormat": "{{friendly_name}}",
               "refId": "A"
             }
@@ -233,8 +306,8 @@ data:
         },
         {
           "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
-          "id": 9,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+          "id": 12,
           "title": "Cost",
           "type": "row"
         },
@@ -248,8 +321,8 @@ data:
               "custom": { "displayMode": "gradient" }
             }
           },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 37 },
-          "id": 10,
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+          "id": 13,
           "options": {
             "orientation": "horizontal",
             "displayMode": "gradient",
@@ -261,7 +334,36 @@ data:
           "type": "bargauge",
           "targets": [
             {
-              "expr": "homeassistant_sensor_unit_usd{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_cost_today\"}",
+              "expr": "homeassistant_sensor_unit_usd{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_cost_daily\"}",
+              "legendFormat": "{{friendly_name}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "unit": "currencyUSD",
+              "decimals": 2,
+              "custom": { "displayMode": "gradient" }
+            }
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 35 },
+          "id": 14,
+          "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "showUnfilled": true,
+            "valueMode": "color"
+          },
+          "title": "Cost This Month — Per Plug",
+          "type": "bargauge",
+          "targets": [
+            {
+              "expr": "homeassistant_sensor_unit_usd{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_cost_monthly\"}",
               "legendFormat": "{{friendly_name}}",
               "refId": "A"
             }
@@ -279,8 +381,8 @@ data:
               }
             }
           },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 37 },
-          "id": 11,
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 43 },
+          "id": 15,
           "options": {
             "tooltip": { "mode": "multi", "sort": "desc" },
             "legend": {
@@ -289,25 +391,36 @@ data:
               "calcs": ["lastNotNull"]
             }
           },
-          "title": "Cost Today Over Time",
+          "title": "Cost Accrual Today (resets at midnight)",
           "type": "timeseries",
           "targets": [
             {
-              "expr": "homeassistant_sensor_unit_usd{entity=\"sensor.homelab_cost_today\"}",
+              "expr": "homeassistant_sensor_unit_usd{entity=\"sensor.homelab_cost_daily\"}",
               "legendFormat": "Homelab Total",
               "refId": "A"
             },
             {
-              "expr": "homeassistant_sensor_unit_usd{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_cost_today\"}",
+              "expr": "homeassistant_sensor_unit_usd{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_cost_daily\"}",
               "legendFormat": "{{friendly_name}}",
               "refId": "B"
             }
           ]
         },
         {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "gridPos": { "h": 3, "w": 24, "x": 0, "y": 51 },
+          "id": 16,
+          "options": {
+            "mode": "markdown",
+            "content": "**Weekly / monthly / yearly cost & energy history lives in Home Assistant** (Settings → Energy, and the *Homelab Power* dashboard). Prometheus retains only ~15 days, so this Grafana board is real-time + recent detail; long-term trends are kept forever in HA Long-Term Statistics."
+          },
+          "title": "",
+          "type": "text"
+        },
+        {
           "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 45 },
-          "id": 12,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 54 },
+          "id": 17,
           "title": "Electrical",
           "type": "row"
         },
@@ -319,8 +432,8 @@ data:
               "custom": { "fillOpacity": 10, "lineWidth": 2, "spanNulls": false }
             }
           },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 46 },
-          "id": 13,
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 55 },
+          "id": 18,
           "options": {
             "tooltip": { "mode": "multi" },
             "legend": { "displayMode": "list", "placement": "bottom" }
@@ -329,7 +442,7 @@ data:
           "type": "timeseries",
           "targets": [
             {
-              "expr": "homeassistant_sensor_voltage_v{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_smart_plug_voltage\"}",
+              "expr": "homeassistant_sensor_voltage_v{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_voltage\"}",
               "legendFormat": "{{friendly_name}}",
               "refId": "A"
             }
@@ -343,8 +456,8 @@ data:
               "custom": { "fillOpacity": 10, "lineWidth": 2, "spanNulls": false }
             }
           },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 46 },
-          "id": 14,
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 55 },
+          "id": 19,
           "options": {
             "tooltip": { "mode": "multi" },
             "legend": { "displayMode": "list", "placement": "bottom" }
@@ -353,7 +466,7 @@ data:
           "type": "timeseries",
           "targets": [
             {
-              "expr": "homeassistant_sensor_current_a{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_smart_plug_current\"}",
+              "expr": "homeassistant_sensor_current_a{entity=~\"sensor\\\\.(gpu_psu|nas_psu|proxmox_server|truenas_server)_current\"}",
               "legendFormat": "{{friendly_name}}",
               "refId": "A"
             }
@@ -369,5 +482,5 @@ data:
       "timezone": "",
       "title": "Homelab Power & Cost",
       "uid": "homelab-power-cost",
-      "version": 1
+      "version": 2
     }

--- a/my-apps/home/home-assistant/configuration.yaml
+++ b/my-apps/home/home-assistant/configuration.yaml
@@ -45,7 +45,10 @@ recorder:
 #
 # Scoped to homelab Tapo plugs only — household plugs (dryer/office/tv) and the
 # unused homelab-smart-plug are deliberately excluded so the homelab cost
-# dashboard isn't polluted with non-server load.
+# dashboard isn't polluted with non-server load. The device-prefix globs
+# (gpu_psu_*, nas_psu_*, proxmox_server_*, truenas_server_*) already capture the
+# new per-device cost/energy/percentage sensors; homelab_cost_* / homelab_total_*
+# capture the totals. Only the standalone rate sensors need explicit globs.
 prometheus:
   requires_auth: false
   filter:
@@ -56,7 +59,8 @@ prometheus:
       - sensor.truenas_server_*
       - sensor.homelab_total_*
       - sensor.homelab_cost_*
-      - sensor.*_cost_today
+      - sensor.current_electricity_rate
+      - sensor.electricity_tariff_period
       # StuckAtPrototype AirCube Zigbee air-quality monitor (temp/humidity/eCO2/
       # tVOC + rssi/lqi). Feeds the aircube-dashboard.yaml Grafana dashboard.
       - sensor.stuckatprototype_aircube_*
@@ -68,6 +72,9 @@ prometheus:
       - sensor.tv_smart_plug_*
 
 # Enable energy monitoring (dashboard configured in UI; sensors below feed it).
+# Add the four sensor.<dev>_energy sensors as "Individual devices" in
+# Settings > Dashboards > Energy, optionally attaching the matching <dev>_cost
+# entity, to unlock HA's native daily/monthly/yearly energy+cost history.
 energy:
 
 # Enable the person integration
@@ -84,16 +91,79 @@ lovelace:
       show_in_sidebar: true
       filename: lovelace-homelab-power.yaml
 
-# Riemann-sum energy + daily utility meters.
+# ---------------------------------------------------------------------------
+# Electricity rate helpers (Consumers Energy, Rate 1001 — time-of-use).
+#
+# GIT IS THE SOURCE OF TRUTH: `initial:` pins each rate to the value from the
+# bill, so an HA restart resets the sliders to these numbers. The UI sliders are
+# for quick what-if experiments; permanent rate changes go HERE, in git.
+#
+# All-in marginal cost is modelled as (energy_rate + delivery_riders) * (1+tax):
+#   * energy_rate varies by season + peak/off-peak (see current_electricity_rate)
+#   * delivery_riders = Distribution + PSCR + every per-kWh surcharge, summed
+#   * tax = MI state sales tax
+# ---------------------------------------------------------------------------
+input_number:
+  rate_summer_onpeak:
+    name: "Rate — Summer On-Peak Energy"
+    min: 0
+    max: 1
+    step: 0.000001
+    mode: box
+    unit_of_measurement: "USD/kWh"
+    icon: mdi:cash-clock
+    initial: 0.151904
+  rate_summer_offpeak:
+    name: "Rate — Summer Off-Peak Energy"
+    min: 0
+    max: 1
+    step: 0.000001
+    mode: box
+    unit_of_measurement: "USD/kWh"
+    icon: mdi:cash
+    initial: 0.103970
+  rate_nonsummer:
+    name: "Rate — Non-Summer Energy"
+    min: 0
+    max: 1
+    step: 0.000001
+    mode: box
+    unit_of_measurement: "USD/kWh"
+    icon: mdi:cash
+    initial: 0.082996
+  rate_delivery_riders:
+    name: "Rate — Delivery Riders (per kWh)"
+    min: 0
+    max: 1
+    step: 0.000001
+    mode: box
+    unit_of_measurement: "USD/kWh"
+    icon: mdi:transmission-tower
+    initial: 0.120887
+  rate_sales_tax_pct:
+    name: "Rate — Sales Tax"
+    min: 0
+    max: 20
+    step: 0.1
+    mode: box
+    unit_of_measurement: "%"
+    icon: mdi:percent
+    initial: 6.0
+
+# ---------------------------------------------------------------------------
+# Riemann-sum energy/cost integrations.
 #
 # The TP-Link P115 plugs expose only instantaneous power (Current consumption,
-# W), Current (A) and Voltage (V) — there is NO cumulative energy sensor. We
-# integrate each plug's power into kWh (`integration` platform), then a
-# daily-cycle `utility_meter` yields "today's" energy that resets at midnight.
-# These feed the cost templates and the dashboard energy graphs.
-# NOTE: the integral starts at 0 when first created and builds up over time;
-# today's numbers are only accurate from the next local midnight onward.
+# W), Current (A) and Voltage (V). We integrate each plug's power into kWh
+# (`integration` platform); the cost integrations integrate a live USD/h
+# cost-rate (power * current TOU rate) so cost accrues at whatever rate was
+# active moment-to-moment — the correct way to handle time-of-use pricing.
+# NOTE: every integral starts at 0 when first created and builds up over time;
+# today's numbers are only accurate from the next local midnight onward, and
+# monthly/yearly totals fill in as data accumulates.
+# ---------------------------------------------------------------------------
 sensor:
+  # --- per-plug energy (kWh) ---
   - platform: integration
     source: sensor.gpu_psu_current_consumption
     name: "GPU PSU Energy"
@@ -123,34 +193,282 @@ sensor:
     round: 3
     method: left
 
+  # --- homelab total energy (kWh) — feeds weekly/monthly/yearly meters ---
+  - platform: integration
+    source: sensor.homelab_total_power
+    name: "Homelab Total Energy"
+    unique_id: homelab_total_energy
+    unit_prefix: k
+    round: 3
+    method: left
+
+  # --- per-plug cumulative cost (USD) — integrates the USD/h cost-rate ---
+  - platform: integration
+    source: sensor.gpu_psu_cost_rate
+    name: "GPU PSU Cost"
+    unique_id: gpu_psu_cost
+    unit_time: h
+    round: 4
+    method: left
+  - platform: integration
+    source: sensor.nas_psu_cost_rate
+    name: "NAS PSU Cost"
+    unique_id: nas_psu_cost
+    unit_time: h
+    round: 4
+    method: left
+  - platform: integration
+    source: sensor.proxmox_server_cost_rate
+    name: "Proxmox Server Cost"
+    unique_id: proxmox_server_cost
+    unit_time: h
+    round: 4
+    method: left
+  - platform: integration
+    source: sensor.truenas_server_cost_rate
+    name: "TrueNAS Server Cost"
+    unique_id: truenas_server_cost
+    unit_time: h
+    round: 4
+    method: left
+
+  # --- homelab total cumulative cost (USD) ---
+  - platform: integration
+    source: sensor.homelab_cost_rate
+    name: "Homelab Cost"
+    unique_id: homelab_cost
+    unit_time: h
+    round: 4
+    method: left
+
+# ---------------------------------------------------------------------------
+# Utility meters — reset-per-cycle counters. HA keeps these in Long-Term
+# Statistics forever, so the daily/weekly/monthly/yearly cost & energy trends
+# survive well beyond Prometheus's 15-day retention.
+#
+# IMPORTANT: each `name:` is chosen so its slug equals the config key, giving a
+# deterministic entity_id (e.g. sensor.gpu_psu_energy_daily). HA derives a
+# utility_meter's entity_id from the slug of `name` when set, so the two MUST
+# match or downstream references (templates, dashboards) silently read nothing.
+# ---------------------------------------------------------------------------
 utility_meter:
+  # ===== ENERGY (kWh) =====
+  # GPU PSU
   gpu_psu_energy_daily:
-    name: "GPU PSU Energy Today"
+    name: "GPU PSU Energy Daily"
     source: sensor.gpu_psu_energy
     cycle: daily
+  gpu_psu_energy_weekly:
+    name: "GPU PSU Energy Weekly"
+    source: sensor.gpu_psu_energy
+    cycle: weekly
+  gpu_psu_energy_monthly:
+    name: "GPU PSU Energy Monthly"
+    source: sensor.gpu_psu_energy
+    cycle: monthly
+  gpu_psu_energy_yearly:
+    name: "GPU PSU Energy Yearly"
+    source: sensor.gpu_psu_energy
+    cycle: yearly
+  # NAS PSU
   nas_psu_energy_daily:
-    name: "NAS PSU Energy Today"
+    name: "NAS PSU Energy Daily"
     source: sensor.nas_psu_energy
     cycle: daily
+  nas_psu_energy_weekly:
+    name: "NAS PSU Energy Weekly"
+    source: sensor.nas_psu_energy
+    cycle: weekly
+  nas_psu_energy_monthly:
+    name: "NAS PSU Energy Monthly"
+    source: sensor.nas_psu_energy
+    cycle: monthly
+  nas_psu_energy_yearly:
+    name: "NAS PSU Energy Yearly"
+    source: sensor.nas_psu_energy
+    cycle: yearly
+  # Proxmox Server
   proxmox_server_energy_daily:
-    name: "Proxmox Server Energy Today"
+    name: "Proxmox Server Energy Daily"
     source: sensor.proxmox_server_energy
     cycle: daily
+  proxmox_server_energy_weekly:
+    name: "Proxmox Server Energy Weekly"
+    source: sensor.proxmox_server_energy
+    cycle: weekly
+  proxmox_server_energy_monthly:
+    name: "Proxmox Server Energy Monthly"
+    source: sensor.proxmox_server_energy
+    cycle: monthly
+  proxmox_server_energy_yearly:
+    name: "Proxmox Server Energy Yearly"
+    source: sensor.proxmox_server_energy
+    cycle: yearly
+  # TrueNAS Server
   truenas_server_energy_daily:
-    name: "TrueNAS Server Energy Today"
+    name: "TrueNAS Server Energy Daily"
     source: sensor.truenas_server_energy
     cycle: daily
+  truenas_server_energy_weekly:
+    name: "TrueNAS Server Energy Weekly"
+    source: sensor.truenas_server_energy
+    cycle: weekly
+  truenas_server_energy_monthly:
+    name: "TrueNAS Server Energy Monthly"
+    source: sensor.truenas_server_energy
+    cycle: monthly
+  truenas_server_energy_yearly:
+    name: "TrueNAS Server Energy Yearly"
+    source: sensor.truenas_server_energy
+    cycle: yearly
+  # Homelab total energy
+  homelab_total_energy_weekly:
+    name: "Homelab Total Energy Weekly"
+    source: sensor.homelab_total_energy
+    cycle: weekly
+  homelab_total_energy_monthly:
+    name: "Homelab Total Energy Monthly"
+    source: sensor.homelab_total_energy
+    cycle: monthly
+  homelab_total_energy_yearly:
+    name: "Homelab Total Energy Yearly"
+    source: sensor.homelab_total_energy
+    cycle: yearly
 
-# Template sensors:
-#   * homelab_total_power           — instantaneous draw of all 4 homelab plugs (W)
-#   * homelab_total_energy_today    — kWh used today across all 4 (resets at midnight)
-#   * homelab_cost_today            — total_energy_today * MICHIGAN_RATE (USD)
-#   * <plug>_cost_today             — per-plug breakdown so Grafana can rank cost
-#
-# Michigan residential rate is hard-coded at 0.21 USD/kWh. Update both the
-# total and per-plug expressions if your utility rate changes.
+  # ===== COST (USD) =====
+  # GPU PSU
+  gpu_psu_cost_daily:
+    name: "GPU PSU Cost Daily"
+    source: sensor.gpu_psu_cost
+    cycle: daily
+  gpu_psu_cost_weekly:
+    name: "GPU PSU Cost Weekly"
+    source: sensor.gpu_psu_cost
+    cycle: weekly
+  gpu_psu_cost_monthly:
+    name: "GPU PSU Cost Monthly"
+    source: sensor.gpu_psu_cost
+    cycle: monthly
+  gpu_psu_cost_yearly:
+    name: "GPU PSU Cost Yearly"
+    source: sensor.gpu_psu_cost
+    cycle: yearly
+  # NAS PSU
+  nas_psu_cost_daily:
+    name: "NAS PSU Cost Daily"
+    source: sensor.nas_psu_cost
+    cycle: daily
+  nas_psu_cost_weekly:
+    name: "NAS PSU Cost Weekly"
+    source: sensor.nas_psu_cost
+    cycle: weekly
+  nas_psu_cost_monthly:
+    name: "NAS PSU Cost Monthly"
+    source: sensor.nas_psu_cost
+    cycle: monthly
+  nas_psu_cost_yearly:
+    name: "NAS PSU Cost Yearly"
+    source: sensor.nas_psu_cost
+    cycle: yearly
+  # Proxmox Server
+  proxmox_server_cost_daily:
+    name: "Proxmox Server Cost Daily"
+    source: sensor.proxmox_server_cost
+    cycle: daily
+  proxmox_server_cost_weekly:
+    name: "Proxmox Server Cost Weekly"
+    source: sensor.proxmox_server_cost
+    cycle: weekly
+  proxmox_server_cost_monthly:
+    name: "Proxmox Server Cost Monthly"
+    source: sensor.proxmox_server_cost
+    cycle: monthly
+  proxmox_server_cost_yearly:
+    name: "Proxmox Server Cost Yearly"
+    source: sensor.proxmox_server_cost
+    cycle: yearly
+  # TrueNAS Server
+  truenas_server_cost_daily:
+    name: "TrueNAS Server Cost Daily"
+    source: sensor.truenas_server_cost
+    cycle: daily
+  truenas_server_cost_weekly:
+    name: "TrueNAS Server Cost Weekly"
+    source: sensor.truenas_server_cost
+    cycle: weekly
+  truenas_server_cost_monthly:
+    name: "TrueNAS Server Cost Monthly"
+    source: sensor.truenas_server_cost
+    cycle: monthly
+  truenas_server_cost_yearly:
+    name: "TrueNAS Server Cost Yearly"
+    source: sensor.truenas_server_cost
+    cycle: yearly
+  # Homelab total cost
+  homelab_cost_daily:
+    name: "Homelab Cost Daily"
+    source: sensor.homelab_cost
+    cycle: daily
+  homelab_cost_weekly:
+    name: "Homelab Cost Weekly"
+    source: sensor.homelab_cost
+    cycle: weekly
+  homelab_cost_monthly:
+    name: "Homelab Cost Monthly"
+    source: sensor.homelab_cost
+    cycle: monthly
+  homelab_cost_yearly:
+    name: "Homelab Cost Yearly"
+    source: sensor.homelab_cost
+    cycle: yearly
+
+# ---------------------------------------------------------------------------
+# Template sensors.
+#   * current_electricity_rate  — live all-in USD/kWh (TOU + riders + tax)
+#   * electricity_tariff_period — human label for the active tariff window
+#   * homelab_total_power       — instantaneous draw of all 4 homelab plugs (W)
+#   * homelab_total_energy_today— kWh used today across all 4 (resets at midnight)
+#   * homelab_cost_rate         — live USD/h spend across all 4 (feeds integration)
+#   * <plug>_cost_rate          — live USD/h spend per plug (feeds integration)
+#   * <plug>_power_share         — live share of homelab draw (%)
+#   * <plug>_energy_share_today  — share of today's homelab energy (%)
+# ---------------------------------------------------------------------------
 template:
   - sensor:
+      # Live all-in rate. HA re-renders now()-based templates every minute, so
+      # this tracks time-of-day and season automatically. float(<bill default>)
+      # keeps it correct even before the input_number sliders are first touched.
+      - name: "Current Electricity Rate"
+        unique_id: current_electricity_rate
+        unit_of_measurement: "USD/kWh"
+        state_class: measurement
+        icon: mdi:cash-multiple
+        state: >
+          {% set n = now() %}
+          {% set summer = n.month in [6, 7, 8, 9] %}
+          {% set onpeak = summer and n.weekday() < 5 and 14 <= n.hour < 19 %}
+          {% if onpeak %}
+            {% set e = states('input_number.rate_summer_onpeak') | float(0.151904) %}
+          {% elif summer %}
+            {% set e = states('input_number.rate_summer_offpeak') | float(0.103970) %}
+          {% else %}
+            {% set e = states('input_number.rate_nonsummer') | float(0.082996) %}
+          {% endif %}
+          {% set r = states('input_number.rate_delivery_riders') | float(0.120887) %}
+          {% set t = states('input_number.rate_sales_tax_pct') | float(6) %}
+          {{ ((e + r) * (1 + t / 100)) | round(5) }}
+
+      - name: "Electricity Tariff Period"
+        unique_id: electricity_tariff_period
+        icon: mdi:clock-outline
+        state: >
+          {% set n = now() %}
+          {% set summer = n.month in [6, 7, 8, 9] %}
+          {% set onpeak = summer and n.weekday() < 5 and 14 <= n.hour < 19 %}
+          {% if onpeak %}Summer On-Peak
+          {% elif summer %}Summer Off-Peak
+          {% else %}Non-Summer{% endif %}
+
       - name: "Homelab Total Power"
         unique_id: homelab_total_power
         unit_of_measurement: "W"
@@ -178,39 +496,137 @@ template:
             + states('sensor.proxmox_server_energy_daily') | float(0)
             + states('sensor.truenas_server_energy_daily') | float(0)) | round(3) }}
 
-      - name: "Homelab Cost Today"
-        unique_id: homelab_cost_today
-        unit_of_measurement: "USD"
-        state_class: total_increasing
+      # ----- live USD/h cost-rate (power_kW * current all-in rate) -----
+      - name: "Homelab Cost Rate"
+        unique_id: homelab_cost_rate
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        icon: mdi:cash-fast
         state: >
-          {{ ((states('sensor.gpu_psu_energy_daily') | float(0)
-            + states('sensor.nas_psu_energy_daily') | float(0)
-            + states('sensor.proxmox_server_energy_daily') | float(0)
-            + states('sensor.truenas_server_energy_daily') | float(0)) * 0.21) | round(2) }}
+          {{ (states('sensor.homelab_total_power') | float(0) / 1000
+            * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
 
-      - name: "GPU PSU Cost Today"
-        unique_id: gpu_psu_cost_today
-        unit_of_measurement: "USD"
-        state_class: total_increasing
-        state: "{{ (states('sensor.gpu_psu_energy_daily') | float(0) * 0.21) | round(2) }}"
+      - name: "GPU PSU Cost Rate"
+        unique_id: gpu_psu_cost_rate
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        state: >
+          {{ (states('sensor.gpu_psu_current_consumption') | float(0) / 1000
+            * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
 
-      - name: "NAS PSU Cost Today"
-        unique_id: nas_psu_cost_today
-        unit_of_measurement: "USD"
-        state_class: total_increasing
-        state: "{{ (states('sensor.nas_psu_energy_daily') | float(0) * 0.21) | round(2) }}"
+      - name: "NAS PSU Cost Rate"
+        unique_id: nas_psu_cost_rate
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        state: >
+          {{ (states('sensor.nas_psu_current_consumption') | float(0) / 1000
+            * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
 
-      - name: "Proxmox Server Cost Today"
-        unique_id: proxmox_server_cost_today
-        unit_of_measurement: "USD"
-        state_class: total_increasing
-        state: "{{ (states('sensor.proxmox_server_energy_daily') | float(0) * 0.21) | round(2) }}"
+      - name: "Proxmox Server Cost Rate"
+        unique_id: proxmox_server_cost_rate
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        state: >
+          {{ (states('sensor.proxmox_server_current_consumption') | float(0) / 1000
+            * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
 
-      - name: "TrueNAS Server Cost Today"
-        unique_id: truenas_server_cost_today
-        unit_of_measurement: "USD"
-        state_class: total_increasing
-        state: "{{ (states('sensor.truenas_server_energy_daily') | float(0) * 0.21) | round(2) }}"
+      - name: "TrueNAS Server Cost Rate"
+        unique_id: truenas_server_cost_rate
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        state: >
+          {{ (states('sensor.truenas_server_current_consumption') | float(0) / 1000
+            * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
+
+      # ----- live % of homelab draw (entity slug == *_power_share) -----
+      - name: "GPU PSU Power Share"
+        unique_id: gpu_psu_power_share
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:chart-pie
+        state: >
+          {% set total = states('sensor.homelab_total_power') | float(0) %}
+          {% if total > 0 %}
+            {{ (states('sensor.gpu_psu_current_consumption') | float(0) / total * 100) | round(1) }}
+          {% else %}0{% endif %}
+
+      - name: "NAS PSU Power Share"
+        unique_id: nas_psu_power_share
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:chart-pie
+        state: >
+          {% set total = states('sensor.homelab_total_power') | float(0) %}
+          {% if total > 0 %}
+            {{ (states('sensor.nas_psu_current_consumption') | float(0) / total * 100) | round(1) }}
+          {% else %}0{% endif %}
+
+      - name: "Proxmox Server Power Share"
+        unique_id: proxmox_server_power_share
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:chart-pie
+        state: >
+          {% set total = states('sensor.homelab_total_power') | float(0) %}
+          {% if total > 0 %}
+            {{ (states('sensor.proxmox_server_current_consumption') | float(0) / total * 100) | round(1) }}
+          {% else %}0{% endif %}
+
+      - name: "TrueNAS Server Power Share"
+        unique_id: truenas_server_power_share
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:chart-pie
+        state: >
+          {% set total = states('sensor.homelab_total_power') | float(0) %}
+          {% if total > 0 %}
+            {{ (states('sensor.truenas_server_current_consumption') | float(0) / total * 100) | round(1) }}
+          {% else %}0{% endif %}
+
+      # ----- share of today's homelab energy (entity slug == *_energy_share_today) -----
+      - name: "GPU PSU Energy Share Today"
+        unique_id: gpu_psu_energy_share_today
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:chart-donut
+        state: >
+          {% set total = states('sensor.homelab_total_energy_today') | float(0) %}
+          {% if total > 0 %}
+            {{ (states('sensor.gpu_psu_energy_daily') | float(0) / total * 100) | round(1) }}
+          {% else %}0{% endif %}
+
+      - name: "NAS PSU Energy Share Today"
+        unique_id: nas_psu_energy_share_today
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:chart-donut
+        state: >
+          {% set total = states('sensor.homelab_total_energy_today') | float(0) %}
+          {% if total > 0 %}
+            {{ (states('sensor.nas_psu_energy_daily') | float(0) / total * 100) | round(1) }}
+          {% else %}0{% endif %}
+
+      - name: "Proxmox Server Energy Share Today"
+        unique_id: proxmox_server_energy_share_today
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:chart-donut
+        state: >
+          {% set total = states('sensor.homelab_total_energy_today') | float(0) %}
+          {% if total > 0 %}
+            {{ (states('sensor.proxmox_server_energy_daily') | float(0) / total * 100) | round(1) }}
+          {% else %}0{% endif %}
+
+      - name: "TrueNAS Server Energy Share Today"
+        unique_id: truenas_server_energy_share_today
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:chart-donut
+        state: >
+          {% set total = states('sensor.homelab_total_energy_today') | float(0) %}
+          {% if total > 0 %}
+            {{ (states('sensor.truenas_server_energy_daily') | float(0) / total * 100) | round(1) }}
+          {% else %}0{% endif %}
 
 # # Expose Camera Stream Source Integration
 # # Allows exposing camera stream URLs via API for go2rtc/Frigate integration

--- a/my-apps/home/home-assistant/lovelace-homelab-power.yaml
+++ b/my-apps/home/home-assistant/lovelace-homelab-power.yaml
@@ -1,5 +1,11 @@
 # YAML-mode dashboard surfaced in the sidebar as "Homelab Power".
 # Wired via lovelace.dashboards.homelab-power in configuration.yaml.
+#
+# Cost model: all-in time-of-use marginal rate (Consumers Energy Rate 1001).
+# The live rate = (season/peak energy rate + delivery riders) * (1 + sales tax);
+# see the input_number.rate_* helpers + sensor.current_electricity_rate.
+# Long-term (monthly/yearly) trends come from HA Long-Term Statistics, which
+# outlives Prometheus's 15-day retention.
 title: Homelab Power
 views:
   - title: Overview
@@ -11,10 +17,32 @@ views:
           - type: markdown
             content: |
               # Homelab Power & Cost
-              Real-time draw and cost across the GPU PSU, NAS PSU, Proxmox host
-              and TrueNAS host. Rate: **$0.21/kWh** (Michigan residential).
-              All switch entities are locked read-only — see the
-              `Homelab plug power-off lockout` automation.
+              Real-time draw, per-device share, and time-of-use cost across the
+              GPU PSU, NAS PSU, Proxmox host and TrueNAS host. Cost uses the
+              **all-in marginal rate** (energy + delivery riders + tax) that
+              varies by season and peak/off-peak window. Switch entities are
+              locked read-only — see the `Homelab plug power-off lockout`
+              automation.
+
+          - type: entities
+            title: Current Rate
+            entities:
+              - entity: sensor.current_electricity_rate
+                name: Effective rate
+              - entity: sensor.electricity_tariff_period
+                name: Tariff window
+              - type: section
+                label: Rate inputs (temporary — git is source of truth)
+              - entity: input_number.rate_summer_onpeak
+                name: Summer on-peak
+              - entity: input_number.rate_summer_offpeak
+                name: Summer off-peak
+              - entity: input_number.rate_nonsummer
+                name: Non-summer
+              - entity: input_number.rate_delivery_riders
+                name: Delivery riders
+              - entity: input_number.rate_sales_tax_pct
+                name: Sales tax
 
           - type: glance
             title: Right Now
@@ -31,22 +59,75 @@ views:
               - entity: sensor.truenas_server_current_consumption
                 name: TrueNAS
 
-          - type: glance
-            title: Today
-            state_color: false
-            entities:
-              - entity: sensor.homelab_total_energy_today
-                name: kWh
-              - entity: sensor.homelab_cost_today
-                name: Cost
-              - entity: sensor.gpu_psu_cost_today
-                name: GPU
-              - entity: sensor.nas_psu_cost_today
-                name: NAS
-              - entity: sensor.proxmox_server_cost_today
-                name: Proxmox
-              - entity: sensor.truenas_server_cost_today
-                name: TrueNAS
+      - type: horizontal-stack
+        title: Share of homelab draw
+        cards:
+          - type: gauge
+            entity: sensor.gpu_psu_power_share
+            name: GPU PSU
+            unit: "%"
+            min: 0
+            max: 100
+            needle: true
+          - type: gauge
+            entity: sensor.nas_psu_power_share
+            name: NAS PSU
+            unit: "%"
+            min: 0
+            max: 100
+            needle: true
+          - type: gauge
+            entity: sensor.proxmox_server_power_share
+            name: Proxmox
+            unit: "%"
+            min: 0
+            max: 100
+            needle: true
+          - type: gauge
+            entity: sensor.truenas_server_power_share
+            name: TrueNAS
+            unit: "%"
+            min: 0
+            max: 100
+            needle: true
+
+      - type: glance
+        title: Cost so far
+        show_state: true
+        columns: 4
+        entities:
+          - entity: sensor.homelab_cost_daily
+            name: Today
+          - entity: sensor.homelab_cost_weekly
+            name: This Week
+          - entity: sensor.homelab_cost_monthly
+            name: This Month
+          - entity: sensor.homelab_cost_yearly
+            name: This Year
+
+      - type: entities
+        title: Cost by device
+        entities:
+          - type: section
+            label: Today
+          - entity: sensor.gpu_psu_cost_daily
+            name: GPU PSU
+          - entity: sensor.nas_psu_cost_daily
+            name: NAS PSU
+          - entity: sensor.proxmox_server_cost_daily
+            name: Proxmox
+          - entity: sensor.truenas_server_cost_daily
+            name: TrueNAS
+          - type: section
+            label: This Month
+          - entity: sensor.gpu_psu_cost_monthly
+            name: GPU PSU
+          - entity: sensor.nas_psu_cost_monthly
+            name: NAS PSU
+          - entity: sensor.proxmox_server_cost_monthly
+            name: Proxmox
+          - entity: sensor.truenas_server_cost_monthly
+            name: TrueNAS
 
       - type: history-graph
         title: Power draw (24h)
@@ -65,16 +146,40 @@ views:
             name: Total
 
       - type: statistics-graph
-        title: Energy used (7d)
+        title: Energy by day (30d)
         chart_type: bar
         period: day
+        days_to_show: 30
         stat_types:
-          - state
+          - change
         entities:
-          - sensor.gpu_psu_energy_daily
-          - sensor.nas_psu_energy_daily
-          - sensor.proxmox_server_energy_daily
-          - sensor.truenas_server_energy_daily
+          - sensor.gpu_psu_energy
+          - sensor.nas_psu_energy
+          - sensor.proxmox_server_energy
+          - sensor.truenas_server_energy
+
+      - type: statistics-graph
+        title: Cost by month (12 months)
+        chart_type: bar
+        period: month
+        days_to_show: 365
+        stat_types:
+          - change
+        entities:
+          - sensor.gpu_psu_cost
+          - sensor.nas_psu_cost
+          - sensor.proxmox_server_cost
+          - sensor.truenas_server_cost
+
+      - type: statistics-graph
+        title: Total homelab cost by month
+        chart_type: bar
+        period: month
+        days_to_show: 365
+        stat_types:
+          - change
+        entities:
+          - sensor.homelab_cost
 
       - type: entities
         title: Per-plug detail
@@ -82,28 +187,32 @@ views:
           - type: section
             label: GPU PSU
           - entity: sensor.gpu_psu_current_consumption
+          - entity: sensor.gpu_psu_power_share
           - entity: sensor.gpu_psu_energy_daily
           - entity: sensor.gpu_psu_voltage
           - entity: sensor.gpu_psu_current
-          - entity: sensor.gpu_psu_cost_today
+          - entity: sensor.gpu_psu_cost_daily
           - type: section
             label: NAS PSU
           - entity: sensor.nas_psu_current_consumption
+          - entity: sensor.nas_psu_power_share
           - entity: sensor.nas_psu_energy_daily
           - entity: sensor.nas_psu_voltage
           - entity: sensor.nas_psu_current
-          - entity: sensor.nas_psu_cost_today
+          - entity: sensor.nas_psu_cost_daily
           - type: section
             label: Proxmox Server
           - entity: sensor.proxmox_server_current_consumption
+          - entity: sensor.proxmox_server_power_share
           - entity: sensor.proxmox_server_energy_daily
           - entity: sensor.proxmox_server_voltage
           - entity: sensor.proxmox_server_current
-          - entity: sensor.proxmox_server_cost_today
+          - entity: sensor.proxmox_server_cost_daily
           - type: section
             label: TrueNAS Server
           - entity: sensor.truenas_server_current_consumption
+          - entity: sensor.truenas_server_power_share
           - entity: sensor.truenas_server_energy_daily
           - entity: sensor.truenas_server_voltage
           - entity: sensor.truenas_server_current
-          - entity: sensor.truenas_server_cost_today
+          - entity: sensor.truenas_server_cost_daily


### PR DESCRIPTION
## What
Rebuilds the homelab energy dashboards (Home Assistant + Grafana) around the user's real **Consumers Energy Rate 1001 time-of-use** tariff, replacing the flat `$0.21/kWh`.

### Home Assistant (`configuration.yaml`)
- `input_number` rate helpers (summer on/off-peak, non-summer, delivery riders, sales tax) — bill values as git-sourced defaults, UI sliders for what-ifs
- `sensor.current_electricity_rate`: live all-in USD/kWh, season + peak/off-peak aware (2–7pm weekdays Jun–Sep)
- per-device + total USD/h cost-rate → integrated into cumulative USD cost (TOU-correct: cost accrues at the rate active moment-to-moment)
- per-device power/energy **share (% of homelab total)**
- **daily/weekly/monthly/yearly** utility_meters for energy AND cost → HA Long-Term Statistics keeps yearly forever (Prometheus only retains 15d)

### HA Lovelace dashboard
Rate header, share gauges, cost-so-far (day/week/month/year), per-device cost, LTS statistics-graph trends.

### Grafana (`homelab-power-dashboard.yaml`)
Current-rate + cost-today + cost-this-month stats, power-share pie + percent bargauge, per-plug cost today/month.

## Bugs fixed (found on the live system)
1. `homelab_total_energy_today` / `homelab_cost_today` read **0** — template summed `sensor.<dev>_energy_daily` but the meter entity was `<dev>_energy_today` (name slug). Meter names now slug to their keys → deterministic entity_ids.
2. Grafana per-plug power/voltage/current panels queried non-existent `*_smart_plug_*` entities → corrected to real `*_current_consumption` / `_voltage` / `_current`.

## Validation
`homeassistant --script check_config` against the new config inside the live pod: **exit 0, no errors**; all new sections parsed.

## Deploy note
Merging to `main` triggers ArgoCD to sync the ConfigMaps + Grafana dashboard. Home Assistant then needs a `rollout restart` to re-copy config (initContainer). One manual UI step remains: add the 4 `sensor.<dev>_energy` sensors as Individual Devices in Settings → Energy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)