### PR TITLE
renovate: gate gitea postgres major bumps on dashboard approval

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -237,6 +237,24 @@
       enabled: false,
     },
     {
+      // 2026-07-17 incident: #1621 (postgres 17.10→18.4) crashlooped
+      // gitea-postgres 159x — PG data dirs are NOT major-version compatible
+      // and need a manual dump/restore. The repo-wide major rule already
+      // blocked automerge and the deployment file even carries a warning
+      // comment, but the PR looked like every other green bump and was
+      // merged by hand. Gate PR CREATION on dependency-dashboard approval
+      // so a major never shows up as a mergeable PR in the first place.
+      // Minors/patches keep automerging per the repo-wide rule. PG19 GA is
+      // ~Sept 2026. Migration runbook captured 2026-07-18 (dump/restore
+      // via temp postgres:17 pod on the same PVC).
+      description: 'gitea plain-Postgres image: MAJOR bumps require dependency-dashboard approval — PG data dirs are not major-version compatible; manual dump/restore needed (2026-07-17 incident, PR #1621)',
+      matchPackageNames: ['postgres'],
+      matchFileNames: ['my-apps/development/gitea/postgres/deployment.yaml'],
+      matchUpdateTypes: ['major'],
+      dependencyDashboardApproval: true,
+      automerge: false,
+    },
+    {
       description: 'Pin project-nomad MySQL to 8.x (AdonisJS/Lucid not tested with MySQL 9)',
       matchPackageNames: ['mysql'],
       matchFileNames: ['my-apps/home/project-nomad/**'],

--- a/my-apps/development/gitea/postgres/deployment.yaml
+++ b/my-apps/development/gitea/postgres/deployment.yaml
@@ -34,7 +34,11 @@ spec:
         - name: postgres
           # Pin MAJOR.MINOR — Renovate bumps patches/minors; MAJOR upgrades
           # need a manual dump/restore (Postgres data dirs are not
-          # major-version compatible). Do NOT let a major bump auto-merge.
+          # major-version compatible). Majors are gated on dependency-
+          # dashboard approval in .github/renovate.json5 after #1621
+          # (17.10->18.4) crashlooped this pod on a stale PG17 data dir.
+          # If merging a major by hand anyway: dump with the OLD major's
+          # image first, wipe/reinit PGDATA, then restore.
           image: postgres:18.4
           securityContext:
             runAsUser: 999


### PR DESCRIPTION
## Why

Yesterday's incident: Renovate PR #1621 (`postgres:17.10 → 18.4`) crashlooped `gitea-postgres` 159× — PG data dirs are not major-version compatible:

```
FATAL: database files are incompatible with server
DETAIL: The data directory was initialized by PostgreSQL version 17
```

The repo-wide major rule did its job (no automerge) and the deployment file even has a warning comment — but the PR looked like every other green bump and got merged by hand (me). Fixed the data layer today with a manual dump/restore (temp `postgres:17.10` pod → `pg_dump` → park old dir → fresh PG18 initdb → restore; 112 tables verified, gitea back to Healthy).

## What changes

- **`.github/renovate.json5`**: new packageRule — `postgres` bumps in `my-apps/development/gitea/postgres/deployment.yaml` with `matchUpdateTypes: [major]` now get `dependencyDashboardApproval: true` + `automerge: false`. A major never appears as a mergeable PR; it sits in the dependency dashboard pending explicit approval. Minors/patches keep automerging per the repo-wide rule.
- **`deployment.yaml` comment**: updated to reflect the real failure mode (human merge, not automerge) and a one-line recovery pointer.

PG19 GA is ~September 2026, so this lands ahead of the next temptation.

Validated with `renovate-config-validator` ✅