### PR TITLE
versatiles: self-hosted worldwide map at maps.vanillax.me

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -237,6 +237,24 @@
       enabled: false,
     },
     {
+      // 2026-07-17 incident: #1621 (postgres 17.10→18.4) crashlooped
+      // gitea-postgres 159x — PG data dirs are NOT major-version compatible
+      // and need a manual dump/restore. The repo-wide major rule already
+      // blocked automerge and the deployment file even carries a warning
+      // comment, but the PR looked like every other green bump and was
+      // merged by hand. Gate PR CREATION on dependency-dashboard approval
+      // so a major never shows up as a mergeable PR in the first place.
+      // Minors/patches keep automerging per the repo-wide rule. PG19 GA is
+      // ~Sept 2026. Migration runbook captured 2026-07-18 (dump/restore
+      // via temp postgres:17 pod on the same PVC).
+      description: 'gitea plain-Postgres image: MAJOR bumps require dependency-dashboard approval — PG data dirs are not major-version compatible; manual dump/restore needed (2026-07-17 incident, PR #1621)',
+      matchPackageNames: ['postgres'],
+      matchFileNames: ['my-apps/development/gitea/postgres/deployment.yaml'],
+      matchUpdateTypes: ['major'],
+      dependencyDashboardApproval: true,
+      automerge: false,
+    },
+    {
       description: 'Pin project-nomad MySQL to 8.x (AdonisJS/Lucid not tested with MySQL 9)',
       matchPackageNames: ['mysql'],
       matchFileNames: ['my-apps/home/project-nomad/**'],

--- a/my-apps/development/gitea/postgres/deployment.yaml
+++ b/my-apps/development/gitea/postgres/deployment.yaml
@@ -34,7 +34,11 @@ spec:
         - name: postgres
           # Pin MAJOR.MINOR — Renovate bumps patches/minors; MAJOR upgrades
           # need a manual dump/restore (Postgres data dirs are not
-          # major-version compatible). Do NOT let a major bump auto-merge.
+          # major-version compatible). Majors are gated on dependency-
+          # dashboard approval in .github/renovate.json5 after #1621
+          # (17.10->18.4) crashlooped this pod on a stale PG17 data dir.
+          # If merging a major by hand anyway: dump with the OLD major's
+          # image first, wipe/reinit PGDATA, then restore.
           image: postgres:18.4
           securityContext:
             runAsUser: 999

--- a/my-apps/maps/versatiles/README.md
+++ b/my-apps/maps/versatiles/README.md
@@ -1,0 +1,150 @@
+# VersaTiles — self-hosted worldwide map at maps.vanillax.me
+
+## What and why
+
+[VersaTiles](https://versatiles.org) is an open-source map stack: a Rust tile
+server plus a MapLibre browser frontend, serving pre-rendered OpenStreetMap
+vector tiles from a single archive file. No database, no API key, no paid
+service, no external tile provider.
+
+Deployed here as **shared map infrastructure** for the cluster (future
+consumers: RadarNG, Project NOMAD, Home Assistant, anything location-aware).
+This is the first phase: upstream VersaTiles as-is — no custom frontend, no
+search, no routing.
+
+- **Public URL:** <https://maps.vanillax.me> (pan/zoom world map, keyless)
+- **Dataset:** `osm.20260608.versatiles` — full planet, zoom 0–14, Shortbread
+  schema, **62.0 GiB**, from <https://download.versatiles.org/> (free, no
+  account, sha256-verified)
+- **Storage:** 150Gi PVC `map-data` on the default `longhorn` (NVMe) class —
+  62 GiB active + headroom for the atomic download-then-swap during refresh.
+  Backup-exempt (re-downloadable public data).
+- **Image:** `versatiles/versatiles-frontend:v4.6.0` (server + bundled
+  upstream frontend; Renovate manages bumps)
+
+## How it works
+
+```
+download.versatiles.org (osm.YYYYMMDD.versatiles + .sha256)
+        │  map-bootstrap Job (ArgoCD Sync hook): download → verify → atomic mv
+        ▼
+map-data PVC (150Gi longhorn)
+        │  read-only mount; init container blocks until archive exists
+        ▼
+versatiles Deployment (serve -c config.yaml /data/osm.versatiles)
+        ▼
+Service :8080 → HTTPRoute (gateway-external) → https://maps.vanillax.me
+```
+
+**Bootstrap:** on first sync the `map-bootstrap` hook Job downloads the
+archive (~15–60 min depending on WAN speed; the ArgoCD app shows Progressing
+the whole time — this is expected), verifies the published sha256, and
+atomically renames it into place. The server pod's `wait-for-map` init
+container blocks until the file exists, so Job and Deployment can deploy
+together in any order. On every later sync the Job re-runs but exits in
+seconds via a marker file on the PVC (`/data/.bootstrap-marker`, line 1 = the
+dataset URL it downloaded).
+
+**Updates (refresh the planet / change dataset):** edit `DATASET_URL` +
+`DATASET_SHA256_URL` in `kustomization.yaml`'s `configMapGenerator` to a newer
+`osm.YYYYMMDD.versatiles` from <https://download.versatiles.org/>, commit,
+push. The hash-suffixed ConfigMap name changes → Job spec changes → hook
+re-runs → marker mismatch → fresh download → atomic swap. The running server
+keeps serving the **old** file through its open file descriptor until
+restarted, so serving never breaks mid-swap. After the Job completes:
+
+```bash
+kubectl -n versatiles rollout restart deploy/versatiles
+```
+
+**Manual re-download (same URL):** delete the marker, then re-run the hook:
+
+```bash
+kubectl -n versatiles exec deploy/versatiles -- rm /data/.bootstrap-marker  # (or via the Job pod)
+kubectl -n versatiles delete job map-bootstrap   # next sync recreates + re-downloads
+```
+
+(Note: the server mounts `/data` read-only; if exec-deleting the marker fails,
+run a one-off pod mounting the PVC read-write.)
+
+**Rollback:** point `DATASET_URL` back at the previous `osm.YYYYMMDD`
+snapshot (older versioned files stay downloadable for months), commit, wait
+for the hook, restart the Deployment. If a download fails mid-way nothing
+breaks: the partial file is a `.tmp`, the active archive and marker are
+untouched, and the Job retries (`backoffLimit: 4`, then ArgoCD app shows
+Degraded — that's the failure alert path, via the existing ArgoCD sync
+alerts).
+
+## Endpoints
+
+- `https://maps.vanillax.me/` — upstream frontend (map viewer)
+- `https://maps.vanillax.me/tiles/index.json` — list of tileset IDs (also the
+  k8s readiness probe)
+- `https://maps.vanillax.me/tiles/osm/tiles.json` — TileJSON for the planet
+  source (id = filename stem `osm`)
+- `https://maps.vanillax.me/tiles/osm/{z}/{x}/{y}` — vector tiles (pbf)
+- `https://maps.vanillax.me/assets/styles/<style_id>/style.json` — MapLibre
+  styles; `https://maps.vanillax.me/assets/glyphs/…`, `…/assets/sprites/…`
+  — fonts and sprites
+
+> **TODO (fill in after first live deploy):** the exact shipped `style_id`
+> list (expected: the VersaTiles `colorful` / `graybeard` / `eclipse` /
+> `neutrino` family) — verify with
+> `curl -s https://maps.vanillax.me/assets/styles/index.json` (or browse
+> `/assets/`) and replace this note with the real URLs.
+
+## CORS
+
+Enabled app-side in `config.yaml` (regex allowlist): any
+`https://*.vanillax.me` origin plus localhost dev servers. Everything else is
+blocked by default. Extend `allow_patterns` to grant new origins.
+
+## Attribution
+
+Map data © OpenStreetMap contributors, [ODbL](https://opendatacommons.org/licenses/odbl/).
+The attribution string is embedded in the archive's TileJSON and rendered by
+the upstream frontend/MapLibre attribution control. Keep it visible in any
+future custom frontend.
+
+## Future RadarNG integration (documentation only — NOT wired up)
+
+RadarNG stays batteries-included upstream (bundled basemap default). The
+clean integration contract for *this* deployment is a MapLibre **style URL**,
+which encapsulates tile sources, glyphs, sprites, layers, and attribution:
+
+```env
+RADAR_BASEMAP_LIGHT_STYLE_URL=https://maps.vanillax.me/assets/styles/<light-style-id>/style.json
+RADAR_BASEMAP_DARK_STYLE_URL=https://maps.vanillax.me/assets/styles/<dark-style-id>/style.json
+```
+
+(Real style IDs go in once verified live — see TODO above.) That keeps RadarNG
+ignorant of whether the backend is VersaTiles, Protomaps, or Martin. The
+radar-ng app in this repo is intentionally untouched by this deployment.
+
+## Known limitations
+
+- No geocoding/search, no routing, no satellite imagery (future phases:
+  Photon / Valhalla / etc. — deliberately not deployed yet).
+- Single replica (RWO PVC, `Recreate`); brief downtime on pod moves/updates.
+- Dataset refresh is a manual URL bump + rollout restart (no auto-cron yet).
+- No native Prometheus metrics upstream; coverage is the generic kube-state
+  + ArgoCD sync/degraded alerts.
+- Zoom is capped at 14 by the dataset (Shortbread planet); street-level
+  detail renders fine because vector tiles overzoom client-side.
+
+## Validation
+
+```bash
+kubectl -n versatiles get pods,pvc,job
+kubectl -n versatiles logs job/map-bootstrap        # download / checksum / swap log
+curl -I https://maps.vanillax.me                    # 200 + html
+curl -s https://maps.vanillax.me/tiles/index.json   # ["osm"]
+```
+
+## Later: NAS/RustFS archival (not implemented)
+
+If historical snapshots become worth keeping, stage `osm.YYYYMMDD.versatiles`
+files on TrueNAS (SMB/NFS share or RustFS bucket) as archive-only storage and
+keep serving from the local PVC — do not put network storage in the tile
+serving path (random byte-range reads; see
+`docs/domains/storage/storage-tiers.md`).

--- a/my-apps/maps/versatiles/config.yaml
+++ b/my-apps/maps/versatiles/config.yaml
@@ -1,0 +1,13 @@
+# versatiles server config (passed via `serve -c`). ONLY the cors section
+# lives here on purpose — sources, static frontend, and port stay on CLI args
+# because upstream documents config.yaml support as still maturing; keeping
+# this file single-purpose limits the blast radius if a future version changes
+# the schema. Patterns are regexes matched against the request Origin.
+cors:
+  default_policy: 'block'
+  allow_patterns:
+    # any https vanillax.me subdomain (maps itself, radar, home-assistant, ...)
+    - '^https://([a-z0-9-]+\.)?vanillax\.me$'
+    # local development (MapLibre dev servers on any port)
+    - '^https?://localhost(:[0-9]+)?$'
+    - '^https?://127\.0\.0\.1(:[0-9]+)?$'

--- a/my-apps/maps/versatiles/deployment.yaml
+++ b/my-apps/maps/versatiles/deployment.yaml
@@ -1,0 +1,113 @@
+# VersaTiles tile server + bundled upstream frontend, serving the planet
+# archive from the map-data PVC at maps.vanillax.me.
+#
+# The versatiles-frontend image's ENTRYPOINT is
+#   versatiles serve --static /app/frontend-dev.br.tar
+# so the k8s `args` APPEND to it — the effective command is
+#   versatiles serve --static /app/frontend-dev.br.tar -c /config/config.yaml /data/osm.versatiles
+# (verified against versatiles-docker's versatiles-frontend/Dockerfile).
+# Don't set `command:` — that would replace the entrypoint and drop the
+# bundled frontend.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: versatiles
+  namespace: versatiles
+  labels:
+    app.kubernetes.io/name: versatiles
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate  # RWO PVC — RollingUpdate deadlocks on Multi-Attach
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: versatiles
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: versatiles
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        # Block pod start until the map-bootstrap hook Job has populated the
+        # PVC, so a fresh deploy waits (~15-60min first download) instead of
+        # crashlooping on a missing archive.
+        - name: wait-for-map
+          image: busybox:1.38
+          command:
+            - sh
+            - -c
+            - |
+              echo "waiting for /data/osm.versatiles..."
+              until [ -s /data/osm.versatiles ]; do
+                sleep 5
+              done
+              echo "found archive, starting server"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: map-data
+              mountPath: /data
+              readOnly: true
+      containers:
+        - name: versatiles
+          image: versatiles/versatiles-frontend:v4.6.0@sha256:53d8b2056bd70b8a2291c5f609c1912f35483e5c89d5d38064b5248cb9fabc61
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-c"
+            - "/config/config.yaml"
+            - "/data/osm.versatiles"
+          ports:
+            - containerPort: 8080
+              name: http
+          # No dedicated health endpoint upstream; /tiles/index.json is served
+          # once the tile source is loaded, which is exactly "ready".
+          startupProbe:
+            httpGet:
+              path: /tiles/index.json
+              port: http
+            periodSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /tiles/index.json
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /tiles/index.json
+              port: http
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          volumeMounts:
+            - name: map-data
+              mountPath: /data
+              readOnly: true  # the bootstrap Job is the only writer
+            - name: config
+              mountPath: /config
+              readOnly: true
+      volumes:
+        - name: map-data
+          persistentVolumeClaim:
+            claimName: map-data
+        - name: config
+          configMap:
+            name: versatiles-config

--- a/my-apps/maps/versatiles/httproute.yaml
+++ b/my-apps/maps/versatiles/httproute.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: versatiles-route
+  namespace: versatiles
+  labels:
+    external-dns: "true"
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "vanillax.me"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-external
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - "maps.vanillax.me"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: versatiles
+          port: 8080
+          weight: 1

--- a/my-apps/maps/versatiles/job-bootstrap.yaml
+++ b/my-apps/maps/versatiles/job-bootstrap.yaml
@@ -1,0 +1,109 @@
+# One-shot-per-dataset Job that downloads the VersaTiles planet archive
+# (~62GB) onto the map-data PVC. The versatiles Deployment's init container
+# blocks pod start until the file exists, so Job and Deployment deploy
+# together — order doesn't matter.
+#
+# Why an ArgoCD hook and not a plain Job: as a plain resource,
+# ttlSecondsAfterFinished would GC the Job OBJECT a day after completion and
+# the AppSet's selfHeal would recreate it — the exact daily re-download loop
+# that burned radar-ng's basemap-bootstrap (see that Job's header). Hook
+# resources sit outside desired state, so selfHeal can't recreate them; the
+# marker fast-path below makes routine per-sync re-runs exit in seconds.
+#
+# Why a versioned snapshot URL (osm.YYYYMMDD) and not the mutable
+# /osm.versatiles alias: the versioned URL + its .sha256 sidecar make the
+# download reproducible and integrity-checked, and changing it in
+# kustomization.yaml IS the update trigger (hash-suffixed ConfigMap name
+# changes -> Job pod spec changes -> hook re-runs -> marker key mismatch ->
+# fresh download). See README.md for the full update/rollback flow.
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: map-bootstrap
+  namespace: versatiles
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  labels:
+    app.kubernetes.io/name: versatiles
+spec:
+  ttlSecondsAfterFinished: 86400  # hygiene only; hooks aren't selfHeal-recreated
+  backoffLimit: 4
+  activeDeadlineSeconds: 14400  # 4h ceiling for the ~62GB download
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: versatiles
+        job: map-bootstrap
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000  # non-root container writes to the PVC
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: download
+          # Same pinned alpine base the repo already uses; busybox wget +
+          # sha256sum are all this needs.
+          image: alpine:3@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              TARGET="/data/${TARGET_FILE}"
+              TMP="${TARGET}.tmp"
+              MARKER="/data/.bootstrap-marker"
+
+              # Fast path: the Sync hook re-runs this Job on every app sync.
+              # A successful download records its URL in a marker on the PVC;
+              # when it already matches there is nothing to do.
+              if [ -s "$TARGET" ] && [ -f "$MARKER" ] && [ "$(head -n1 "$MARKER")" = "$DATASET_URL" ]; then
+                echo "marker matches (${DATASET_URL}); archive already present, nothing to do"
+                exit 0
+              fi
+
+              echo "downloading ${DATASET_URL} -> ${TMP}"
+              rm -f "$TMP"
+              wget -q -O "$TMP" "$DATASET_URL"
+
+              echo "verifying sha256 (${DATASET_SHA256_URL})"
+              EXPECTED="$(wget -q -O - "$DATASET_SHA256_URL" | cut -d' ' -f1)"
+              ACTUAL="$(sha256sum "$TMP" | cut -d' ' -f1)"
+              if [ "$EXPECTED" != "$ACTUAL" ]; then
+                echo "FATAL: sha256 mismatch: expected ${EXPECTED}, got ${ACTUAL}" >&2
+                rm -f "$TMP"
+                exit 1
+              fi
+
+              # Atomic swap: same filesystem, so mv can't leave a partial
+              # file where the init container's non-empty check would see it.
+              # A running server keeps serving the OLD file via its open fd
+              # until the Deployment is restarted (documented in README.md).
+              mv -f "$TMP" "$TARGET"
+              printf '%s\nsize=%s downloaded=%s\n' "$DATASET_URL" "$(wc -c <"$TARGET")" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$MARKER"
+              echo "done: ${TARGET} ($(wc -c <"$TARGET") bytes)"
+          envFrom:
+            - configMapRef:
+                name: bootstrap-env
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: map-data
+              mountPath: /data
+      volumes:
+        - name: map-data
+          persistentVolumeClaim:
+            claimName: map-data

--- a/my-apps/maps/versatiles/kustomization.yaml
+++ b/my-apps/maps/versatiles/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: versatiles
+
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - job-bootstrap.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+
+configMapGenerator:
+  # Hash-suffixed names are the update mechanism: editing DATASET_URL below
+  # (or config.yaml) changes the generated name, which changes the consuming
+  # pod spec, which re-runs the bootstrap hook / restarts the server on the
+  # next sync. To refresh the planet: point DATASET_URL (+ sha256) at a newer
+  # osm.YYYYMMDD snapshot from https://download.versatiles.org/ — see README.
+  - name: versatiles-config
+    files:
+      - config.yaml
+  - name: bootstrap-env
+    literals:
+      - DATASET_URL=https://download.versatiles.org/osm.20260608.versatiles
+      - DATASET_SHA256_URL=https://download.versatiles.org/osm.20260608.versatiles.sha256
+      - TARGET_FILE=osm.versatiles

--- a/my-apps/maps/versatiles/namespace.yaml
+++ b/my-apps/maps/versatiles/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: versatiles

--- a/my-apps/maps/versatiles/pvc.yaml
+++ b/my-apps/maps/versatiles/pvc.yaml
@@ -1,0 +1,27 @@
+# Holds the active planet archive plus headroom for the atomic download-then-
+# rename swap in job-bootstrap.yaml (peak usage during a refresh is ~2x the
+# archive: old file still active + new file in .tmp). Default longhorn (NVMe)
+# class, NOT longhorn-flash: tile serving is read-dominated random byte-range
+# IO, and the NVMe tier out-reads the flash tier (161k vs 68k random-read IOPS
+# — see infrastructure/storage/longhorn/storageclass-flash.yaml "WHEN NOT to
+# use it"). NOT NFS/SMB: random small reads on HDD-NFS are the documented
+# catastrophe case (docs/domains/storage/storage-tiers.md).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: map-data
+  namespace: versatiles
+  labels:
+    backup-exempt: "true"
+  annotations:
+    storage.vanillax.dev/backup-exempt-reason: >-
+      ~62GB VersaTiles planet archive; re-downloadable from
+      download.versatiles.org by the map-bootstrap hook Job (sha256-verified);
+      backing it up would waste 62GB of kopia repo on public data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 150Gi

--- a/my-apps/maps/versatiles/service.yaml
+++ b/my-apps/maps/versatiles/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: versatiles
+  namespace: versatiles
+  labels:
+    app.kubernetes.io/name: versatiles
+spec:
+  selector:
+    app.kubernetes.io/name: versatiles
+  ports:
+    - name: http  # named port — HTTPRoute fails silently without it
+      port: 8080
+      targetPort: http


### PR DESCRIPTION
## Summary

Phase-1 shared map infrastructure: upstream **VersaTiles as-is** — no custom code, no custom images, no new repo.

- **App:** `my-apps/maps/versatiles/` → auto-discovered as `my-apps-versatiles`, namespace `versatiles` (new `maps/` category; AppSet globs `my-apps/*/*`, nothing to enumerate)
- **Image:** `versatiles/versatiles-frontend:v4.6.0` (digest-pinned; server + bundled upstream frontend). Its ENTRYPOINT already includes `serve --static <frontend>`, so k8s `args` just append the config + tile source — verified against the upstream Dockerfile.
- **Dataset:** `osm.20260608.versatiles` — official OSM planet, zoom 0–14, **62.0 GiB**, versioned snapshot URL + published sha256 (verified both URLs live). No auth, no key, ODbL attribution embedded.
- **Storage:** 150Gi `longhorn` (default NVMe class, single replica per repo values) — read-dominated random byte-range IO belongs on the NVMe tier per `storageclass-flash.yaml`'s own guidance; NOT flash (write tier), NOT NFS/SMB (random-IO-on-HDD-NFS is the documented radar-ng burn). Backup-exempt (re-downloadable, sha256-verified).
- **Bootstrap:** Sync-hook Job (`BeforeHookCreation` + PVC marker — the radar-ng pattern, avoiding its TTL/selfHeal daily-loop burn). Download → sha256 verify → atomic `mv`. Dataset refresh = bump `DATASET_URL` in the `configMapGenerator` (hash-suffix change re-runs the hook); rollback = point back at the older snapshot.
- **CORS:** app-side versatiles config (regex allowlist: `https://*.vanillax.me` + localhost dev). Config file carries ONLY the cors section; everything else stays on CLI args (upstream documents config support as maturing).
- **Route:** three-piece external HTTPRoute (`external-dns` label + target annotation + `sectionName: https`), named Service port.
- **RadarNG:** deliberately untouched. Future integration = MapLibre style URL (documented in README only).

## Validation done

- `kustomize build` renders clean (8 resources); ConfigMap hash suffixes propagate into the Job's `envFrom` and the Deployment's volume (the update trigger works)
- Rendered output greps confirm: hook annotations, all three HTTPRoute pieces, named port `http`, backup-exempt label + fully-qualified reason annotation
- Bootstrap script extracted from the render and `sh -n` clean (`set -eu`, busybox-compatible)
- Dataset + sha256 sidecar URLs return HTTP 200 (62,0 GiB content-length)
- Image digest resolved from Docker Hub and pinned

## Not verifiable until after merge

- First sync downloads 62 GiB — **the app will show Progressing ~15–60 min**; the server pod waits on its init container meanwhile. This is expected, not stuck.
- Exact shipped style IDs (`/assets/styles/…`) — README carries a marked TODO to fill in from the live instance (`curl https://maps.vanillax.me/tiles/index.json`, browse `/assets/`).
- `readOnlyRootFilesystem: true` against the real binary (upstream image runs from `/app`, works dir `/data`; if it crashloops wanting a writable tmp, add an emptyDir `/tmp` — one-line fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)