### PR TITLE
fix(radar-ng): add fsGroup 1000 for longhorn-flash RWO volumes (P0 regression fix)

### DIFF
--- a/my-apps/development/radar-ng/deployment-tile-server.yaml
+++ b/my-apps/development/radar-ng/deployment-tile-server.yaml
@@ -52,6 +52,11 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+        # fsGroup for the longhorn-flash RWO tiles/grids/state volumes (see
+        # temporal-worker-deployment.yaml) — non-root pods need it to read the
+        # group-owned files the worker writes.
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/my-apps/development/radar-ng/temporal-worker-deployment.yaml
+++ b/my-apps/development/radar-ng/temporal-worker-deployment.yaml
@@ -47,6 +47,13 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+        # fsGroup REQUIRED: tiles/grids/state moved to longhorn-flash RWO (ext4)
+        # on 2026-07-15. Fresh Longhorn block volumes mount root:root, so a
+        # non-root (uid 1000) worker cannot write — unlike the previous
+        # truenas-nfs class, which mapped all access to root and masked this.
+        # fsGroup makes the kubelet chown the volume group-writable to gid 1000.
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
**P0 regression fix for #1613.** Moving `tiles`/`grids`/`state` from `truenas-nfs` to `longhorn-flash` changed them from NFS (`mapAllUser: root` — all access ran as root, writes always worked) to Longhorn RWO ext4 (**fresh volumes mount `root:root`**). The worker runs `runAsUser 1000 / runAsGroup 1000` with **no fsGroup**, so it could not write — live volumes were `drwxr-xr-x root:root`, every tile/grid/state write got `EACCES`, and **radar-ng tile generation was silently broken**.

Verified on the live cluster:
```
/data/tiles: drwxr-xr-x root root  →  touch: Permission denied  →  WRITE FAILED
```

## Fix
Adds `fsGroup: 1000` (+ `fsGroupChangePolicy: OnRootMismatch`) to the worker WorkerDeployment pod template and the tile-server Deployment. fsGroup makes the kubelet chown the volume group-writable to gid 1000 on mount → the non-root worker writes, the read-only tile-server reads.

## Immediate remediation already applied
The live volumes were chowned to `1000:1000` out-of-band to restore writes **now** (verified: worker WRITE OK on all three). This PR makes it **durable** across any future PVC recreation / pod roll.

## Note for the other in-flight PRs
The same fsGroup gap applies to **any Longhorn RWO volume mounted by a non-root pod**. #1622 (pmtiles → RWO) and #1623 (PostHog/monitoring → flash) will need the same treatment on their consumers before/at migration — I'll handle that at execution time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)