### PR TITLE
tune(home-assistant): AirCube naming/alerts + dashboard fixes post re-pair

### DIFF
--- a/monitoring/prometheus-stack/aircube-dashboard.yaml
+++ b/monitoring/prometheus-stack/aircube-dashboard.yaml
@@ -8,7 +8,12 @@
 #   - eCO2 (no device_class)   -> homeassistant_sensor_unit_ppm
 #   - tVOC (volatile_organic_compounds_parts device_class)
 #                              -> homeassistant_sensor_volatile_organic_compounds_parts_ppb
-# (metric names verified live against /api/prometheus on 2026-06-29)
+#   - VOC Level (unitless AQI index, no device_class)
+#                              -> homeassistant_sensor_state (generic metric shared by ALL
+#                                 unitless sensors — the entity= matcher is what isolates it)
+# rssi/lqi are NOT charted: ZHA exposes them as diagnostic entities that are
+# disabled by default, so they emit no value metric until enabled in the HA UI.
+# (metric names verified live against /api/prometheus on 2026-07-15)
 #
 # Every query is wrapped in `max by (entity)` and the stat panels use
 # `instant: true`. The `entity` label is stable, but HA's Prometheus target
@@ -41,7 +46,7 @@ data:
       "title": "Air Quality — AirCube",
       "uid": "aircube-air-quality",
       "schemaVersion": 39,
-      "version": 2,
+      "version": 3,
       "refresh": "30s",
       "panels": [
         {
@@ -190,8 +195,8 @@ data:
                 "steps": [
                   { "color": "orange", "value": null },
                   { "color": "green", "value": 30 },
-                  { "color": "green", "value": 60 },
-                  { "color": "orange", "value": 65 }
+                  { "color": "orange", "value": 60 },
+                  { "color": "red", "value": 65 }
                 ]
               }
             },
@@ -236,9 +241,10 @@ data:
                 "fillOpacity": 15,
                 "lineWidth": 2,
                 "showPoints": "never",
-                "spanNulls": true
+                "spanNulls": true,
+                "thresholdsStyle": { "mode": "dashed" }
               },
-              "color": { "mode": "palette-classic" },
+              "color": { "mode": "thresholds" },
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -277,9 +283,18 @@ data:
                 "fillOpacity": 15,
                 "lineWidth": 2,
                 "showPoints": "never",
-                "spanNulls": true
+                "spanNulls": true,
+                "thresholdsStyle": { "mode": "dashed" }
               },
-              "color": { "mode": "palette-classic" }
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "orange", "value": 500 },
+                  { "color": "red", "value": 1000 }
+                ]
+              }
             },
             "overrides": []
           },
@@ -343,6 +358,98 @@ data:
               "expr": "max by (entity) (homeassistant_sensor_humidity_percent{entity=\"sensor.stuckatprototype_aircube_humidity\"})",
               "legendFormat": "Humidity (%)",
               "refId": "B"
+            }
+          ]
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+          "id": 10,
+          "title": "VOC Level (AQI index)",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "id": 11,
+          "title": "VOC Level",
+          "description": "AirCube VOC air-quality index (0=clean). Unitless, so HA exports it on the generic homeassistant_sensor_state metric — the entity matcher is what isolates it.",
+          "type": "stat",
+          "gridPos": { "h": 8, "w": 6, "x": 0, "y": 25 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "decimals": 0,
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 50 },
+                  { "color": "orange", "value": 100 },
+                  { "color": "red", "value": 200 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "max by (entity) (homeassistant_sensor_state{entity=\"sensor.stuckatprototype_aircube_voc_level\"})",
+              "legendFormat": "VOC Level",
+              "instant": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "id": 12,
+          "title": "VOC Level over time",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 18, "x": 6, "y": 25 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": true,
+                "thresholdsStyle": { "mode": "dashed" }
+              },
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 50 },
+                  { "color": "orange", "value": 100 },
+                  { "color": "red", "value": 200 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": { "calcs": ["last", "max", "mean"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "max by (entity) (homeassistant_sensor_state{entity=\"sensor.stuckatprototype_aircube_voc_level\"})",
+              "legendFormat": "VOC Level",
+              "refId": "A"
             }
           ]
         }

--- a/monitoring/prometheus-stack/tapo-power-dashboard.yaml
+++ b/monitoring/prometheus-stack/tapo-power-dashboard.yaml
@@ -62,7 +62,7 @@ data:
           "type": "stat",
           "targets": [
             {
-              "expr": "label_replace(label_replace(max by (entity) ({__name__=~\"homeassistant_sensor_power_w|homeassistant_sensor_current_consumption_w\", entity!=\"\"}), \"name\", \"$1\", \"entity\", \"sensor\\\\.(.*)\"), \"name\", \"threadripper-gpus$1\", \"name\", \"gpu_psu(.*)\")",
+              "expr": "label_replace(label_replace(max by (entity) ({__name__=\"homeassistant_sensor_power_w\", entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server)_current_consumption\"}), \"name\", \"$1\", \"entity\", \"sensor\\\\.(.*)\"), \"name\", \"threadripper-gpus$1\", \"name\", \"gpu_psu(.*)\")",
               "legendFormat": "{{name}}",
               "instant": true,
               "refId": "A"
@@ -103,7 +103,7 @@ data:
           "type": "timeseries",
           "targets": [
             {
-              "expr": "label_replace(label_replace(max by (entity) ({__name__=~\"homeassistant_sensor_power_w|homeassistant_sensor_current_consumption_w\", entity!=\"\"}), \"name\", \"$1\", \"entity\", \"sensor\\\\.(.*)\"), \"name\", \"threadripper-gpus$1\", \"name\", \"gpu_psu(.*)\")",
+              "expr": "label_replace(label_replace(max by (entity) ({__name__=\"homeassistant_sensor_power_w\", entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server)_current_consumption\"}), \"name\", \"$1\", \"entity\", \"sensor\\\\.(.*)\"), \"name\", \"threadripper-gpus$1\", \"name\", \"gpu_psu(.*)\")",
               "legendFormat": "{{name}}",
               "refId": "A"
             }
@@ -145,7 +145,7 @@ data:
           "type": "stat",
           "targets": [
             {
-              "expr": "label_replace(label_replace(max by (entity) ({__name__=~\"homeassistant_sensor_energy_kwh|homeassistant_sensor_today_energy_kwh\", entity!=\"\"}), \"name\", \"$1\", \"entity\", \"sensor\\\\.(.*)\"), \"name\", \"threadripper-gpus$1\", \"name\", \"gpu_psu(.*)\")",
+              "expr": "label_replace(label_replace(max by (entity) ({__name__=\"homeassistant_sensor_energy_kwh\", entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server)_today_s_consumption\"}), \"name\", \"$1\", \"entity\", \"sensor\\\\.(.*)\"), \"name\", \"threadripper-gpus$1\", \"name\", \"gpu_psu(.*)\")",
               "legendFormat": "{{name}}",
               "instant": true,
               "refId": "A"
@@ -256,5 +256,5 @@ data:
       "timezone": "",
       "title": "Tapo Power Monitor",
       "uid": "tapo-power-monitor",
-      "version": 3
+      "version": 4
     }

--- a/my-apps/home/home-assistant/automations.yaml
+++ b/my-apps/home/home-assistant/automations.yaml
@@ -32,3 +32,48 @@
           {{ trigger.entity_id }} was turned off and has been restored.
           Disable the "Homelab plug power-off lockout" automation if this
           was intentional.
+
+# AirCube air-quality alerts.
+#
+# Fire a persistent notification when air quality crosses a "take action"
+# threshold, sustained for 5 min so a transient spike (cooking, a spray) does
+# not nag. Each uses a fixed notification_id so repeat triggers UPDATE the same
+# notification instead of stacking. Thresholds match the aircube-dashboard.yaml
+# bands: eCO2 1000 ppm = ventilate; tVOC 500 ppb = elevated.
+- id: aircube_eco2_high
+  alias: AirCube eCO2 high — ventilate
+  description: Notifies when AirCube eCO2 exceeds 1000 ppm for 5 minutes.
+  mode: single
+  trigger:
+    - platform: numeric_state
+      entity_id: sensor.stuckatprototype_aircube_equivalent_co2
+      above: 1000
+      for:
+        minutes: 5
+  action:
+    - service: persistent_notification.create
+      data:
+        notification_id: aircube_eco2_high
+        title: Air quality — eCO2 high
+        message: >
+          AirCube eCO2 is {{ states('sensor.stuckatprototype_aircube_equivalent_co2') }} ppm
+          (above 1000). Open a window or increase ventilation.
+
+- id: aircube_tvoc_high
+  alias: AirCube tVOC high
+  description: Notifies when AirCube tVOC exceeds 500 ppb for 5 minutes.
+  mode: single
+  trigger:
+    - platform: numeric_state
+      entity_id: sensor.stuckatprototype_aircube_volatile_organic_compounds_parts
+      above: 500
+      for:
+        minutes: 5
+  action:
+    - service: persistent_notification.create
+      data:
+        notification_id: aircube_tvoc_high
+        title: Air quality — tVOC high
+        message: >
+          AirCube tVOC is {{ states('sensor.stuckatprototype_aircube_volatile_organic_compounds_parts') }} ppb
+          (above 500). Ventilate and check for VOC sources (paint, cleaners, off-gassing).

--- a/my-apps/home/home-assistant/configuration.yaml
+++ b/my-apps/home/home-assistant/configuration.yaml
@@ -51,9 +51,18 @@ http:
     - 192.168.10.32/27 # Cilium IP Pool
     - 192.168.10.50 # Gateway IP
 
-# Enable the recorder (database)
+# Enable the recorder (database).
+# Exclude Zigbee link-diagnostic sensors (rssi/lqi) — they churn every update
+# and add nothing to history, so keep them out of the SQLite DB. Long-term
+# statistics (the energy/cost trends) are stored separately and are unaffected.
+# purge_keep_days is left at the HA default (10) — raise it here if you want a
+# longer detailed-history window (costs PVC space; does not affect LTS).
 recorder:
   db_url: sqlite:////config/home-assistant_v2.db
+  exclude:
+    entity_globs:
+      - sensor.*_rssi
+      - sensor.*_lqi
 
 # Prometheus metrics endpoint for Grafana.
 #
@@ -562,7 +571,3 @@ template:
           {% if total > 0 %}
             {{ (states('sensor.truenas_server_energy_daily') | float(0) / total * 100) | round(1) }}
           {% else %}0{% endif %}
-
-# # Expose Camera Stream Source Integration
-# # Allows exposing camera stream URLs via API for go2rtc/Frigate integration
-# expose_camera_stream_source:

--- a/my-apps/home/home-assistant/customize.yaml
+++ b/my-apps/home/home-assistant/customize.yaml
@@ -1,4 +1,5 @@
-# Per-entity overrides for Tapo homelab plugs.
+# Per-entity overrides for the Tapo homelab plugs and the AirCube air-quality
+# monitor.
 #
 # - Friendly names flow into the `friendly_name` Prometheus label and HA's UI
 #   (Energy dashboard, Developer Tools).
@@ -62,3 +63,40 @@ switch.truenas_server_smart_plug:
 # ---------- TrueNAS host ----------
 # (Displays "Truenas Server …" from the device name; derived sensors keep their
 # "TrueNAS Server …" names.)
+
+# ---------- StuckAtPrototype AirCube (Zigbee air-quality, ZHA quirk) ----------
+# ZHA's auto-derived friendly names are verbose ("StuckAtPrototype AirCube
+# Volatile organic compounds parts"); shorten them. These names flow into the
+# `friendly_name` Prometheus label, but the Grafana dashboard matches on the
+# stable `entity` label (not friendly_name), so renaming here is display-only
+# and does NOT break aircube-dashboard.yaml.
+sensor.stuckatprototype_aircube_temperature:
+  friendly_name: AirCube Temperature
+sensor.stuckatprototype_aircube_humidity:
+  friendly_name: AirCube Humidity
+sensor.stuckatprototype_aircube_equivalent_co2:
+  friendly_name: AirCube eCO2
+sensor.stuckatprototype_aircube_volatile_organic_compounds_parts:
+  friendly_name: AirCube tVOC
+sensor.stuckatprototype_aircube_voc_level:
+  friendly_name: AirCube VOC Level
+number.stuckatprototype_aircube_brightness:
+  friendly_name: AirCube Brightness
+
+# Declutter the default dashboard: rssi/lqi are Zigbee link diagnostics, and
+# `number.stuckatprototype_aircube` is a DUPLICATE of the brightness slider —
+# it's ZHA's raw AnalogOutput present_value, controlling the same thing as
+# number.stuckatprototype_aircube_brightness (the quirk's v2 .number()). The
+# identify button is a commissioning aid, not a daily control.
+sensor.stuckatprototype_aircube_rssi:
+  friendly_name: AirCube RSSI
+  hidden: true
+sensor.stuckatprototype_aircube_lqi:
+  friendly_name: AirCube LQI
+  hidden: true
+number.stuckatprototype_aircube:
+  friendly_name: AirCube Brightness (duplicate — use AirCube Brightness)
+  hidden: true
+button.stuckatprototype_aircube_identify:
+  friendly_name: AirCube Identify
+  hidden: true


### PR DESCRIPTION
## Why
The AirCube air-quality sensor was re-paired after a firmware flash but had **zero HA-side treatment** (no friendly names, no alerts) and gaps/bugs in its Grafana coverage. This tunes both, plus fixes latent issues on the Tapo power dashboard found along the way.

## HA config
- **customize.yaml** — name all AirCube entities ("AirCube …"); hide the rssi/lqi diagnostics, the identify button, and `number.stuckatprototype_aircube` (a duplicate of the quirk's brightness slider).
- **automations.yaml** — air-quality alerts: eCO₂ >1000 ppm ("ventilate") and tVOC >500 ppb, sustained 5 min, fixed `notification_id` so repeats update in place instead of stacking.
- **configuration.yaml** — recorder excludes `*_rssi`/`*_lqi` (constant churn, no history value); removed the dead commented-out `expose_camera_stream_source` block.

## Grafana
- **aircube-dashboard** — added **VOC Level** stat + timeseries (`homeassistant_sensor_state`, the unitless generic metric); fixed humidity thresholds (was two `green` steps, no mold-risk red); added tVOC over-time thresholds; added `thresholdsStyle` so the air-quality bands actually render.
- **tapo-power-dashboard** — dropped dead metric OR-terms (`current_consumption_w` / `today_energy_kwh` don't exist); scoped **Live Power**, **Power Over Time**, and **Energy Today** to the three real plugs. Energy Today was silently pulling in **27 series** (every utility meter + homelab totals).

## Verification
- HA `check_config` → **EXIT=0, no errors** against a full ephemeral config copy inside the running pod.
- Both dashboard JSONs parse; metric names cross-checked live against `/api/prometheus`.

## Deploy note
Dashboards reload automatically via the Grafana sidecar on sync. **HA config needs a pod restart** after the ConfigMap updates (the initContainer copies config→PVC only on pod start; `disableNameSuffixHash: true` means a ConfigMap change alone won't trigger a rollout).

## Not included (deliberate)
- No `CO2` device_class on eCO₂ — would rename the Prometheus metric and break the dashboard panel.
- No RSSI/LQI panels — those ZHA diagnostic entities are disabled by default and emit no metric until enabled in the HA UI.
- The failing `tplink 192.168.101.131` ("Proxmox Server P115") errors are a stale UI integration in HA `.storage`, not in git — must be deleted in the HA UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)