### PR TITLE
versatiles: move map archive to TrueNAS SMB (nuke-survivable)

### DIFF
--- a/my-apps/maps/versatiles/README.md
+++ b/my-apps/maps/versatiles/README.md
@@ -16,9 +16,16 @@ search, no routing.
 - **Dataset:** `osm.20260608.versatiles` — full planet, zoom 0–14, Shortbread
   schema, **62.0 GiB**, from <https://download.versatiles.org/> (free, no
   account, sha256-verified)
-- **Storage:** 150Gi PVC `map-data` on the default `longhorn` (NVMe) class —
-  62 GiB active + headroom for the atomic download-then-swap during refresh.
-  Backup-exempt (re-downloadable public data).
+- **Storage:** TrueNAS SMB share `//192.168.10.133/k8s/versatiles` via static
+  PV + PVC `map-data-smb` (comfyui pattern). **Chosen for nuke-survival:** the
+  archive + bootstrap marker live on the NAS, so a rebuilt cluster's bootstrap
+  Job finds them and exits in seconds — no 62 GiB re-download per rebuild.
+  Backup-exempt (the NAS copy is the durable copy). Perf tradeoff accepted:
+  random tile reads over SMB are slower than local NVMe; if it ever matters,
+  add a local cache tier in front — don't move the durable copy.
+  **One-time prereq:** create the `versatiles` folder inside the `k8s` SMB
+  share on TrueNAS before first deploy (Finder:
+  `smb://192.168.10.133/k8s` → New Folder `versatiles`).
 - **Image:** `versatiles/versatiles-frontend:v4.6.0` (server + bundled
   upstream frontend; Renovate manages bumps)
 
@@ -28,7 +35,7 @@ search, no routing.
 download.versatiles.org (osm.YYYYMMDD.versatiles + .sha256)
         │  map-bootstrap Job (ArgoCD Sync hook): download → verify → atomic mv
         ▼
-map-data PVC (150Gi longhorn)
+map-data-smb PVC → TrueNAS //192.168.10.133/k8s/versatiles (survives cluster rebuilds)
         │  read-only mount; init container blocks until archive exists
         ▼
 versatiles Deployment (serve -c config.yaml /data/osm.versatiles)
@@ -129,6 +136,9 @@ radar-ng app in this repo is intentionally untouched by this deployment.
 - Dataset refresh is a manual URL bump + rollout restart (no auto-cron yet).
 - No native Prometheus metrics upstream; coverage is the generic kube-state
   + ArgoCD sync/degraded alerts.
+- Tile serving reads randomly from the archive over SMB — noticeably slower
+  than local NVMe under load, accepted for cross-rebuild durability (see
+  Storage above).
 - Zoom is capped at 14 by the dataset (Shortbread planet); street-level
   detail renders fine because vector tiles overzoom client-side.
 
@@ -141,10 +151,11 @@ curl -I https://maps.vanillax.me                    # 200 + html
 curl -s https://maps.vanillax.me/tiles/index.json   # ["osm"]
 ```
 
-## Later: NAS/RustFS archival (not implemented)
+## Later: local speed tier (not implemented)
 
-If historical snapshots become worth keeping, stage `osm.YYYYMMDD.versatiles`
-files on TrueNAS (SMB/NFS share or RustFS bucket) as archive-only storage and
-keep serving from the local PVC — do not put network storage in the tile
-serving path (random byte-range reads; see
-`docs/domains/storage/storage-tiers.md`).
+Serving currently reads straight from the NAS share. If tile latency ever
+matters, add a local NVMe **cache/copy** in front (e.g. a longhorn PVC an
+init step rsyncs from the NAS copy) — the NAS stays the durable
+source-of-truth that survives cluster rebuilds; local storage would be pure
+cache. Historical `osm.YYYYMMDD` snapshots can also accumulate on the same
+share as cheap archive.

--- a/my-apps/maps/versatiles/deployment.yaml
+++ b/my-apps/maps/versatiles/deployment.yaml
@@ -107,7 +107,7 @@ spec:
       volumes:
         - name: map-data
           persistentVolumeClaim:
-            claimName: map-data
+            claimName: map-data-smb
         - name: config
           configMap:
             name: versatiles-config

--- a/my-apps/maps/versatiles/job-bootstrap.yaml
+++ b/my-apps/maps/versatiles/job-bootstrap.yaml
@@ -106,4 +106,4 @@ spec:
       volumes:
         - name: map-data
           persistentVolumeClaim:
-            claimName: map-data
+            claimName: map-data-smb

--- a/my-apps/maps/versatiles/pvc.yaml
+++ b/my-apps/maps/versatiles/pvc.yaml
@@ -1,27 +1,80 @@
-# Holds the active planet archive plus headroom for the atomic download-then-
-# rename swap in job-bootstrap.yaml (peak usage during a refresh is ~2x the
-# archive: old file still active + new file in .tmp). Default longhorn (NVMe)
-# class, NOT longhorn-flash: tile serving is read-dominated random byte-range
-# IO, and the NVMe tier out-reads the flash tier (161k vs 68k random-read IOPS
-# — see infrastructure/storage/longhorn/storageclass-flash.yaml "WHEN NOT to
-# use it"). NOT NFS/SMB: random small reads on HDD-NFS are the documented
-# catastrophe case (docs/domains/storage/storage-tiers.md).
+# NAS-backed (TrueNAS SMB) storage for the planet archive — chosen for
+# NUKE-SURVIVAL, not speed: the cluster gets rebuilt often, and the archive +
+# bootstrap marker living on the NAS means a fresh cluster's bootstrap Job
+# sees them and exits in seconds instead of re-downloading 62GB. The NAS copy
+# IS the durable copy; no kopiur backup needed.
+#
+# Perf tradeoff (accepted, "start slow then move fast"): tile serving is
+# random byte-range reads, the slow case on HDD-backed SMB
+# (docs/domains/storage/storage-tiers.md). Personal-traffic tile loads +
+# cache=loose + OS page cache make it tolerable; if it ever feels slow the
+# upgrade path is a local NVMe cache/copy tier in front — NOT moving the
+# durable copy off the NAS.
+#
+# Static PV with a FIXED share path (comfyui pattern), NOT a dynamic *-smb
+# class: dynamic provisioning creates a fresh pvc-<uuid> subdir per PVC, so a
+# rebuilt cluster would get an empty new folder and silently re-download —
+# defeating the survival goal.
+#
+# PREREQ (one-time, manual): the folder must exist on TrueNAS before the
+# mount succeeds — create `versatiles` inside the `k8s` SMB share
+# (Finder: smb://192.168.10.133/k8s → New Folder "versatiles").
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: versatiles-smb-pv
+spec:
+  capacity:
+    storage: 150Gi  # nominal; SMB doesn't enforce quota here
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - dir_mode=0775
+    - file_mode=0664
+    - uid=1000
+    - gid=1000
+    - vers=3.1.1
+    # SMB multichannel (enabled server-side on TrueNAS): 4 channels over 10G.
+    - max_channels=4
+    - noserverino
+    - cache=loose
+    - rsize=4194304
+    - wsize=4194304
+    - actimeo=60
+    - echo_interval=60
+    - max_credits=64
+  csi:
+    driver: smb.csi.k8s.io
+    volumeHandle: versatiles-smb-pv
+    volumeAttributes:
+      source: "//192.168.10.133/k8s/versatiles"
+    nodeStageSecretRef:
+      name: smbcreds
+      namespace: csi-driver-smb
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: map-data
+  # -smb suffix: renamed from the original longhorn `map-data` when storage
+  # moved local→NAS. PVC spec (volumeName/storageClass) is immutable, so a
+  # rename lets ArgoCD create/prune cleanly instead of wedging on an
+  # in-place patch (same lesson as comfyui's NFS→SMB move).
+  name: map-data-smb
   namespace: versatiles
   labels:
     backup-exempt: "true"
   annotations:
     storage.vanillax.dev/backup-exempt-reason: >-
-      ~62GB VersaTiles planet archive; re-downloadable from
-      download.versatiles.org by the map-bootstrap hook Job (sha256-verified);
-      backing it up would waste 62GB of kopia repo on public data
+      lives on the TrueNAS k8s/versatiles SMB share, which is itself the
+      durable cross-rebuild copy; also re-downloadable from
+      download.versatiles.org (sha256-verified) if the NAS copy is lost
 spec:
   accessModes:
-    - ReadWriteOnce
-  storageClassName: longhorn
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: versatiles-smb-pv
   resources:
     requests:
       storage: 150Gi


### PR DESCRIPTION
## Summary

Storage decision reversed by operator priority: cluster gets nuked often, so **cross-rebuild durability beats read latency**. The 62 GiB planet archive + bootstrap marker move from a longhorn PVC to the TrueNAS SMB share `//192.168.10.133/k8s/versatiles` (static PV + PVC, comfyui pattern, uid=1000 mount options + 10G SMB tuning).

- After a cluster rebuild, the bootstrap hook Job sees the existing archive + marker on the NAS and exits in seconds — **no re-download per nuke**. The NAS copy is the durable copy (backup-exempt reason updated accordingly).
- **Static PV, not a dynamic `*-smb` class**: dynamic provisioning creates a fresh `pvc-<uuid>` subdir per claim, so a rebuilt cluster would get an empty folder and silently re-download — defeating the goal.
- PVC renamed `map-data` → `map-data-smb` (immutable spec; rename lets ArgoCD create/prune cleanly — the documented comfyui NFS→SMB lesson). The old longhorn PVC (mid-first-download, no completed data) gets pruned.
- README documents the accepted perf tradeoff and the future upgrade path (local NVMe *cache* in front; durable copy stays on NAS).

## ⚠️ One-time prereq BEFORE merging

Create the folder on TrueNAS or the SMB mount fails and pods sit in ContainerCreating:

**Finder → `smb://192.168.10.133/k8s` → New Folder → `versatiles`**

## After merge

Sync recreates the hook Job against the NAS PVC → fresh 62 GiB download (15–60 min, app Progressing) → server starts. Every rebuild after this one skips the download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)