### PR TITLE
fix(posthog): run manage.py migrate before the schema guard (fixes empty-DB bootstrap)

### DIFF
--- a/my-apps/development/posthog/core/jobs.yaml
+++ b/my-apps/development/posthog/core/jobs.yaml
@@ -104,6 +104,16 @@ spec:
           echo "ClickHouse ready"
           echo "Flushing ClickHouse system logs..."
           wget -q -O- "http://clickhouse:8123/?query=SYSTEM+FLUSH+LOGS" 2>/dev/null || true
+          echo "Running Django migrations..."
+          python manage.py migrate --noinput
+          # Self-hosted schema guard MUST run AFTER manage.py migrate. On a fresh
+          # empty DB, public.posthog_person does not exist until migrate creates
+          # it, so an ALTER-before-migrate fails with "relation posthog_person
+          # does not exist" and the whole job dies before ever migrating (hit
+          # 2026-07-15 when the posthog DB was wiped during a storage migration —
+          # the guard was previously ordered before migrate and only ever worked
+          # because the schema already existed). ADD COLUMN IF NOT EXISTS keeps it
+          # idempotent on an already-migrated DB.
           echo "Applying self-hosted Postgres schema guards..."
           python - <<'PY'
           import os
@@ -122,8 +132,6 @@ spec:
                   "ADD COLUMN IF NOT EXISTS last_seen_at timestamptz NULL"
               )
           PY
-          echo "Running Django migrations..."
-          python manage.py migrate --noinput
           echo "Running ClickHouse migrations..."
           python manage.py migrate_clickhouse
           # Async ClickHouse migrations gate worker startup (worker entrypoint


### PR DESCRIPTION
The `posthog-migrate` hook ran a self-hosted "schema guard" (`ALTER TABLE public.posthog_person ADD COLUMN ...`) **before** `python manage.py migrate`. On an existing DB it worked (table already there). On a **fresh/empty DB** it fails with `relation "public.posthog_person" does not exist` and the job dies **before** the Django migrations ever run — so the schema is never created and every PostHog app pod (worker, ingestion, capture…) CrashLoops on the missing table.

**Surfaced 2026-07-15** when the posthog Postgres PVC was wiped during the `longhorn-flash` storage migration — the migrate hook could no longer bootstrap an empty database.

## Fix
Reorder: `manage.py migrate --noinput` (creates every table) runs **first**, then the guard's `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` runs against the now-existing table. Idempotent on an already-migrated DB; correct on a fresh one.

After merge, ArgoCD re-runs the migrate Sync hook → schema is created → the CrashLooping app pods recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)