### PR TITLE
feat(radar-ng): move tiles/grids/state off HDD-NFS to longhorn-flash SSD

### DIFF
--- a/docs/domains/storage/storage-tiers.md
+++ b/docs/domains/storage/storage-tiers.md
@@ -21,6 +21,30 @@ distinct classes, and you choose per volume:
 - **shared (RWX) → NFS/SMB.** Neither local block tier can be RWX safely.
 - **when in doubt → `longhorn` default.**
 
+## The rule that matters most in practice: get small-block RANDOM IO off the HDD
+
+The biggest real-world storage win here is **not** flash-vs-NVMe (that difference is marginal, and
+Longhorn caps fsync ~200 IOPS on both — see below). It is **HDD-NFS → local SSD** for the right
+workload:
+
+- **Small-block RANDOM IO on HDD-backed NFS (`truenas-nfs` / SMB on BigTank) is catastrophic** —
+  measured **102 IOPS @ 310ms** on BigTank. A workload that reads/writes many small files with
+  random access (a tile renderer, a search index, a small database) will *thrash* there.
+- The same workload on **local SSD is thousands of IOPS at sub-ms** — a 20–100× win, from *either*
+  local tier. Use `longhorn-flash` for it specifically, so the thrashing lands on the separate SSD
+  spindle and stays **off** the shared NVMe disk the databases use.
+- **Large SEQUENTIAL IO on HDD-NFS is fine** — jellyfin, frigate, tubearchivist, kiwix stream large
+  media files, and HDDs do sequential throughput well (~160+ MB/s). Leave them on SMB/NFS.
+
+So the question isn't "which apps deserve flash" — it's **"which apps do small-block random IO and
+are currently on HDD-NFS."** First mover: **radar-ng** (`tiles`/`grids`/`state`), moved from
+`truenas-nfs` (HDD) to `longhorn-flash` (SSD, RWO) on 2026-07-15. It was the textbook case — a tile
+renderer thrashing thousands of small PNG/MVT files on 102-IOPS spinning disk over NFS.
+
+RWX→RWO note: those PVCs were RWX only for multiple writer pods. Kubernetes RWO is per-*node*, so on
+a single-node cluster co-located pods share one RWO volume (the proven `openmeteo-data` pattern).
+Before going multi-node, pin the consumers with podAffinity or move back to a real RWX class.
+
 ## Do not put fsync-sensitive storage behind the network
 
 Below the tier table is the record of a network-attached flash tier that was **built,

--- a/my-apps/development/radar-ng/pvcs.yaml
+++ b/my-apps/development/radar-ng/pvcs.yaml
@@ -1,16 +1,28 @@
-# Shared RWX PVCs for the radar-ng backend, on the truenas-csi NFS class.
+# radar-ng backend PVCs.
 #
-# Access-mode rationale:
-#   - tiles/grids/state are written by multiple pods (ingestors, nowcast) and
-#     read by tile-server, so RWX.
-#   - openmeteo-data is written by the serve Deployment and its sync CronJobs,
-#     which can run concurrently with serve, so RWX.
+# tiles/grids/state moved off `truenas-nfs` (BigTank = spinning HDD, RWX) onto
+# `longhorn-flash` (enterprise SATA SSD, RWO) on 2026-07-15. This is a SMALL-BLOCK
+# RANDOM-IO workload — the tile renderer reads MRMS grids and writes thousands of
+# small PNG/MVT tiles — and on HDD-backed NFS it thrashed: measured 102 IOPS @
+# 310ms on BigTank. On local SSD that is thousands of IOPS at sub-ms latency, and
+# putting it on the separate `flash` spindle keeps that thrashing OFF the shared
+# NVMe disk the databases live on. (Large SEQUENTIAL media — jellyfin, frigate —
+# stays on HDD-NFS; HDD is fine for streaming. Small-block RANDOM is the thing HDD
+# is terrible at, and that is radar-ng.)
 #
-# Moved off Longhorn RWX (which spins up an NFS share-manager pod per volume)
-# to the centralized truenas-csi `truenas-nfs` class — real NFS RWX, no
-# share-manager pods, TrueNAS-side snapshots. These volumes hold backup-exempt
-# rebuildable data, so the storageClassName change (immutable on a bound PVC)
-# is applied by deleting + recreating the PVCs; the data regenerates.
+# RWX -> RWO: these were RWX only to allow multiple writer pods. Kubernetes RWO is
+# "once per NODE" (not per pod), so on this single-node cluster all radar-ng pods
+# (workers + tile-server + temporal-worker) share one RWO volume fine — the exact
+# pattern openmeteo-data below already proves in production. RWO ext4 is also
+# faster than any NFS/share-manager path and sidesteps the errno-95 O_TMPFILE class
+# of NFS bugs (see openmeteo-data).
+#   MULTI-NODE CAVEAT: RWO-shared-by-many-pods only holds while they co-locate on
+#   one node. Before adding worker nodes, pin radar-ng workers + tile-server +
+#   temporal-worker together with podAffinity (as open-meteo already does), or move
+#   these back to a real RWX class.
+#
+# All three hold backup-exempt REBUILDABLE data, so the immutable storageClass/
+# accessMode change is applied by delete+recreate of the PVCs; tiles regenerate.
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -22,8 +34,8 @@ metadata:
   annotations:
     storage.vanillax.dev/backup-exempt-reason: "PNG/MVT tiles generated from grids/; rebuildable by re-running tile generation"
 spec:
-  accessModes: [ReadWriteMany]
-  storageClassName: truenas-nfs
+  accessModes: [ReadWriteOnce]
+  storageClassName: longhorn-flash
   resources:
     requests:
       storage: 100Gi
@@ -38,8 +50,8 @@ metadata:
   annotations:
     storage.vanillax.dev/backup-exempt-reason: "MRMS NetCDF grids; re-fetchable from upstream MRMS within retention window"
 spec:
-  accessModes: [ReadWriteMany]
-  storageClassName: truenas-nfs
+  accessModes: [ReadWriteOnce]
+  storageClassName: longhorn-flash
   resources:
     requests:
       storage: 20Gi
@@ -54,8 +66,8 @@ metadata:
   annotations:
     storage.vanillax.dev/backup-exempt-reason: "Transient ingestion state (last-seen timestamps, partial frames); regenerates on next pull"
 spec:
-  accessModes: [ReadWriteMany]
-  storageClassName: truenas-nfs
+  accessModes: [ReadWriteOnce]
+  storageClassName: longhorn-flash
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
radar-ng's tile renderer does **small-block random IO** — reads MRMS grids, writes thousands of small PNG/MVT tiles. Its `tiles`/`grids`/`state` PVCs sat on `truenas-nfs` = **BigTank spinning HDD**, measured this session at **102 IOPS @ 310ms**. That's the random small-block thrashing that degraded the app. On local SSD it's thousands of IOPS at sub-ms.

Moves those three to **`longhorn-flash`** (enterprise SATA SSD, #1612).

## Why this is the right call (and the reframe)

Not flash-vs-NVMe — that's marginal, and Longhorn caps fsync ~200 IOPS on both. The win is **HDD → SSD** (20–100× for this workload), plus putting the thrashing on the **separate `flash` spindle** so it stays off the shared NVMe disk the databases use.

The real rule this surfaced (now in `storage-tiers.md`): *the biggest storage win is small-block **random** IO off HDD-NFS onto local SSD — not which apps "deserve flash."* Large **sequential** media (jellyfin, frigate, tubearchivist) stays on HDD-NFS; HDD does sequential fine.

## RWX → RWO

These were RWX only for multiple writer pods. Kubernetes RWO is **per-node**, so on this single-node cluster all consumers (workers + tile-server + temporal-worker) share one RWO volume — the exact pattern **`openmeteo-data` already runs in production**. RWO ext4 is faster than any NFS path and sidesteps the `errno 95 / O_TMPFILE` NFS bug class.

**Multi-node caveat** (documented in the PVC + doc): RWO-shared-by-many-pods only holds while consumers co-locate on one node. Before adding worker nodes, pin them with podAffinity or move back to a real RWX class.

## Scope / left alone
- `pmtiles` — read-mostly mmap, documented RWO-hostile (Multi-Attach vs the 24/7 basemap Deployment) → stays `truenas-nfs` RWX.
- `openmeteo-data` — already `longhorn` RWO SSD, works → unchanged.

## Migration
Data is `backup-exempt` and **rebuildable**, so the immutable storageClass/accessMode change is applied by **delete + recreate** of the PVCs (the procedure the existing comments already describe). Tiles regenerate on the new SSD volumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)