### PR TITLE
stage predictable cluster subnets for next rebuild

### DIFF
--- a/docs/domains/networking/topology.md
+++ b/docs/domains/networking/topology.md
@@ -65,6 +65,29 @@ routes each PodCIDR to its owner (see
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
+## Address plan
+
+Cluster-internal ranges follow a mnemonic scheme anchored on the HomeLab
+VLAN 10. The pod/service values are **staged, not live**: they are baked in at
+cluster bootstrap and can only change at a full rebuild, so the live cluster
+still runs the Talos defaults until the next rebuild activates the
+`predictable-cluster-subnets` patch in the Omni cluster template.
+
+| Layer | Live today | Plan (next rebuild) | Why |
+|-------|-----------|---------------------|-----|
+| Nodes (HomeLab, VLAN 10) | 192.168.10.0/24 | unchanged | Firewalla-owned |
+| Routed VM subnet | 192.168.123.0/24 | unchanged | static in git |
+| Pods | 10.244.0.0/16 (Talos default) | 10.10.0.0/16 | "VLAN 10 → 10.10" |
+| Services | 10.96.0.0/12 (Talos default) | 10.11.0.0/16 | next block after pods |
+| Cilium `ipv4NativeRoutingCIDR` | 10.14.0.0/16 (mismatched, inert) | 10.10.0.0/16 | must equal pod CIDR |
+
+Activation checklist (one commit, applied only via rebuild): uncomment the
+template patch, flip both `pod-aggregate-route` patches, the Cilium value,
+the `omni/libvirt-provider` pod-route units, and the Dell UFW `/16` rules.
+Free-range check against Firewalla networks (192.168.1/10/50/100/101/103,
+10.190.26, 10.180.43) done 2026-07-16 — 10.10/16 and 10.11/16 collide with
+nothing.
+
 ## IP Assignments
 
 ### Main LAN (192.168.10.0/24)

--- a/docs/domains/networking/wifi-libvirt-talos-workers.md
+++ b/docs/domains/networking/wifi-libvirt-talos-workers.md
@@ -50,7 +50,7 @@ Four address layers are involved:
 | Dell uplink | `192.168.10.20` | Firewalla DHCP reservation | Next hop for every Dell-hosted routed subnet |
 | Legacy libvirt NAT | `192.168.122.0/24` | Dell `virbr0` | Temporary provider proof only; not production |
 | Routed VM network | `192.168.123.0/24` | Dell `virbr1` | Production Talos VM node addresses |
-| Kubernetes pods | `10.244.0.0/16` aggregate | Kubernetes + Cilium | A distinct `/24` is assigned to each node |
+| Kubernetes pods | `10.244.0.0/16` aggregate | Kubernetes + Cilium | A distinct `/24` per node; staged to become `10.10.0.0/16` at the next rebuild (topology doc "Address plan") |
 
 The physical Dell is the router between HomeLab and `192.168.123.0/24`.
 Firewalla carries a static route for that subnet through `192.168.10.20`.

--- a/infrastructure/networking/cilium/values.yaml
+++ b/infrastructure/networking/cilium/values.yaml
@@ -46,6 +46,11 @@ cgroup:
 # Routing Configuration
 routingMode: native
 autoDirectNodeRoutes: true
+# Does NOT match the live pod CIDR (10.244.0.0/16, Talos default) — inert
+# today because bpf.masquerade exempts cluster destinations via the ipcache.
+# Becomes 10.10.0.0/16 when the staged predictable-cluster-subnets patch in
+# the Omni cluster template is activated at the next rebuild; change the two
+# together, never live.
 ipv4NativeRoutingCIDR: 10.14.0.0/16
 
 # IPAM Configuration

--- a/omni/cluster-template/cluster-template-singlenode-gpu.yaml
+++ b/omni/cluster-template/cluster-template-singlenode-gpu.yaml
@@ -12,6 +12,22 @@ kubernetes:
 talos:
   version: v1.13.4
 patches:
+# STAGED — ACTIVATE ONLY AT A FULL CLUSTER REBUILD. Pod/service subnets are
+# immutable after bootstrap; syncing this onto the live cluster half-applies
+# and breaks routing. Predictable address plan (see
+# docs/domains/networking/topology.md): nodes are VLAN 10 (192.168.10.0/24),
+# pods 10.10.0.0/16, services 10.11.0.0/16. When activating, also flip in the
+# same commit: the two pod-aggregate-route patches below,
+# infrastructure/networking/cilium/values.yaml ipv4NativeRoutingCIDR, the
+# omni/libvirt-provider pod-route units, and the Dell UFW /16 rules.
+# - name: predictable-cluster-subnets
+#   inline:
+#     cluster:
+#       network:
+#         podSubnets:
+#         - 10.10.0.0/16
+#         serviceSubnets:
+#         - 10.11.0.0/16
 - name: disable-default-cni
   inline:
     cluster:


### PR DESCRIPTION
Stages the mnemonic address plan requested after #1657 — **no live change**; activation happens only at the next full cluster rebuild.

| Layer | Live today | Next rebuild | Why |
|---|---|---|---|
| Nodes (VLAN 10) | 192.168.10.0/24 | unchanged | Firewalla-owned |
| Pods | 10.244.0.0/16 (Talos default) | **10.10.0.0/16** | "VLAN 10 → 10.10" |
| Services | 10.96.0.0/12 (default) | **10.11.0.0/16** | next block up |
| Cilium `ipv4NativeRoutingCIDR` | 10.14.0.0/16 (mismatched, inert) | **10.10.0.0/16** | must equal pod CIDR |

- The template patch is **commented out** with a warning: pod/service subnets are immutable after bootstrap; syncing them onto the live cluster half-applies and breaks routing.
- Topology doc gains an "Address plan" section with the activation checklist (template patch + both `pod-aggregate-route` patches + Cilium value + Dell pod-route units + UFW rules, all in one commit, applied only via rebuild).
- Free-range check against all Firewalla networks done 2026-07-16: 10.10/16 and 10.11/16 collide with nothing (existing: 192.168.1/10/50/100/101/103, 10.190.26, 10.180.43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)