### PR TITLE
fix fizzy oom crashloop: pin puma workers

### DIFF
--- a/my-apps/utility/fizzy/deployment.yaml
+++ b/my-apps/utility/fizzy/deployment.yaml
@@ -28,6 +28,11 @@ spec:
               value: America/Detroit
             - name: RAILS_ENV
               value: production
+            # Rails 8 puma defaults workers to processor count — 32 threads on
+            # the GPU node meant ~32 forked workers ballooning to the 2Gi limit
+            # within minutes of boot (OOM crashloop, 345+ restarts).
+            - name: WEB_CONCURRENCY
+              value: "2"
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
fizzy has been OOM-crashlooping every ~8 minutes since Jul 15 (346 restarts): Prometheus shows working set going 6Mi → ~2000Mi within two minutes of every boot, then riding the 2Gi limit until the OOM killer fires. Root cause: no `WEB_CONCURRENCY` set — Rails 8's puma config defaults workers to processor count, and the GPU node has 32 threads, so fizzy tried to run ~32 forked workers in a 2Gi container. Pinned to 2 workers (~600Mi expected footprint); the crashloop coincided with the new ReplicaSet from #1652, which is what re-rolled the pod onto this behavior.

Verification plan post-merge: pod stops restarting, working set settles well under 1Gi, fizzy.vanillax.me still serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)