### PR TITLE
feat(storage): PostHog + monitoring → longhorn-flash (IO isolation)

### DIFF
--- a/docs/domains/storage/storage-tiers.md
+++ b/docs/domains/storage/storage-tiers.md
@@ -37,9 +37,24 @@ workload:
   media files, and HDDs do sequential throughput well (~160+ MB/s). Leave them on SMB/NFS.
 
 So the question isn't "which apps deserve flash" — it's **"which apps do small-block random IO and
-are currently on HDD-NFS."** First mover: **radar-ng** (`tiles`/`grids`/`state`), moved from
-`truenas-nfs` (HDD) to `longhorn-flash` (SSD, RWO) on 2026-07-15. It was the textbook case — a tile
-renderer thrashing thousands of small PNG/MVT files on 102-IOPS spinning disk over NFS.
+are currently on HDD-NFS."** First mover: **radar-ng** (`tiles`/`grids`/`state`/`pmtiles`), moved
+from `truenas-nfs` (HDD) to `longhorn-flash` (SSD, RWO) on 2026-07-15. It was the textbook case — a
+tile renderer thrashing thousands of small PNG/MVT files on 102-IOPS spinning disk over NFS.
+
+### The second use of `longhorn-flash`: IO isolation for noisy write-heavy apps
+
+`longhorn-flash` is also a *separate physical spindle*, so it doubles as an isolation lane. Apps
+that are **write-heavy but read-tolerant** — metrics, logs, disposable analytics — are moved here
+NOT because flash is faster (through Longhorn it isn't; ~200 fsync either way, and SATA reads
+slower), but so their heavy IO stops contending with the latency-sensitive databases on the shared
+NVMe disk. Moved 2026-07-15: **all of PostHog** (clickhouse/postgres/redis/kafka — disposable
+product analytics) and **all of monitoring** (Prometheus TSDB, Alertmanager, Grafana, Loki
+write/backend). All backup-exempt; their history is disposable (Loki/Tempo data lives on S3/RustFS
+anyway), so the migration is a clean delete+recreate.
+
+Net effect: the shared NVMe disk (`longhorn` default) is left for the databases and latency-
+sensitive volumes; the flash spindle absorbs the noisy random/write-heavy IO. Two disks, workloads
+split by profile.
 
 RWX→RWO note: those PVCs were RWX only for multiple writer pods. Kubernetes RWO is per-*node*, so on
 a single-node cluster co-located pods share one RWO volume (the proven `openmeteo-data` pattern).

--- a/monitoring/loki-stack/values.yaml
+++ b/monitoring/loki-stack/values.yaml
@@ -61,6 +61,11 @@ loki:
 deploymentMode: SimpleScalable
 backend:
   replicas: 1
+  # Local write-path state (WAL / boltdb-shipper cache) on the flash isolation
+  # tier — Loki's actual log data lives on S3 (RustFS). Keeps log-ingest IO off
+  # the shared NVMe disk the databases use. Backup-exempt; rebuilds from S3.
+  persistence:
+    storageClass: longhorn-flash
   resources:
     requests:
       cpu: 50m
@@ -85,6 +90,9 @@ read:
       name: loki-s3-credentials
 write:
   replicas: 1
+  # Local write-path state on the flash isolation tier (log data is on S3/RustFS).
+  persistence:
+    storageClass: longhorn-flash
   resources:
     requests:
       cpu: 50m

--- a/monitoring/prometheus-stack/values.yaml
+++ b/monitoring/prometheus-stack/values.yaml
@@ -32,7 +32,7 @@ prometheus:
           annotations:
             storage.vanillax.dev/backup-exempt-reason: "Prometheus metrics are re-scrapeable; monitoring data not worth backup pipeline overhead"
         spec:
-          storageClassName: longhorn
+          storageClassName: longhorn-flash
           accessModes:
             - ReadWriteOnce
           resources:
@@ -169,7 +169,7 @@ alertmanager:
           annotations:
             storage.vanillax.dev/backup-exempt-reason: "Alertmanager silences are operator-set; trivially recreated"
         spec:
-          storageClassName: longhorn
+          storageClassName: longhorn-flash
           accessModes:
             - ReadWriteOnce
           resources:
@@ -205,7 +205,7 @@ grafana:
   # Persistence
   persistence:
     enabled: true
-    storageClassName: longhorn
+    storageClassName: longhorn-flash
     size: 10Gi
     accessModes:
       - ReadWriteOnce

--- a/my-apps/development/posthog/data-layer/clickhouse.yaml
+++ b/my-apps/development/posthog/data-layer/clickhouse.yaml
@@ -18,7 +18,7 @@ metadata:
     storage.vanillax.dev/backup-exempt-reason: "regenerable from PostHog ingest; 100Gi too large for current Kopia/RustFS S3 path"
 spec:
   accessModes: ["ReadWriteOnce"]
-  storageClassName: longhorn
+  storageClassName: longhorn-flash
   resources:
     requests:
       # Shrunk 100Gi -> 40Gi for the single-node 2950X rebuild (2026-06-19).

--- a/my-apps/development/posthog/data-layer/kafka.yaml
+++ b/my-apps/development/posthog/data-layer/kafka.yaml
@@ -14,7 +14,7 @@ metadata:
     storage.vanillax.dev/backup-exempt-reason: "PostHog data is disposable/rebuildable in this homelab; do not back up. Redpanda runs --unsafe-bypass-fsync with ~1h retention + auto_create_topics — log is ephemeral/rebuildable."
 spec:
   accessModes: ["ReadWriteOnce"]
-  storageClassName: longhorn
+  storageClassName: longhorn-flash
   resources:
     requests:
       # Shrunk 20Gi -> 8Gi for the single-node rebuild (2026-06-19). Redpanda

--- a/my-apps/development/posthog/data-layer/postgres.yaml
+++ b/my-apps/development/posthog/data-layer/postgres.yaml
@@ -102,7 +102,7 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
-  storageClassName: longhorn
+  storageClassName: longhorn-flash
   resources:
     requests:
       # Shrunk 20Gi -> 8Gi for the single-node rebuild (2026-06-19). PostHog's

--- a/my-apps/development/posthog/data-layer/redis.yaml
+++ b/my-apps/development/posthog/data-layer/redis.yaml
@@ -82,7 +82,7 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
-  storageClassName: longhorn
+  storageClassName: longhorn-flash
   resources:
     requests:
       # Shrunk 10Gi -> 4Gi for the single-node rebuild (2026-06-19). Valkey cache


### PR DESCRIPTION
Moves **all of PostHog** (clickhouse/postgres/redis/kafka) and **all of monitoring** (Prometheus TSDB, Alertmanager, Grafana, Loki write/backend) from `longhorn` (shared NVMe) to `longhorn-flash` (enterprise SATA SSD, separate spindle).

## Why — isolation, not speed

Through Longhorn both disks cap fsync ~200 IOPS, and SATA reads slower than NVMe. So this is **not** a speed play — it's **IO isolation**. These are the cluster's heaviest **write-heavy / read-tolerant** workloads (metrics compaction, log ingest, ClickHouse merges, Kafka appends). Getting them off the shared NVMe disk leaves it for the **latency-sensitive databases** (CNPG immich/paperless/temporal) — cutting the IO contention that shows up as DB commit **tail latency**.

Two disks, split by profile:
- `longhorn` (NVMe) → latency-sensitive DBs + fast reads
- `longhorn-flash` (SSD spindle) → noisy random/write-heavy (radar-ng + this)

## Safe because disposable

All backup-exempt: PostHog is product analytics; Prometheus metrics re-scrape; **Loki/Tempo actual data lives on S3/RustFS** (these PVCs are just local write-path state). Migration is delete+recreate (StatefulSet `volumeClaimTemplate.storageClassName` is immutable) — history loss acceptable by design.

Tempo unchanged (no PVC, S3-direct).

## Capacity
Flash disk 322G @ 600% over-provisioning (~1.9TB schedulable); these ~195G of requests fit easily alongside radar-ng.

## Post-merge execution (delete+recreate)
For each StatefulSet: delete the STS + its PVCs so ArgoCD recreates on `longhorn-flash`. Data regenerates / re-ingests from S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)