### PR TITLE
fix(open-webui): mcpo v0.0.20 tag does not exist — pin main by digest

### DIFF
--- a/my-apps/ai/open-webui/mcp-config.yaml
+++ b/my-apps/ai/open-webui/mcp-config.yaml
@@ -28,7 +28,7 @@ spec:
                     operator: DoesNotExist
       containers:
       - name: mcpo-multi
-        image: ghcr.io/open-webui/mcpo:v0.0.20
+        image: ghcr.io/open-webui/mcpo:main@sha256:1e82c9555c19e50b80745705f32b47a2647589f35279527b5118ecd3a71bd467
         ports:
         - containerPort: 8001
           name: http

--- a/my-apps/ai/open-webui/mcp-kiwix.yaml
+++ b/my-apps/ai/open-webui/mcp-kiwix.yaml
@@ -30,7 +30,7 @@ spec:
                     operator: DoesNotExist
       containers:
       - name: mcpo-kiwix
-        image: ghcr.io/open-webui/mcpo:v0.0.20
+        image: ghcr.io/open-webui/mcpo:main@sha256:1e82c9555c19e50b80745705f32b47a2647589f35279527b5118ecd3a71bd467
         ports:
         - containerPort: 8002
           name: http


### PR DESCRIPTION
The kustomize-review branch pinned `ghcr.io/open-webui/mcpo` to `v0.0.20`, but the registry only publishes `main`/`latest`/`git-*` tags — `v0.0.20` returns 404 (verified against the ghcr manifest API). Both mcpo Deployments (mcpo-multi, mcpo-kiwix) are stuck with their new ReplicaSets in ImagePullBackOff; the old pods are still serving, so no outage.

This pins `main` by digest instead, matching the `alpine:latest@sha256:` pin pattern already used in home-assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)