### PR TITLE
versatiles: fix cors config for the real v4.6.0 schema

### DIFF
--- a/my-apps/maps/versatiles/config.yaml
+++ b/my-apps/maps/versatiles/config.yaml
@@ -2,12 +2,15 @@
 # lives here on purpose — sources, static frontend, and port stay on CLI args
 # because upstream documents config.yaml support as still maturing; keeping
 # this file single-purpose limits the blast radius if a future version changes
-# the schema. Patterns are regexes matched against the request Origin.
+# the schema.
+#
+# v4.6.0 schema (from `versatiles help config`): allowed_origins entries are
+# exact origins, domain globs, or /slash-enclosed/ regexes. Origins not in the
+# list are blocked — there is no separate default_policy field.
 cors:
-  default_policy: 'block'
-  allow_patterns:
+  allowed_origins:
     # any https vanillax.me subdomain (maps itself, radar, home-assistant, ...)
-    - '^https://([a-z0-9-]+\.)?vanillax\.me$'
+    - '/^https://([a-z0-9-]+\.)?vanillax\.me$/'
     # local development (MapLibre dev servers on any port)
-    - '^https?://localhost(:[0-9]+)?$'
-    - '^https?://127\.0\.0\.1(:[0-9]+)?$'
+    - '/^https?://localhost(:[0-9]+)?$/'
+    - '/^https?://127\.0\.0\.1(:[0-9]+)?$/'


### PR DESCRIPTION
The tile server crashlooped as soon as the 66GB archive landed: `cors: unknown field 'default_policy'` — the config was written for a schema versatiles v4.6.0 doesn't have. Verified the real schema by running `versatiles help config` in the actual image: `allowed_origins` (exact origins, domain globs, or `/slash-enclosed/` regexes) + `max_age_seconds`; unlisted origins are blocked by default, so the old `default_policy: block` intent is preserved.

Same origins as before: any https vanillax.me subdomain + localhost/127.0.0.1 dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)