### PR TITLE
switch cilium to vxlan tunnel routing

### DIFF
--- a/infrastructure/networking/cilium/values.yaml
+++ b/infrastructure/networking/cilium/values.yaml
@@ -44,9 +44,16 @@ cgroup:
   hostRoot: /sys/fs/cgroup
 
 # Routing Configuration
-routingMode: native
-autoDirectNodeRoutes: true
-ipv4NativeRoutingCIDR: 10.14.0.0/16
+# Tunnel (VXLAN) instead of native routing: the Wi-Fi worker sits behind an
+# ASUS media bridge whose L3-aware forwarding drops inbound-first frames for
+# any IP it has never seen ARP for — which is every pod IP. Encapsulating
+# cross-node pod traffic between node IPs (which the bridge forwards
+# reliably in both directions) removes the entire class of problem, for any
+# transport and any future rebuild. Cross-node pod-to-pod pays ~50B/packet
+# VXLAN overhead; node-IP traffic (NFS, iSCSI, Longhorn replication, API) is
+# untouched. UDP 8472 must pass between node IPs.
+routingMode: tunnel
+tunnelProtocol: vxlan
 
 # IPAM Configuration
 ipam:
@@ -70,8 +77,15 @@ bpf:
   # Performance: pre-allocate BPF map entries (reduces per-packet latency)
   preallocateMaps: true
 
-# Performance: BIG TCP reduces CPU overhead for large transfers (kernel >= 5.19)
-enableIPv4BIGTCP: true
+# BIG TCP requires native routing — must stay off under VXLAN. Changing this
+# alters pod GSO sizes; existing pods need a restart to pick it up.
+enableIPv4BIGTCP: false
+
+# One agent at a time: the chart default of 2 could restart two of the three
+# nodes' agents simultaneously.
+updateStrategy:
+  rollingUpdate:
+    maxUnavailable: 1
 
 # L2 Announcements for LoadBalancer Services
 l2announcements:
@@ -84,6 +98,10 @@ l2announcements:
 # Enable XDP acceleration (REQUIRED for Talos L2 announcements)
 # Fixes kernel ARP dropping issue between XDP and TC in Talos 1.9+
 # See: https://github.com/cilium/cilium/discussions/36829
+# CAUTION under VXLAN: XDP acceleration is unsupported with tunneling, so
+# best-effort silently degrades to the tc path. If L2-announced LoadBalancer
+# IPs stop answering ARP after the tunnel migration, this is the suspect —
+# verify external gateway reachability explicitly after any routing change.
 loadBalancer:
   acceleration: best-effort
 


### PR DESCRIPTION
Fixes the confirmed media-bridge defect: inbound-first traffic to Dell pod IPs is dropped by the AX86U's L3-aware forwarding (verified: wired cilium agents show Dell endpoints 0/1; direct curls to Dell pod IPs time out via both the VM's and the host's MAC, while node-IP traffic and Dell-initiated flows work). Encapsulating cross-node pod traffic between node IPs sidesteps the bridge's filter entirely and is rebuild-proof for any future transport.

## Changes
- `routingMode: tunnel` + `tunnelProtocol: vxlan`; `autoDirectNodeRoutes` and `ipv4NativeRoutingCIDR` removed (the latter was a long-standing mismatch vs the real pod CIDR, inert under BPF masquerade)
- `enableIPv4BIGTCP: false` — BIG TCP requires native routing; **existing pods keep old GSO sizes until restarted** (post-merge step)
- `updateStrategy.rollingUpdate.maxUnavailable: 1` — chart default of 2 could restart two of three agents at once
- XDP caution documented at `loadBalancer.acceleration`: unsupported with tunneling, best-effort degrades to tc — L2-announced LoadBalancer IPs must be verified after rollout (Talos ARP issue #36829 was the reason XDP was enabled)

## Cost accounting
- ~50 B/packet + encap CPU on **cross-node pod↔pod** only
- Node-IP traffic unaffected: NFS/TrueNAS, Longhorn iSCSI attach, API — no VXLAN
- Same-node pod traffic unaffected
- Longhorn manager/instance-manager cross-node control traffic **is** pod-IP and will be tunneled (no storage network configured)
- Requires UDP 8472 between node IPs (open on the flat LAN; the media bridge forwards node-IP UDP)

## Rollout plan
Baselines captured pre-merge (cilium health, Dell-pod inbound, Prometheus Dell targets, DNS/egress, wired pod-to-pod latency/bulk). Merge → ArgoCD syncs → agents restart one at a time → re-run all checks + external LB/gateway reachability → `kubectl rollout restart` for workloads (GSO reset). Rollback = revert this commit (ArgoCD syncs back; same one-at-a-time restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)