### PR TITLE
worldmonitor: fix redis arg syntax, require AISSTREAM_API_KEY

### DIFF
--- a/my-apps/media/worldmonitor/deployment-redis.yaml
+++ b/my-apps/media/worldmonitor/deployment-redis.yaml
@@ -32,10 +32,15 @@ spec:
                   key: REDIS_PASSWORD
           command:
             - redis-server
+          # redis-server rejects --flag=value syntax ("Bad directive") — each
+          # flag and its value must be separate args
           args:
-            - "--requirepass=$(REDIS_PASSWORD)"
-            - "--maxmemory=256mb"
-            - "--maxmemory-policy=allkeys-lru"
+            - "--requirepass"
+            - "$(REDIS_PASSWORD)"
+            - "--maxmemory"
+            - "256mb"
+            - "--maxmemory-policy"
+            - "allkeys-lru"
           ports:
             - name: redis
               containerPort: 6379

--- a/my-apps/media/worldmonitor/deployment-relay.yaml
+++ b/my-apps/media/worldmonitor/deployment-relay.yaml
@@ -40,6 +40,11 @@ spec:
                 secretKeyRef:
                   name: worldmonitor-secrets
                   key: RELAY_SHARED_SECRET
+            - name: AISSTREAM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: worldmonitor-secrets
+                  key: AISSTREAM_API_KEY
             - name: PORT
               value: "3004"
           ports:

--- a/my-apps/media/worldmonitor/externalsecret.yaml
+++ b/my-apps/media/worldmonitor/externalsecret.yaml
@@ -37,3 +37,9 @@ spec:
       remoteRef:
         key: worldmonitor
         property: redis_connection_string
+    # REQUIRED: the AIS relay exits at startup without it (scripts/ais-relay.cjs).
+    # Free key: https://aisstream.io
+    - secretKey: AISSTREAM_API_KEY
+      remoteRef:
+        key: worldmonitor
+        property: aisstream_api_key


### PR DESCRIPTION
Two startup crashloops found on first deploy of #1688:

- **Redis**: `redis-server` rejects `--flag=value` syntax (`Bad directive or wrong number of arguments`) — flags and values must be separate args. (docker-compose used space-separated form; the k8s translation introduced the `=`.)
- **AIS relay**: hard-exits at startup without `AISSTREAM_API_KEY` (`scripts/ais-relay.cjs` line 59-63, no graceful degrade). Wired from the 1Password item as a new required field.

**Before merging:** add the field to the 1Password item (free key from https://aisstream.io):
```bash
op item edit worldmonitor --vault homelab-prod "aisstream_api_key[password]=<YOUR_KEY>"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)