### PR TITLE
document vxlan tunnel routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ kubectl get nodes
 ```
 
 > Three settings here **must match** the values ArgoCD will render at Wave 0 (`infrastructure/networking/cilium/`), or Wave 0 fights the CLI install:
+> - **Routing mode matches by default**: the CLI's default (`tunnel`/vxlan) equals `values.yaml`'s `routingMode: tunnel`. If the managed values ever change routing mode, add the matching `--set routingMode=...` here or Wave 0 restarts every agent mid-bootstrap.
 > - **`--version 1.19.5`** must match `infrastructure/networking/cilium/kustomization.yaml`. A mismatch makes ArgoCD upgrade Cilium at Wave 0, regenerating some Hubble certs but not others → `x509: certificate signed by unknown authority` blocks every later wave.
 > - **`cluster.name`** must match `values.yaml` (Hubble cert SANs). Run without it and certs are issued for `default`/`kind-kind` → TLS failures.
 > - **Hubble stays disabled at bootstrap on purpose** — ArgoCD enables it at Wave 0 so it's the sole owner of the Hubble TLS certs (no CLI-vs-ArgoCD cert mismatch).

--- a/docs/domains/networking/topology.md
+++ b/docs/domains/networking/topology.md
@@ -18,10 +18,14 @@ CPU worker — all three nodes on the same `192.168.10.0/24`:
 
 Verify live node addresses with `kubectl get nodes -o wide`.
 
-PodCIDRs are natively routed (Cilium, no overlay). All three nodes share one
-L2, so Cilium's `autoDirectNodeRoutes` exchanges every per-node PodCIDR route
-automatically — **no static pod routes exist anywhere** (not on Firewalla,
-not in machine config, not on any host).
+Cross-node pod traffic rides a **Cilium VXLAN tunnel between node IPs**
+(`routingMode: tunnel`) — **no pod routes exist anywhere** (not on Firewalla,
+not in machine config, not on any host), and no device between nodes ever
+sees a pod IP on the wire. Tunnel mode was adopted because the Wi-Fi
+worker's media bridge silently drops inbound-first frames for IPs without an
+ARP-learned binding — i.e. every pod IP (see
+[Wi-Fi Talos workers](wifi-libvirt-talos-workers.md)). Node-IP traffic
+(NFS, Longhorn iSCSI, API) is not encapsulated.
 
 ## Physical Topology
 

--- a/docs/domains/networking/wifi-libvirt-talos-workers.md
+++ b/docs/domains/networking/wifi-libvirt-talos-workers.md
@@ -59,10 +59,23 @@ Address layers:
 | Talos VM | `192.168.10.119` static | Omni machine config (git) | Worker node address |
 | Kubernetes pods | `10.244.0.0/16` aggregate | Kubernetes + Cilium | A distinct `/24` per node, fully automatic |
 
-**No pod routes exist anywhere outside Cilium.** Because the VM is on the
-same L2 as the wired nodes, `autoDirectNodeRoutes` exchanges the per-node
-PodCIDR routes automatically, for any `/24` Kubernetes assigns after any
-rebuild. Firewalla carries no cluster routes at all.
+**Cross-node pod traffic is VXLAN-tunneled between node IPs** (Cilium
+`routingMode: tunnel`), so nothing between the nodes — including the media
+bridge — ever sees a pod IP on the wire, and no pod routes exist anywhere.
+Firewalla carries no cluster routes at all.
+
+Tunneling is load-bearing, not optional. The first bridged deployment ran
+Cilium native routing and hit a subtle defect: the media bridge is
+**L3-aware** and forwards inbound frames only for IPs it has ARP-learned.
+Pod IPs never ARP (they are routed behind the node address), so
+inbound-first connections to Dell pod IPs — Prometheus scrapes, service
+traffic to Dell-scheduled backends, cilium-health endpoint probes — were
+silently dropped or worked only intermittently after the bridge eventually
+learned an address, while node-IP traffic and Dell-initiated flows worked
+perfectly. Encapsulating pod traffic inside node-IP UDP (port 8472) removes
+the entire class of problem for any bridge or transport. The cost lands
+only on cross-node pod↔pod packets (~50 bytes + encap CPU); NFS, Longhorn
+iSCSI attach, and API traffic ride node IPs untunneled.
 
 ## Why the VM address is static
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ Backups are **kopiur** (Kopia-native operator).
 - **Databases**: [Plain Postgres migration — CNPG exit ramp, new-DB default](domains/cnpg/plain-postgres-migration.md) · [Backup/restore/start — beginner guide](domains/cnpg/backup-restore-start-guide.md) · [CNPG explained](domains/cnpg/explained.md) · [CNPG disaster recovery](domains/cnpg/disaster-recovery.md)
 - **GitOps / ArgoCD**: [argocd](domains/argocd/argocd.md) · [entrypoints & waves](domains/argocd/entrypoints.md)
 - **Enterprise multi-cluster planning**: [roadmap](domains/multicluster/enterprise-gitops-roadmap.md) · [concrete fleet PRD](domains/multicluster/prd.md)
-- **Networking**: [topology](domains/networking/topology.md) · [routed Wi-Fi Talos workers](domains/networking/wifi-libvirt-talos-workers.md) · [policy](domains/networking/policy.md) · [Technitium `vanillax.me` migration](domains/networking/technitium-vanillax-me-migration.md)
+- **Networking**: [topology](domains/networking/topology.md) · [Wi-Fi Talos workers](domains/networking/wifi-libvirt-talos-workers.md) · [policy](domains/networking/policy.md) · [Technitium `vanillax.me` migration](domains/networking/technitium-vanillax-me-migration.md)
 - **Storage**: [kopia maintenance](domains/storage/kopia-maintenance-plan.md) · [RWO/RWX model & sizing](domains/storage/storage-model-rwo-rwx-and-sizing.md) · [RustFS credentials](domains/rustfs/credential-runbook.md) · [future: tiered storage](domains/storage/architecture-future.md)
 - **Observability**: [radar-ng](domains/observability/radar-ng.md)
 - **AI / GPU**: [model catalog](domains/ai-gpu/model-catalog.md) · [3090 LLM optimization](domains/ai-gpu/3090-llm-optimization.md) · [pi agent local-dev guide](domains/ai-gpu/pi-agent-local-dev.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,7 +113,7 @@ nav:
       - Plain Postgres migration (CNPG exit ramp): domains/cnpg/plain-postgres-migration.md
   - Networking:
       - Topology: domains/networking/topology.md
-      - Routed Wi-Fi Talos workers: domains/networking/wifi-libvirt-talos-workers.md
+      - Wi-Fi Talos workers: domains/networking/wifi-libvirt-talos-workers.md
       - Cilium policies: domains/networking/policy.md
       - Technitium vanillax.me migration: domains/networking/technitium-vanillax-me-migration.md
   - AI / GPU:


### PR DESCRIPTION
Doc follow-up to #1660: topology and Wi-Fi worker runbook now describe tunnel mode and the media bridge's L3-aware inbound-drop defect that motivated it (including its intermittent/eventually-consistent behavior). No config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)