### PR TITLE
chore(gitea): scale to 0 for postgres cutover (step 2 of runbook)

### DIFF
--- a/my-apps/development/gitea/values.yaml
+++ b/my-apps/development/gitea/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 1
+replicaCount: 0
 
 persistence:
   enabled: true


### PR DESCRIPTION
Stops gitea writers ahead of the pg_dump/pg_restore in the CNPG→plain-postgres cutover (docs/domains/cnpg/plain-postgres-migration.md §Per-app cutover). Done via git rather than kubectl because my-apps selfHeal would revert a manual scale. The follow-up repoint PR restores replicaCount and switches the DB host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)