### PR TITLE
feat(radar-ng): pmtiles → longhorn-flash SSD (completes random-IO migration)

### DIFF
--- a/my-apps/development/radar-ng/pvcs.yaml
+++ b/my-apps/development/radar-ng/pvcs.yaml
@@ -108,18 +108,24 @@ metadata:
   annotations:
     storage.vanillax.dev/backup-exempt-reason: "Protomaps basemap extract; rebuildable by re-running basemap-bootstrap Job from a build.protomaps.com daily build"
 spec:
-  # RWX (was RWO). The RWO assumption "Bootstrap Job + Deployment run
-  # one-at-a-time" was false in practice: the basemap Deployment runs 24/7
-  # holding the RWO volume, so basemap-bootstrap could NEVER attach while
-  # basemap was up -> permanent Multi-Attach error, Job stuck 10h+.
-  # go-pmtiles is distroless (no shell) so an idempotent single
-  # initContainer isn't possible without a custom image; RWX lets the
-  # one-shot, stable-named bootstrap Job and the reader Deployment coexist
-  # (Job writes once then Completes; basemap mmap-reads). Now served by
-  # truenas-csi NFS RWX (no Longhorn share-manager pod) — TrueNAS exports the
-  # dataset directly.
-  accessModes: [ReadWriteMany]
-  storageClassName: truenas-nfs
+  # RWO on longhorn-flash (was RWX on truenas-nfs HDD). basemap mmap-reads this
+  # protomaps extract for map tile serving — small-block RANDOM reads, which on
+  # spinning HDD-over-NFS (102 IOPS @ 310ms) is exactly the thrash that hurt
+  # radar-ng. On the enterprise-SSD flash spindle it is thousands of IOPS at
+  # sub-ms, and off the shared NVMe disk the databases use.
+  #
+  # The old "RWO = permanent Multi-Attach" concern (basemap 24/7 reader vs the
+  # one-shot basemap-bootstrap writer Job) was Longhorn RWO behaving as single-POD
+  # attach. Current Longhorn does RWO multi-pod-same-NODE — proven in this same
+  # namespace: tiles/grids/state now run RWO with 4 co-located pods sharing them.
+  # basemap + the bootstrap Job co-locate on the single worker node, so both
+  # attach fine. (Multi-node caveat as with tiles: pin them together with
+  # podAffinity, or use a real RWX class, before adding worker nodes.)
+  #
+  # Rebuildable: after this PVC is recreated empty, re-run the basemap-bootstrap
+  # Job to re-download the extract from build.protomaps.com.
+  accessModes: [ReadWriteOnce]
+  storageClassName: longhorn-flash
   resources:
     requests:
       storage: 50Gi


### PR DESCRIPTION
Completes the radar-ng random-IO story (#1613 moved tiles/grids/state). `pmtiles` is the protomaps basemap extract that **basemap mmap-reads** for map tile serving — small-block **random reads**, catastrophic on the BigTank HDD over NFS (**102 IOPS @ 310ms**). Moves it to `longhorn-flash` (enterprise SSD): thousands of IOPS at sub-ms, and off the shared NVMe DB disk.

## RWX → RWO is now viable

The old comment said RWO caused "permanent Multi-Attach" (basemap 24/7 reader vs the one-shot bootstrap Job writer). That was Longhorn RWO acting as single-**pod** attach. **Current Longhorn does RWO multi-pod-same-node — proven in this same namespace** by #1613 (tiles/grids/state run RWO with 4 co-located pods sharing them). On the single node, basemap + bootstrap Job co-locate and both attach.

**Multi-node caveat** (same as tiles): pin consumers with podAffinity or use a real RWX class before adding worker nodes.

## Migration
Backup-exempt / rebuildable. Applied by delete+recreate; after the empty PVC binds, **re-run the basemap-bootstrap Job** to re-download the extract from build.protomaps.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)