### PR TITLE
Upgrade kopiur operator to 0.7.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,14 @@ omni/                   # Omni (Sidero) deployment configs
 docs/                   # Documentation
 ```
 
+## Comment Style
+
+Comments earn their place in two ways only:
+1. **How it works** — mechanics not obvious from the YAML itself (e.g. how an ArgoCD app renders a chart, why `includeCRDs: true` IS the CRD lifecycle).
+2. **We got burned** — gotchas that caused a real incident or would silently break things (the "NEVER remove X" class).
+
+Do **not** write changelog/jira-style comments: no per-version release-note summaries, no "assessed on date, no impact" entries, no restating upstream changelogs — git history and release pages already record that. A version bump only warrants a comment if it changes how something works or adds a new gotcha. Don't match the legacy comment density in older files; it's accumulated cruft, not the standard.
+
 ## Critical Rules
 
 ### DO:

--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -36,9 +36,6 @@ helmCharts:
     # same kubeVersion floor, same 8-CRD set. Breaking changes are all internal
     # Rust dep bumps (kube 4.0, croner 3.0) + the RepositoryReplication cred fix
     # (#200) which we don't use. Render-verified with our values.
-    # 0.7.1–0.7.3 (2026-07-12): no breaking changes; fixes populator behavior
-    # on bound PVCs + credential-Secret projection (both touch our
-    # restore-before-bind path). Values keys/CRD set/kubeVersion unchanged.
     version: 0.7.3
     releaseName: kopiur
     namespace: kopiur-system

--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -36,13 +36,9 @@ helmCharts:
     # same kubeVersion floor, same 8-CRD set. Breaking changes are all internal
     # Rust dep bumps (kube 4.0, croner 3.0) + the RepositoryReplication cred fix
     # (#200) which we don't use. Render-verified with our values.
-    # 0.7.1–0.7.3 (2026-07-10→12): no breaking changes. 0.7.1 adds kopia CLI
-    # tuning flags to the CRDs (#221, optional fields) + staged-PVC
-    # storageClass/accessModes overrides and binding-race fix (#228) + mover
-    # ConfigMap reaping (#225). 0.7.2/0.7.3 fix credential-Secret projection
-    # scoping/naming (#234) and populator behavior on already-bound PVCs +
-    # ClusterRepository secret-namespace handling — both directly relevant to
-    # our restore-before-bind + ClusterExternalSecret fanout setup.
+    # 0.7.1–0.7.3 (2026-07-12): no breaking changes; fixes populator behavior
+    # on bound PVCs + credential-Secret projection (both touch our
+    # restore-before-bind path). Values keys/CRD set/kubeVersion unchanged.
     version: 0.7.3
     releaseName: kopiur
     namespace: kopiur-system

--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -36,7 +36,14 @@ helmCharts:
     # same kubeVersion floor, same 8-CRD set. Breaking changes are all internal
     # Rust dep bumps (kube 4.0, croner 3.0) + the RepositoryReplication cred fix
     # (#200) which we don't use. Render-verified with our values.
-    version: 0.7.0
+    # 0.7.1–0.7.3 (2026-07-10→12): no breaking changes. 0.7.1 adds kopia CLI
+    # tuning flags to the CRDs (#221, optional fields) + staged-PVC
+    # storageClass/accessModes overrides and binding-race fix (#228) + mover
+    # ConfigMap reaping (#225). 0.7.2/0.7.3 fix credential-Secret projection
+    # scoping/naming (#234) and populator behavior on already-bound PVCs +
+    # ClusterRepository secret-namespace handling — both directly relevant to
+    # our restore-before-bind + ClusterExternalSecret fanout setup.
+    version: 0.7.3
     releaseName: kopiur
     namespace: kopiur-system
     includeCRDs: true


### PR DESCRIPTION
## Summary
Upgrades the kopiur operator Helm chart from 0.7.0 to 0.7.3, bringing critical fixes for restore-before-bind and ClusterExternalSecret fanout workflows.

## Changes
- **Version bump**: 0.7.0 → 0.7.3
- **Rationale**: 
  - 0.7.1 adds optional kopia CLI tuning flags to CRDs (#221) and staged-PVC storageClass/accessModes overrides with binding-race fix (#228), plus mover ConfigMap reaping (#225)
  - 0.7.2/0.7.3 fix credential-Secret projection scoping/naming (#234) and populator behavior on already-bound PVCs, plus ClusterRepository secret-namespace handling — both directly relevant to our restore-before-bind + ClusterExternalSecret fanout setup

## Implementation Details
No breaking changes across the 0.7.1–0.7.3 range. All changes are additive (optional CRD fields) or bug fixes. The credential-Secret and ClusterRepository fixes in 0.7.2/0.7.3 directly address the restore-before-bind pattern used in this cluster's backup architecture (Wave 2 operator, Wave 3 config fanout).

https://claude.ai/code/session_01TT1htUQdtV1AFGUX8Vqfkt