### PR TITLE
fizzy: pin solid_queue processes too (JOB_CONCURRENCY=2)

### DIFF
--- a/my-apps/utility/fizzy/deployment.yaml
+++ b/my-apps/utility/fizzy/deployment.yaml
@@ -28,10 +28,15 @@ spec:
               value: America/Detroit
             - name: RAILS_ENV
               value: production
-            # Rails 8 puma defaults workers to processor count — 32 threads on
-            # the GPU node meant ~32 forked workers ballooning to the 2Gi limit
-            # within minutes of boot (OOM crashloop, 345+ restarts).
+            # Fizzy sizes itself to the hardware twice over — both must be
+            # pinned on the 32-thread GPU node or it OOMs its 2Gi limit within
+            # minutes of boot (was a 345+ restart crashloop):
+            # - puma: workers default to processor count
+            # - solid_queue: queue.yml processes default to physical cores
+            #   (verified in-image: JOB_CONCURRENCY is the fetch env)
             - name: WEB_CONCURRENCY
+              value: "2"
+            - name: JOB_CONCURRENCY
               value: "2"
             - name: SECRET_KEY_BASE
               valueFrom:


### PR DESCRIPTION
Follow-up to #1677: WEB_CONCURRENCY=2 landed and the pod survived past the old 8-minute OOM horizon, but it still climbed to ~2000Mi — process inspection showed **42 processes, 32 of them solid-queue workers**. The in-image `config/queue.yml` defaults `processes:` to `Concurrent.physical_processor_count` with `JOB_CONCURRENCY` as the override env (verified by reading the file in the running container). Pinned to 2. Expected steady state: ~6 Ruby processes, well under 1Gi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)