### PR TITLE
versatiles: make planet download resumable

### DIFF
--- a/my-apps/maps/versatiles/job-bootstrap.yaml
+++ b/my-apps/maps/versatiles/job-bootstrap.yaml
@@ -67,9 +67,24 @@ spec:
                 exit 0
               fi
 
+              # The origin drops long single-stream transfers ("wget:
+              # connection closed prematurely"); with set -e each drop killed
+              # the container, OnFailure restarted it, and the rm -f started
+              # over from byte 0 — the 62GB download could never finish.
+              # Resume with wget -c in a bounded loop; a stale partial from a
+              # different DATASET_URL is caught by the sha256 check below
+              # (mismatch deletes the tmp, next run starts clean).
               echo "downloading ${DATASET_URL} -> ${TMP}"
-              rm -f "$TMP"
-              wget -q -O "$TMP" "$DATASET_URL"
+              attempt=0
+              while ! wget -q -c -O "$TMP" "$DATASET_URL"; do
+                attempt=$((attempt + 1))
+                if [ "$attempt" -ge 200 ]; then
+                  echo "FATAL: download did not complete after ${attempt} resume attempts" >&2
+                  exit 1
+                fi
+                echo "connection dropped at $(wc -c <"$TMP" 2>/dev/null || echo 0) bytes, resuming (attempt ${attempt})"
+                sleep 5
+              done
 
               echo "verifying sha256 (${DATASET_SHA256_URL})"
               EXPECTED="$(wget -q -O - "$DATASET_SHA256_URL" | cut -d' ' -f1)"


### PR DESCRIPTION
The bootstrap job could never finish: download.versatiles.org drops long single-stream transfers (`wget: connection closed prematurely`), `set -e` killed the container, `OnFailure` restarted it, and the script's `rm -f` restarted the 62GB download from byte 0 every time. Both the old longhorn-era job and the current SMB job died this way (verified via `kubectl logs --previous`).

Fix: bounded `wget -c` resume loop — partial progress on the SMB PVC survives container restarts and pod recreation. The existing sha256 verification still gates the atomic swap, and a stale partial from a changed `DATASET_URL` fails that check and cleans itself up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)