### PR TITLE
worldmonitor: bump images to sha-b8ada8f (self-host Pro unlock)

### DIFF
--- a/my-apps/media/worldmonitor/deployment-app.yaml
+++ b/my-apps/media/worldmonitor/deployment-app.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: worldmonitor
-          image: ghcr.io/mitchross/worldmonitor:sha-b8bc626
+          image: ghcr.io/mitchross/worldmonitor:sha-b8ada8f
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/my-apps/media/worldmonitor/deployment-redis-rest.yaml
+++ b/my-apps/media/worldmonitor/deployment-redis-rest.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: redis-rest
-          image: ghcr.io/mitchross/worldmonitor-redis-rest:sha-b8bc626
+          image: ghcr.io/mitchross/worldmonitor-redis-rest:sha-b8ada8f
           imagePullPolicy: IfNotPresent
           env:
             - name: SRH_TOKEN

--- a/my-apps/media/worldmonitor/deployment-relay.yaml
+++ b/my-apps/media/worldmonitor/deployment-relay.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: ais-relay
-          image: ghcr.io/mitchross/worldmonitor-relay:sha-b8bc626
+          image: ghcr.io/mitchross/worldmonitor-relay:sha-b8ada8f
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Picks up [mitchross/worldmonitor#2](https://github.com/mitchross/worldmonitor/pull/2): `VITE_SELF_HOSTED=true` is baked into the self-hosted app image, so `isProUser()` returns true — all Pro-gated panels unlock and the "Upgrade to Pro" card hides itself. Only `latest-brief` stays gated (bound to a Clerk userId server-side).

Merge after the fork's publish workflow finishes building `sha-b8ada8f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)