### PR TITLE
argocd: remove global HTTPRoute ignoreDifferences (argo-cd#25284 array freeze)

### DIFF
--- a/docs/domains/argocd/argocd.md
+++ b/docs/domains/argocd/argocd.md
@@ -173,7 +173,12 @@ sync). Directory paths and names are ordinary string templates.
 Generated Applications use:
 
 - `ServerSideApply=true` for explicit field ownership and large resources.
-- `RespectIgnoreDifferences=true` only with narrowly scoped ignore rules.
+- `RespectIgnoreDifferences=true` only with narrowly scoped ignore rules —
+  and never on array subfields (`.spec.foo[].bar`): argo-cd#25284 freezes the
+  whole array element during sync, so sibling-field changes (e.g. an HTTPRoute
+  `sectionName` pin) never apply while the app stays OutOfSync. The global
+  HTTPRoute ignore was removed for this on 2026-07-18; keep route manifests
+  explicit about `group`/`kind`/`weight` instead of ignoring the defaults.
 - `FailOnSharedResource=true` so a future directory/layout mistake cannot make
   two Applications fight over one Kubernetes object.
 - Bounded retry so a failed hook cannot pin the app-of-apps to a stale manifest

--- a/infrastructure/controllers/argocd/apps/appsets/my-apps-appset.yaml
+++ b/infrastructure/controllers/argocd/apps/appsets/my-apps-appset.yaml
@@ -93,7 +93,10 @@ spec:
             factor: 2
             maxDuration: 10m
       ignoreDifferences:
-      # HTTPRoute, ExternalSecret, and PVC restore diff noise is ignored globally.
+      # ExternalSecret and PVC restore diff noise is ignored globally.
+      # (The global HTTPRoute ignore was removed 2026-07-18: argo-cd#25284
+      # array-element freeze blocked parentRef sectionName syncs. Keep route
+      # manifests explicit about group/kind/weight instead — see values.yaml.)
       # App-level PVC ignores are still required because
       # RespectIgnoreDifferences=true only strips app ignore rules during sync;
       # otherwise immutable restore fields keep retrying forever on Bound PVCs.

--- a/infrastructure/controllers/argocd/values.yaml
+++ b/infrastructure/controllers/argocd/values.yaml
@@ -60,20 +60,22 @@ configs:
     # Global diff noise cleanup for resources normalized by their controllers.
     # Keep these system-level so AppSets only carry app-specific rules.
     #
-    # parentRefs: normalize ONLY the defaulted `group`/`kind` subfields that the
-    # API server fills in (gateway.networking.k8s.io / Gateway). Do NOT ignore the
-    # whole `/spec/parentRefs` array, and do NOT ignore whole parentRef entries
-    # via `select(.group == null or .kind == null)` — both silently swallow
-    # Gateway re-parenting (e.g. the gateway-internal -> gateway-internal-technitium
-    # split-DNS migration) while ArgoCD still reports Synced. `name`/`namespace`/
-    # `sectionName` MUST stay diffable so re-parenting actually syncs to live.
-    resource.customizations.ignoreDifferences.gateway.networking.k8s.io_HTTPRoute: |
-      jqPathExpressions:
-      - .spec.parentRefs[].group
-      - .spec.parentRefs[].kind
-      - .spec.rules[].backendRefs[].group
-      - .spec.rules[].backendRefs[].kind
-      - .spec.rules[].backendRefs[].weight
+    # HTTPRoute ignoreDifferences REMOVED 2026-07-18 — do not re-add.
+    # Argo CD bug argoproj/argo-cd#25284: with RespectIgnoreDifferences=true,
+    # an ignore rule on an array SUBFIELD (.spec.parentRefs[].group etc.)
+    # freezes the ENTIRE array element during sync — the desired element is
+    # replaced by the live one before apply. Diff still reports OutOfSync but
+    # sync never converges. Real casualty: #1681's `sectionName: https` pin on
+    # opentelemetry/otel-gateway silently never applied (11 selfHeal attempts,
+    # live spec generation stuck at 1). The same bug means backendRef port/name
+    # changes would not sync either while weight/kind are ignored.
+    # Noise the rule used to hide (API-defaulted group/kind/weight, upstream
+    # argo-cd#22151) is instead handled by keeping manifests EXPLICIT: all 60
+    # in-repo HTTPRoutes (58 files) now set parentRef group/kind and backendRef
+    # group/kind/weight in git (last implicit ones fixed 2026-07-18 alongside
+    # this removal). Keep it that way — omitting those fields in a new route
+    # will show as OutOfSync noise until you make them explicit.
+    # Chart-rendered routes that omit defaults may show the same benign noise.
     resource.customizations.ignoreDifferences.external-secrets.io_ExternalSecret: |
       jqPathExpressions:
       - .metadata.generation

--- a/infrastructure/storage/container-registry/httproute.yaml
+++ b/infrastructure/storage/container-registry/httproute.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: kube-system
 spec:
   parentRefs:
-    - name: gateway-internal-technitium
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-internal-technitium
       namespace: gateway
   hostnames:
     - "registry.vanillax.me"

--- a/my-apps/ai/perplexica/httproute.yaml
+++ b/my-apps/ai/perplexica/httproute.yaml
@@ -17,5 +17,8 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: perplexica
+        - group: ""
+          kind: Service
+          name: perplexica
           port: 3000
+          weight: 1

--- a/my-apps/ai/presenton/httproute.yaml
+++ b/my-apps/ai/presenton/httproute.yaml
@@ -21,3 +21,4 @@ spec:
       kind: Service
       name: presenton
       port: 80
+      weight: 1

--- a/my-apps/development/posthog/httproute.yaml
+++ b/my-apps/development/posthog/httproute.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: posthog
 spec:
   parentRefs:
-    - name: gateway-internal-technitium
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-internal-technitium
       namespace: gateway
       sectionName: https
   hostnames:
@@ -26,16 +28,22 @@ spec:
             type: PathPrefix
             value: /batch
       backendRefs:
-        - name: capture
+        - group: ""
+          kind: Service
+          name: capture
           port: 3000
+          weight: 1
     # Session replay capture (Rust)
     - matches:
         - path:
             type: PathPrefix
             value: /s
       backendRefs:
-        - name: replay-capture
+        - group: ""
+          kind: Service
+          name: replay-capture
           port: 3000
+          weight: 1
     # Feature flags + /decide (Rust) — required for session replay config
     - matches:
         - path:
@@ -45,8 +53,11 @@ spec:
             type: PathPrefix
             value: /flags
       backendRefs:
-        - name: feature-flags
+        - group: ""
+          kind: Service
+          name: feature-flags
           port: 3001
+          weight: 1
     # CDP webhooks
     - matches:
         - path:
@@ -56,16 +67,22 @@ spec:
             type: PathPrefix
             value: /public/m
       backendRefs:
-        - name: plugins
+        - group: ""
+          kind: Service
+          name: plugins
           port: 6738
+          weight: 1
     # Default - Django web UI/API
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: web
+        - group: ""
+          kind: Service
+          name: web
           port: 8000
+          weight: 1
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -78,7 +95,9 @@ metadata:
     external-dns.alpha.kubernetes.io/target: "vanillax.me"
 spec:
   parentRefs:
-    - name: gateway-external
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-external
       namespace: gateway
       sectionName: https
   hostnames:
@@ -98,15 +117,21 @@ spec:
             type: PathPrefix
             value: /batch
       backendRefs:
-        - name: capture
+        - group: ""
+          kind: Service
+          name: capture
           port: 3000
+          weight: 1
     - matches:
         - path:
             type: PathPrefix
             value: /s
       backendRefs:
-        - name: replay-capture
+        - group: ""
+          kind: Service
+          name: replay-capture
           port: 3000
+          weight: 1
     # Feature flags + /decide (Rust) — required for session replay config
     - matches:
         - path:
@@ -116,8 +141,11 @@ spec:
             type: PathPrefix
             value: /flags
       backendRefs:
-        - name: feature-flags
+        - group: ""
+          kind: Service
+          name: feature-flags
           port: 3001
+          weight: 1
     # CDP webhooks
     - matches:
         - path:
@@ -127,13 +155,19 @@ spec:
             type: PathPrefix
             value: /public/m
       backendRefs:
-        - name: plugins
+        - group: ""
+          kind: Service
+          name: plugins
           port: 6738
+          weight: 1
     # Default fallback to web
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: web
+        - group: ""
+          kind: Service
+          name: web
           port: 8000
+          weight: 1

--- a/my-apps/media/copyparty/httproute.yaml
+++ b/my-apps/media/copyparty/httproute.yaml
@@ -21,3 +21,4 @@ spec:
           kind: Service
           name: copyparty
           port: 3923
+          weight: 1

--- a/my-apps/media/immich/httproute.yaml
+++ b/my-apps/media/immich/httproute.yaml
@@ -5,15 +5,20 @@ metadata:
   namespace: immich
 spec:
   parentRefs:
-    - name: gateway-internal-technitium
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-internal-technitium
       namespace: gateway
       sectionName: https
   hostnames:
     - "photos.vanillax.me"
   rules:
     - backendRefs:
-        - name: immich-server
+        - group: ""
+          kind: Service
+          name: immich-server
           port: 2283
+          weight: 1
       matches:
         - path:
             type: PathPrefix


### PR DESCRIPTION
## Symptom

`opentelemetry-operator` app stuck OutOfSync on `HTTPRoute/otel-gateway` despite 11 selfHeal sync attempts, each reporting 'serverside-applied'. Live object never changed (spec generation stuck at 1 since Jun 28).

## Root cause

Known upstream bug **argoproj/argo-cd#25284** (open): with `RespectIgnoreDifferences=true`, an ignore rule on an **array subfield** (`.spec.parentRefs[].group`, `.spec.rules[].backendRefs[].weight`) freezes the **entire array element** during sync — the desired element is replaced by the live one before apply. The diff still reports OutOfSync, but sync never converges.

Casualty: **#1681's `sectionName: https` pin on otel-gateway never applied** — OTLP ingest has been binding the plain-HTTP :80 listener since last night, opposite the intent of the commit. Any future `parentRefs` change (re-parenting, the split-DNS migration) or `backendRefs` port/name change would silently not sync the same way. This directly contradicts the repo comment's own requirement ('sectionName MUST stay diffable so re-parenting actually syncs to live').

## Fix

- **Remove** `resource.customizations.ignoreDifferences.gateway.networking.k8s.io_HTTPRoute` from `values.yaml` (with a do-not-re-add comment explaining the bug).
- The rule existed to hide API-defaulting noise (`group`/`kind`/`weight`, upstream argo-cd#22151). Instead of ignoring, **make manifests explicit**: adds `group`/`kind`/`weight` to the 7 route files that relied on defaulting (posthog ×2 routes, immich, copyparty, perplexica, presenton, container-registry). Verified: **all 60 in-repo HTTPRoutes now fully explicit** (scripted check, missing=0).
- Stale comment in `my-apps-appset.yaml` updated; `docs/domains/argocd/argocd.md` gains the array-subfield caveat on its `RespectIgnoreDifferences` bullet.

## Validation

- All touched kustomizations render (`kustomize build --enable-helm`): argocd, argocd/apps, posthog, presenton, perplexica, immich, copyparty, container-registry ✅
- Rendered `argocd-cm` no longer contains the HTTPRoute key; ExternalSecret/PVC/CRD/OTel customizations intact ✅

## Post-merge verification

1. ArgoCD (self-managing) syncs `argocd-cm`.
2. `opentelemetry-operator` app selfHeals: `kubectl -n opentelemetry get httproute otel-gateway -o jsonpath='{.spec.parentRefs[0].sectionName}'` → `https`, generation bumps to 2, app goes **Synced**.
3. No app should show new OutOfSync noise (all routes explicit); if a chart-rendered route does, fix is to make its values/template explicit, NOT to re-add the ignore.

Note: ExternalSecret ignore rules (`.spec.data[].remoteRef.*`) are the same array-subfield shape and carry the same freeze risk for sibling `remoteRef` changes — left in place here since nothing is actively broken; worth a follow-up decision.