### PR TITLE
feat(storage): truenas-flash NVMe-oF fast tier for databases

### DIFF
--- a/docs/domains/storage/storage-model-rwo-rwx-and-sizing.md
+++ b/docs/domains/storage/storage-model-rwo-rwx-and-sizing.md
@@ -9,12 +9,24 @@ Storage-class decisions and capacity sizing across the core repo
 - **Static SMB/NFS shares stay on the plain CSI drivers** (`csi-driver-nfs`,
   `csi-driver-smb`). They hold real data you browse/edit by hand; keep them
   human-readable and decoupled from the TrueNAS API. `truenas-csi`
-  (`csi.truenas.io`) is for **dynamic provisioning only**, and v1.0.4 does
-  **iSCSI + NFS only — no SMB**.
-- **Talos:** use **Longhorn for RWO** (block). Do **not** add truenas-csi iSCSI on
-  Talos — it would need the `siderolabs/iscsi-tools` system extension + a Cilium
-  TCP 3260 egress rule, and Longhorn does block RWO better here (node-local
-  replication). Use truenas-csi **NFS (`truenas-nfs`) for RWX** only.
+  (`csi.truenas.io`) is for **dynamic provisioning only**, and does
+  **iSCSI + NVMe-oF + NFS — no SMB**.
+- **Talos:** **Longhorn is the default for RWO** (block, node-local). Use
+  truenas-csi **NFS (`truenas-nfs`) for RWX**, and **`truenas-flash` (NVMe-oF) for
+  write-latency-sensitive RWO** — databases. Rationale (measured 2026-07-13):
+  Longhorn's backing disks are consumer EDILOCA NVMe at **259 fsync IOPS @
+  1.25ms**; the flashpool SSDs do **14,484 @ 0.064ms**, and even paying ~0.15ms of
+  10GbE round-trip that is ~6x better for the fsync-per-commit workload databases
+  actually run. Longhorn still wins for read-heavy volumes and RWX-via-share.
+- **Do not add truenas-csi *iSCSI* on Talos** — but NOT for the reason previously
+  given here. `siderolabs/iscsi-tools` is in fact **already installed on all three
+  machine sets**, and `CONFIG_ISCSI_TCP=y` is built into the Talos 1.13 kernel. The
+  real blocker is that upstream never reads `iscsi.global.basename`
+  (truenas-csi#41): this appliance still carries the FreeNAS-era base name
+  `iqn.2005-10.org.freenas.ctl`, and a mismatch fails every stage with `failed to
+  find device path: []` *and* bakes the wrong IQN into the PV at provision time.
+  NVMe-oF sidesteps it entirely. TCP 3260 stays blocked in Cilium; TCP 4420 is now
+  allowed.
 - **OpenShift/SNO:** no Longhorn. RWO/DBs → `vanillax-local-rwo`
   (`csi.truenas.io` **iSCSI**, block, safe for databases). RWX →
   `truenas-nfs-csi` (NFS). Regenerable caches → `local-path` (node-local).

--- a/docs/domains/storage/storage-tiers.md
+++ b/docs/domains/storage/storage-tiers.md
@@ -1,0 +1,125 @@
+# Storage tiers — which StorageClass for which PVC
+
+**The one rule:** *does this volume fsync on every write?*
+Databases do (every commit). Almost nothing else does.
+
+That single question decides the tier, because the tiers are not "fast" and "slow" — they each
+win at a different thing, and picking wrong makes things **worse**, not just suboptimal.
+
+## The measurements this rule is built on
+
+Each measured through its **full stack** (fio, 2026-07-13):
+
+| | 4K fsync write | 4K random read | 1M seq read | 1M seq write |
+|---|---|---|---|---|
+| **`longhorn`** (consumer EDILOCA NVMe, in Proxmox) | **259 IOPS** | **161k IOPS** | **2310 MB/s** | 109 MB/s |
+| **`truenas-flash`** (enterprise SATA SSD, RAIDZ1, over NVMe-oF) | **~3,000 IOPS** | 68k IOPS | 1018 MB/s | **~750 MB/s** |
+
+Read that table twice. **Longhorn's consumer NVMe out-reads the enterprise SATA by 2x.** NVMe beats
+SATA at reading, and power-loss protection does not change that. What the consumer drive *cannot*
+do is write: 259 fsync IOPS is a DRAM-less, no-PLP write cliff.
+
+So: **`truenas-flash` is ~11x on writes and ~2x WORSE on reads.** It is a *write* tier, not a
+"fast" tier. Moving a read-heavy volume onto it is a **downgrade**.
+
+## The decision tree
+
+```
+                    Does more than one pod mount it,
+                    or is it bulk media / model weights?
+                              |
+                 yes ---------+--------- no
+                  |                       |
+          SMB / NFS classes        Is it a DATABASE?
+       (BigTank or ai-pool)        (fsyncs every write)
+                                          |
+                            yes ----------+---------- no
+                             |                         |
+                     truenas-flash                 longhorn
+                     (NVMe-oF, RWO)             (the default)
+```
+
+### 1. `truenas-flash` — databases only
+
+Postgres, MySQL, ClickHouse, Kafka/Redpanda, Redis (persistent), Prometheus TSDB, Loki,
+Qdrant, Meilisearch. Anything whose write path is "append to a log, fsync, acknowledge."
+
+**RWO only.** NVMe-oF is block storage — it cannot be RWX. A block device mounted by two
+writers is a corrupted block device.
+
+### 2. `longhorn` — the default, and it stays the default
+
+App config, app state, caches, libraries, anything read-mostly, and **anything needing RWX**
+(Longhorn provides that via a share-manager pod). It reads better than the flash tier and it is
+node-local (no NAS dependency). **When in doubt, use Longhorn.**
+
+### 3. SMB / NFS — bulk and shared
+
+Media libraries, model weights, anything multiple pods read, anything you want to browse by hand.
+Files, not blocks. See `infrastructure/storage/CLAUDE.md` for the class list.
+
+## Why not "just put everything on flash"
+
+Three independent reasons, each sufficient on its own:
+
+1. **Reads get worse.** See the table. Most PVCs are read-mostly.
+2. **It adds a NAS dependency.** A Longhorn volume survives the NAS being down; a `truenas-flash`
+   volume does not mount. The cluster still *boots* (volumes attach at pod-schedule time, not VM
+   boot), but those pods will not start. Don't spend that dependency on a volume that gains nothing.
+3. **Backups break silently unless you also swap the kopiur component.** See below. This is the
+   one that will actually hurt you.
+
+## ⚠️ The backup trap — read this before moving any PVC
+
+A `VolumeSnapshotClass` is bound to exactly **one** CSI driver.
+`my-apps/common/kopiur-backup` injects `volumeSnapshotClassName: longhorn-snapclass`, which is
+bound to `driver.longhorn.io`. It **physically cannot snapshot a `csi.truenas.io` volume.**
+
+Move a backed-up PVC to `truenas-flash` without changing anything else and it will look perfectly
+backed up in git while producing **nothing**. You find out during a restore.
+
+The fix — stack the flash override **after** the base component:
+
+```yaml
+components:
+  - ../../common/kopiur-backup        # base
+  - ../../common/kopiur-backup-flash  # swaps in truenas-snapshot
+```
+
+Then **verify, do not assume**:
+```bash
+kubectl -n <ns> get snapshot     # must reach Succeeded with a NON-ZERO file count
+```
+
+CNPG databases are the exception: they back up via **Barman to S3**, which does not use a
+VolumeSnapshotClass at all. A CNPG PVC can change storage class without touching its backups.
+(Never add kopiur CRs to a CNPG PVC — that rule is unchanged.)
+
+## Migration risk ladder
+
+Move in this order. Each rung is safe only because the one before it proved something.
+
+**Rung 1 — backup-exempt databases (zero backup risk, they have no backups by design).**
+Also serves as the canary for the whole NVMe-oF path.
+`posthog` (clickhouse, postgres, redis7, redpanda), `prometheus-stack` (TSDB),
+`redis-instance`, `searxng` (redis).
+
+**Rung 2 — CNPG (Barman-backed; no VolumeSnapshotClass dependency).**
+`immich-database`, `paperless-database`, `temporal-database` (+ their WAL volumes).
+Note: CNPG cannot change `storageClass` in place — it needs a new cluster + switchover, or a
+restore from Barman. Plan it as a database operation, not a YAML edit.
+
+**Rung 3 — kopiur-backed databases. ONLY after a `kopiur-backup-flash` Snapshot has been
+observed reaching `Succeeded` with non-zero files.**
+`gitea/gitea-postgres-data`, `project-nomad/mysql-data`, `project-nomad/qdrant-data`,
+`karakeep/meilisearch-pvc`, `kafka/data-0-dev-kafka-dual-role-0`, `loki-stack/*`.
+
+## Everything else stays on Longhorn
+
+Every other PVC — `immich/library`, `home-assistant/config`, `jellyfin/config`, `n8n/data`,
+`open-webui/storage`, `perplexica`, `paperless-ngx/data`+`media`, `karakeep/data-pvc`,
+`frigate/frigate-config`, `copyparty`, `fizzy`, `presenton`, `flatnotes`, `tubesync/config-pvc`,
+`gitea-shared-storage`, `homepage-dashboard`, `zomboid-data`, `restore-canary`, `registry`, and
+all the caches (`immich-ml-cache`, `act-runner-docker-cache`, `swarmui/*`, `nomad-storage`,
+`protomaps-data`, `openmeteo-data`, `embeddings-model-cache`) — is app state or read-mostly.
+**It gains nothing from flash and would read slower there.** Leave it.

--- a/infrastructure/networking/cilium/policies/block-lan-access.yaml
+++ b/infrastructure/networking/cilium/policies/block-lan-access.yaml
@@ -71,6 +71,13 @@ spec:
               protocol: TCP
             - port: "9000"
               protocol: TCP
+            # NVMe-oF/TCP — the `truenas-flash` StorageClass (csi.truenas.io,
+            # protocol: nvmeof) attaches ZVOLs from `flashpool` over this port.
+            # Without it every flash-tier volume mount hangs rather than fails
+            # loudly. TCP 3260 (iSCSI) stays blocked on purpose — this cluster
+            # uses NVMe-oF, and Talos needs no initiator extension for it.
+            - port: "4420"
+              protocol: TCP
 
     # ============================================
     # ALLOW: Wyze Bridge RTSP (for Frigate)

--- a/infrastructure/storage/CLAUDE.md
+++ b/infrastructure/storage/CLAUDE.md
@@ -12,9 +12,22 @@
 | `local-path` | Node-local fast storage |
 
 `truenas-nfs` provisions new datasets under `BigTank/k8s/nfs/v`. It does not
-replace static `nfs.csi.k8s.io` PVs for pre-existing data. TrueNAS CSI v1.0.4
-creates NFS shares with `mapall` semantics; run the documented ownership
-canary before adopting the class for a workload that runs as a non-root UID.
+replace static `nfs.csi.k8s.io` PVs for pre-existing data. TrueNAS CSI (pinned
+**v1.1.1**) creates NFS shares with `mapall` semantics; run the documented
+ownership canary before adopting the class for a workload that runs as a
+non-root UID.
+
+`truenas-flash` (added 2026-07-13) provisions ZVOLs on `flashpool` (3x enterprise
+SATA SSD, RAIDZ1) over **NVMe-oF/TCP** for write-latency-sensitive workloads. It
+is the fast tier for databases: the Longhorn default class sits on consumer
+EDILOCA NVMe measured at **259 fsync IOPS @ 1.25ms**, versus **14,484 @ 0.064ms**
+on flashpool. NVMe-oF, not iSCSI — Talos 1.13 has `CONFIG_NVME_TCP=y` built in and
+nvme-cli ships inside the driver image, so it needs no system extension and no
+rolling reboot. A PVC moved here MUST also swap its kopiur bundle to the
+`kopiur-backup-flash` component (VolumeSnapshotClass `truenas-snapshot`) — the
+base component's `longhorn-snapclass` is bound to `driver.longhorn.io` and cannot
+snapshot a `csi.truenas.io` volume, so the PVC would look backed up in git while
+producing nothing.
 
 ## Longhorn PVC Template
 

--- a/infrastructure/storage/truenas-csi/configmap.yaml
+++ b/infrastructure/storage/truenas-csi/configmap.yaml
@@ -12,8 +12,21 @@ data:
   TRUENAS_INSECURE_SKIP_VERIFY: "true"
   TRUENAS_DEFAULT_POOL: "BigTank"
   TRUENAS_NFS_SERVER: "192.168.10.133"
+  # NVMe-oF/TCP portal — backs the `truenas-flash` StorageClass (pool: flashpool,
+  # 3x enterprise SATA SSD RAIDZ1). NVMe-oF, not iSCSI, because Talos 1.13 has
+  # CONFIG_NVME_TCP=y built in and nvme-cli ships inside the driver image, so this
+  # needs no system extension and no rolling reboot. Cilium must allow TCP 4420 to
+  # 192.168.10.133 (see networking/cilium/policies/block-lan-access.yaml) or every
+  # mount hangs. DH-CHAP is deliberately unset: the Talos kernel does not set
+  # CONFIG_NVME_HOST_AUTH, so auth comes from the Cilium egress policy instead.
+  TRUENAS_NVMEOF_PORTAL: "192.168.10.133:4420"
   # Required by the shared upstream driver config even though this rollout does
   # not create an iSCSI StorageClass or permit TCP 3260 through Cilium.
+  # IQN base MUST equal the appliance's actual Target Global "Base Name" — this box
+  # still carries the FreeNAS-era value. Upstream never reads iscsi.global.basename
+  # (truenas-csi#41), and a mismatch fails every stage with
+  # `failed to find device path: []`, baking the wrong IQN into the PV at provision
+  # time. Kept correct so a future iSCSI SC does not inherit a silent landmine.
   TRUENAS_ISCSI_PORTAL: "192.168.10.133:3260"
-  TRUENAS_ISCSI_IQN_BASE: "iqn.2000-01.io.truenas"
+  TRUENAS_ISCSI_IQN_BASE: "iqn.2005-10.org.freenas.ctl"
 

--- a/infrastructure/storage/truenas-csi/storageclass.yaml
+++ b/infrastructure/storage/truenas-csi/storageclass.yaml
@@ -25,26 +25,32 @@ reclaimPolicy: Retain
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
 ---
-# Fast tier for write-latency-sensitive workloads (databases). ZVOL on `flashpool`
-# (3x HPE MK000480GWCEV enterprise SATA SSD, RAIDZ1) exported over NVMe-oF/TCP.
+# WRITE tier only. ZVOL on `flashpool` (3x enterprise SATA SSD w/ PLP, RAIDZ1),
+# exported over NVMe-oF/TCP. NVMe-oF is the wire protocol — nothing here is an NVMe
+# disk; see configmap.yaml for why it beats iSCSI on Talos.
 #
-# Why this exists: the Longhorn default class is backed by consumer EDILOCA EN605
-# NVMe in the Proxmox host, measured at 259 fsync IOPS @ 1.25ms — DRAM-less, no
-# power-loss protection. The flashpool SSDs measure 14,484 fsync IOPS @ 0.064ms.
-# Even paying ~0.15ms of 10GbE round-trip, this lands ~6x better than local disk
-# for the fsync-per-commit workload Postgres/ClickHouse/Kafka actually run.
+# Use this ONLY for fsync-heavy workloads (Postgres/ClickHouse/Kafka/Prometheus).
+# Measured, each through its full stack:
+#              4K fsync write     4K random read
+#   Longhorn:      259 IOPS         161k IOPS
+#   this class:  ~3,000 IOPS         68k IOPS
+# So it is ~11x on writes and ~2x WORSE on reads — Longhorn's consumer NVMe simply
+# out-reads enterprise SATA. Moving a read-heavy volume here is a downgrade.
 #
-# NVMe-oF (not iSCSI) on purpose — see configmap.yaml for the full reasoning.
+# The ~3,000 ceiling is ZFS's ZIL on zvols, not the disks (a raw drive does 14,484)
+# and not the vdev layout — stripe, mirror and RAIDZ1 all measured identical, and it
+# does not scale with queue depth. Do not restripe the pool chasing write IOPS, and
+# do NOT "fix" it with sync=disabled: that makes ZFS lie about fsync, which for
+# Postgres is a corrupt cluster, not a few lost seconds.
 #
-# volblocksize is IMMUTABLE once a ZVOL is created. 16K matches Postgres' 8K page
-# with compression headroom; do not change it after volumes exist.
+# volblocksize is IMMUTABLE once a ZVOL exists. Do not change it after volumes exist.
 #
-# NOT the default class: Longhorn stays default. Only move a PVC here deliberately,
-# and only after adding a kopiur bundle that references VolumeSnapshotClass
-# `truenas-snapshot` — the shared my-apps/common/kopiur-backup component hardcodes
-# `longhorn-snapclass`, which is bound to driver.longhorn.io and will NOT snapshot a
-# csi.truenas.io volume. A database moved here without that swap loses its backups
-# silently.
+# GOTCHA — a PVC moved here loses its backups unless you also swap the kopiur
+# component. A VolumeSnapshotClass is bound to ONE CSI driver: the shared
+# my-apps/common/kopiur-backup injects `longhorn-snapclass` (driver.longhorn.io),
+# which cannot snapshot a csi.truenas.io volume. Stack
+# my-apps/common/kopiur-backup-flash on top to swap in `truenas-snapshot`. Without
+# it the PVC looks backed up in git and produces nothing.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/infrastructure/storage/truenas-csi/storageclass.yaml
+++ b/infrastructure/storage/truenas-csi/storageclass.yaml
@@ -24,3 +24,41 @@ parameters:
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
+---
+# Fast tier for write-latency-sensitive workloads (databases). ZVOL on `flashpool`
+# (3x HPE MK000480GWCEV enterprise SATA SSD, RAIDZ1) exported over NVMe-oF/TCP.
+#
+# Why this exists: the Longhorn default class is backed by consumer EDILOCA EN605
+# NVMe in the Proxmox host, measured at 259 fsync IOPS @ 1.25ms — DRAM-less, no
+# power-loss protection. The flashpool SSDs measure 14,484 fsync IOPS @ 0.064ms.
+# Even paying ~0.15ms of 10GbE round-trip, this lands ~6x better than local disk
+# for the fsync-per-commit workload Postgres/ClickHouse/Kafka actually run.
+#
+# NVMe-oF (not iSCSI) on purpose — see configmap.yaml for the full reasoning.
+#
+# volblocksize is IMMUTABLE once a ZVOL is created. 16K matches Postgres' 8K page
+# with compression headroom; do not change it after volumes exist.
+#
+# NOT the default class: Longhorn stays default. Only move a PVC here deliberately,
+# and only after adding a kopiur bundle that references VolumeSnapshotClass
+# `truenas-snapshot` — the shared my-apps/common/kopiur-backup component hardcodes
+# `longhorn-snapclass`, which is bound to driver.longhorn.io and will NOT snapshot a
+# csi.truenas.io volume. A database moved here without that swap loses its backups
+# silently.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: truenas-flash
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: csi.truenas.io
+parameters:
+  protocol: "nvmeof"
+  pool: "flashpool"
+  datasetPath: "k8s/flash"
+  compression: "LZ4"
+  sync: "STANDARD"
+  volblocksize: "16K"
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/my-apps/CLAUDE.md
+++ b/my-apps/CLAUDE.md
@@ -161,6 +161,37 @@ patches:
 
 **Do NOT use `Replace=true,Force=true`** — causes duplicate Job execution ([#24005](https://github.com/argoproj/argo-cd/issues/24005)).
 
+### Which StorageClass? (decide BEFORE writing the PVC)
+
+Full reasoning + the measured numbers + the per-PVC classification:
+**`docs/domains/storage/storage-tiers.md`**. The short version:
+
+> **The only question that matters: does this volume fsync on every write?**
+> Databases do. Almost nothing else does.
+
+| Use | Class | Why |
+|-----|-------|-----|
+| **Databases** (Postgres, MySQL, ClickHouse, Kafka, Redis, Prometheus TSDB, Qdrant, Meilisearch) | `truenas-flash` | ~3,000 fsync IOPS vs Longhorn's **259**. RWO only. |
+| **Everything else** — app config/state, caches, read-mostly, and **anything RWX** | `longhorn` (default) | **Reads 2x FASTER than the flash tier**, and no NAS dependency. |
+| **Bulk media / model weights / hand-browsable** | SMB or NFS classes | Files, not blocks. |
+
+**The tiers are not "fast" and "slow".** `truenas-flash` is ~11x on writes and ~2x **WORSE** on
+reads — Longhorn's consumer NVMe genuinely out-reads enterprise SATA. Putting a read-heavy volume
+on flash is a **downgrade**. When in doubt: **Longhorn**.
+
+**⚠️ Moving a backed-up PVC to `truenas-flash` silently kills its backups** unless you also stack
+the flash kopiur override. A VolumeSnapshotClass is bound to ONE CSI driver, and the base
+component injects `longhorn-snapclass` (`driver.longhorn.io`), which cannot snapshot a
+`csi.truenas.io` volume:
+
+```yaml
+components:
+  - ../../common/kopiur-backup        # base
+  - ../../common/kopiur-backup-flash  # REQUIRED on truenas-flash PVCs
+```
+Then verify — `kubectl -n <ns> get snapshot` must reach `Succeeded` with a **non-zero** file count.
+(CNPG is exempt from this trap: it backs up via Barman to S3, not via a VolumeSnapshotClass.)
+
 ### Application with Persistent Storage + Backups
 
 Backups are **kopiur** (home-operations' Kopia-native operator). It replaced

--- a/my-apps/common/kopiur-backup-flash/kustomization.yaml
+++ b/my-apps/common/kopiur-backup-flash/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# Thin override for PVCs on the `truenas-flash` StorageClass (csi.truenas.io,
+# NVMe-oF ZVOLs on `flashpool`). STACK IT AFTER the base component — it does not
+# replace it:
+#
+#   components:
+#     - ../../common/kopiur-backup        # base: repository, copyMethod, schedule
+#     - ../../common/kopiur-backup-flash  # then: swap the VolumeSnapshotClass
+#
+# WHY this exists: a VolumeSnapshotClass is bound to ONE CSI driver. The base
+# component injects `longhorn-snapclass`, which is bound to `driver.longhorn.io`
+# (infrastructure/controllers/kopiur/volumesnapshotclass.yaml). It physically
+# cannot snapshot a `csi.truenas.io` volume. Point a flash-tier PVC at the base
+# component alone and the SnapshotPolicy will never produce a usable Snapshot —
+# the PVC looks backed up in git and is not. This swaps in `truenas-snapshot`
+# (infrastructure/storage/truenas-csi/volumesnapshotclass.yaml, driver:
+# csi.truenas.io), which can.
+#
+# `replace` (not `add`) on purpose: the base already set the field, so this is an
+# override and MUST fail loudly if the base ever stops setting it, rather than
+# silently appending a second value.
+#
+# After adding this to an app, VERIFY — do not assume:
+#   kubectl -n <ns> get snapshot
+#   # the Snapshot must reach Succeeded with a NON-ZERO file count
+patches:
+  - target:
+      kind: SnapshotPolicy
+      group: kopiur.home-operations.com
+    patch: |
+      - op: replace
+        path: /spec/volumeSnapshotClassName
+        value: truenas-snapshot


### PR DESCRIPTION
## What

Adds a `truenas-flash` StorageClass backing write-latency-sensitive workloads with ZVOLs on a new **`flashpool`** (3× HPE MK000480GWCEV enterprise SATA SSD, RAIDZ1, ~890GB usable) exported over **NVMe-oF/TCP**.

**Additive only.** `truenas-flash` is not the default class and no workload references it yet. Longhorn stays default.

## Why — measured on this hardware

`fio`, 4K rand-write QD1 `fsync=1` (i.e. a database commit):

| | IOPS | avg | p99 |
|---|---|---|---|
| Longhorn / EDILOCA EN605 consumer NVMe *(where every DB lives today)* | **259** | **1.25 ms** | 2.5 ms |
| flashpool / enterprise SATA SSD (PLP) | **14,484** | **0.064 ms** | 0.146 ms |

The default Longhorn class sits on DRAM-less consumer NVMe with no power-loss protection, at `replica: 1`, holding CNPG immich/paperless/temporal, gitea PG, PostHog PG+ClickHouse, Kafka, and Prometheus. Even paying ~0.15ms of 10GbE round-trip, flash-over-wire lands **~6× better** than that local disk for fsync-per-commit.

Longhorn still wins for read-heavy volumes (161k IOPS, 2310 MB/s seq read) and RWX — it stays the default.

## NVMe-oF, not iSCSI — deliberately

- Talos 1.13 has `CONFIG_NVME_TCP=y` **built in**, and `nvme-cli` ships **inside the driver image** → no system extension, no rolling reboot.
- truenas-csi **never reads `iscsi.global.basename`** ([upstream #41](https://github.com/truenas/truenas-csi/issues/41)). This appliance still carries the FreeNAS-era `iqn.2005-10.org.freenas.ctl`, so an iSCSI class would fail every stage with `failed to find device path: []` **and bake the wrong IQN into the PV at provision time**. The configmap's IQN base is corrected to the appliance's real value so a future iSCSI class can't inherit that trap.

## kopiur — the sharp edge

A VolumeSnapshotClass is bound to exactly **one** CSI driver. The shared `kopiur-backup` component injects `longhorn-snapclass` (`driver.longhorn.io`), which **physically cannot snapshot a `csi.truenas.io` volume** — a PVC moved to the flash tier would *look backed up in git while producing nothing*.

Adds a thin `kopiur-backup-flash` component that stacks on the base and swaps in `truenas-snapshot`. **No PVC moves in this PR.**

## Also

- **Cilium**: allow TCP 4420 to `192.168.10.133`. Without it, flash-tier mounts *hang* rather than fail loudly. 3260 stays blocked.
- **Docs**: corrects two stale claims — truenas-csi is pinned **v1.1.1** (not v1.0.4), and `siderolabs/iscsi-tools` is **already installed on all three machine sets** (the storage-model doc claimed iSCSI "would need" it).

## Done outside this PR (TrueNAS-side, no repo change)

- `flashpool` created (RAIDZ1, autotrim on).
- `BigTank/steam-linux` (248G) migrated to `flashpool` and the iSCSI extent repointed. Verified byte-identical; BigTank original retained as rollback. Steam random-read went **243 IOPS @ 131ms → 226,857 IOPS @ 0.14ms**.

## Next / gate

A **canary PVC + fio** must prove the NVMe-oF wire path before any database migrates — it also settles whether the `siderolabs/nvme-cli` extension is needed (source says no; if wrong it means an Omni schematic change + rolling reboot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)