### PR TITLE
feat(gitea): cut over to plain postgres + kopiur (step 4 of runbook)

### DIFF
--- a/my-apps/development/gitea/values.yaml
+++ b/my-apps/development/gitea/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 0
+replicaCount: 1
 
 persistence:
   enabled: true
@@ -38,7 +38,7 @@ gitea:
       SSH_DOMAIN: gitea.vanillax.me
     database:
       DB_TYPE: postgres
-      HOST: gitea-database-rw.cloudnative-pg.svc.cluster.local:5432
+      HOST: gitea-postgres.gitea.svc.cluster.local:5432
       NAME: gitea
       USER: gitea
       SCHEMA: public


### PR DESCRIPTION
Data copy done while gitea was scaled to 0: pg_dump (custom format, 1.5MB) from CNPG `gitea-database-1` → pg_restore into `gitea-postgres` with `--no-owner --role=gitea`. Verified identical counts on both sides: 112 tables, 5 repositories, 2 users.

This commit repoints `gitea.config.database.HOST` to `gitea-postgres.gitea.svc.cluster.local:5432` and restores `replicaCount: 1`.

CNPG cluster retirement (step 6) comes as a separate PR after the next hourly kopiur snapshot (:13) completes non-empty against the populated instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)