### PR TITLE
argocd: 1h repo-server manifest cache TTL + stale-cache runbook

### DIFF
--- a/docs/domains/argocd/argocd.md
+++ b/docs/domains/argocd/argocd.md
@@ -301,6 +301,52 @@ revert your fix on the next reconcile. Three escalation levels, smallest first:
    Nothing reconciles, nothing prunes, UI still shows (stale) state. Resume
    triggers a full re-compare against current git — equivalent to a fresh sync.
 
+## Runbook: App "Synced" at HEAD but Cluster Runs an Older Commit
+
+**Symptom (2026-07-19 incident):** merged commits never reach the cluster.
+The Application reports `Synced` at the latest revision, but live resources
+match a prior commit (e.g. a configMapGenerator hash never changes, an image
+bump never rolls). Hard refresh does not help. Upstream: open bug
+[argoproj/argo-cd#26530](https://github.com/argoproj/argo-cd/issues/26530) —
+the repo-server caches manifests rendered from a stale checkout under the new
+revision's cache key, and the poisoned entry survives hard refresh and the
+hourly `timeout.hard.reconciliation`.
+
+**Confirm** (expected result: repeated cache hits for the app path at the
+current revision even while you issue hard refreshes):
+```bash
+kubectl -n argocd logs deploy/argocd-repo-server --since=10m | grep "manifest cache hit"
+```
+
+**Remediate** (safe — both are stateless cache/render components; ~30s of
+sync unavailability, no workload impact):
+```bash
+kubectl -n argocd rollout restart deploy/argocd-repo-server deploy/argocd-redis
+kubectl -n argocd rollout status deploy/argocd-repo-server
+kubectl -n argocd annotate application <app> argocd.argoproj.io/refresh=hard --overwrite
+```
+Recovery is immediate: the next render is fresh, the app goes `OutOfSync`,
+and automated sync applies the real HEAD.
+
+**Bound the blast radius:** `reposerver.repo.cache.expiration: "1h"` in
+`values.yaml` (`configs.params`) caps how long a poisoned entry can live
+(default was 24h). Distinct from the 2026-05-29 stale *live-state* cache
+incident that motivated `timeout.hard.reconciliation` — that knob does not
+clear this cache.
+
+**Two adjacent gotchas discovered in the same incident:**
+- Editing **only a hook resource** (e.g. `argocd.argoproj.io/hook: Sync` Jobs)
+  never makes an app OutOfSync — hooks sit outside desired state, so the change
+  only applies on the next *sync operation*. Force one:
+  ```bash
+  kubectl -n argocd patch application <app> --type merge \
+    -p '{"operation":{"initiatedBy":{"username":"manual"},"sync":{"prune":true}}}'
+  ```
+- A running sync operation **blocks** while waiting on an in-flight hook Job,
+  and no new operation can start. If the hook can't finish, delete the Job
+  (`kubectl delete job <hook-job>`) — the op fails, then a fresh sync recreates
+  the hook from the current spec (`BeforeHookCreation`).
+
 ## Related Docs
 
 - [ArgoCD entrypoints](entrypoints.md)

--- a/infrastructure/controllers/argocd/values.yaml
+++ b/infrastructure/controllers/argocd/values.yaml
@@ -8,6 +8,16 @@ configs:
     controller.operation.processors: "25"
     # Performance: limit concurrent manifest generations to prevent OOM
     reposerver.parallelism.limit: "5"
+    # Redis manifest-cache TTL (default 24h). 2026-07-19: repo-server cached
+    # manifests rendered from a STALE checkout under the NEW revision's cache
+    # key — apps reported Synced at HEAD while the cluster ran a prior commit
+    # (versatiles configmap never rolled, worldmonitor image bump ignored).
+    # Even hard refresh kept logging "manifest cache hit" for the poisoned
+    # entry; the hourly timeout.hard.reconciliation (below) could not clear it
+    # either. Only restarting argocd-repo-server + argocd-redis recovered.
+    # Upstream (argoproj/argo-cd#26530) is open with no fixed release, so
+    # bound the poison window to 1h instead of 24h.
+    reposerver.repo.cache.expiration: "1h"
     # Performance: increase repo-server timeout for large Helm charts like prometheus-stack
     controller.repo.server.timeout.seconds: "300"
     # Server-Side Diff — controller asks the API server for a dry-run apply


### PR DESCRIPTION
## What happened (2026-07-19)

Apps reported **Synced at HEAD while the cluster ran an older commit**: the versatiles CORS-fix ConfigMap never rolled (server crashlooped 19h / 193 restarts on the already-fixed config) and a worldmonitor image bump was ignored. `argocd-repo-server` logged `manifest cache hit` for the **new** revision even under hard refresh — the cache entry had been rendered from a stale checkout but keyed to the new revision. Neither hard refresh nor the hourly `timeout.hard.reconciliation` (added after the 2026-05-29 live-state-cache incident — that's a different cache) could clear it. Only `rollout restart deploy/argocd-repo-server deploy/argocd-redis` recovered, instantly.

Upstream: [argoproj/argo-cd#26530](https://github.com/argoproj/argo-cd/issues/26530) — open, no fixed release (we're on v3.4.5).

## Changes

- `values.yaml`: `reposerver.repo.cache.expiration: "1h"` — caps how long a poisoned manifest-cache entry can live (default 24h). Cost: at most one extra render per app per hour.
- `docs/domains/argocd/argocd.md`: detect/remediate runbook (symptom → `grep "manifest cache hit"` → restart repo-server+redis), plus two adjacent gotchas verified in the same incident: hook-only edits never mark an app OutOfSync (need an explicit sync operation), and a sync op blocked on a running hook Job wedges all future ops until the Job is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)