### PR TITLE
fix(frigate): patient restream preset for go2rtc Nest cold-start

### DIFF
--- a/my-apps/home/frigate/config.yml
+++ b/my-apps/home/frigate/config.yml
@@ -54,6 +54,12 @@ ffmpeg:
   # profile per stream. Detection stays OpenVINO-on-CPU — Frigate 0.17's
   # TensorRT detector needs Turing+, not Pascal.
   hwaccel_args: preset-nvidia
+# Cameras use preset-rtsp-restream (NOT the -low-latency variant): go2rtc's
+# nest producers cold-start on first consumer, and the low-latency preset's
+# nobuffer probing gives up before the Nest WebRTC negotiation finishes —
+# every camera then loops "Invalid data found when processing input" forever
+# (verified live 2026-07-19: warming a producer via the go2rtc API instantly
+# unstuck the camera). The patient preset rides out the cold start.
 # go2rtc with Nest cameras via direct SDM API
 # Using the correct echo:curl syntax from official documentation
 go2rtc:
@@ -92,7 +98,7 @@ cameras:
   backyard:
     enabled: true
     ffmpeg:
-      input_args: preset-rtsp-restream-low-latency
+      input_args: preset-rtsp-restream
       inputs:
       - path: rtsp://127.0.0.1:8554/backyard-nest?video
         roles:
@@ -114,7 +120,7 @@ cameras:
   garage-inside:
     enabled: true
     ffmpeg:
-      input_args: preset-rtsp-restream-low-latency
+      input_args: preset-rtsp-restream
       inputs:
       - path: rtsp://127.0.0.1:8554/garage-inside-nest?video
         roles:
@@ -134,7 +140,7 @@ cameras:
   garage-outside:
     enabled: true
     ffmpeg:
-      input_args: preset-rtsp-restream-low-latency
+      input_args: preset-rtsp-restream
       inputs:
       - path: rtsp://127.0.0.1:8554/garage-outside-nest?video
         roles:
@@ -154,7 +160,7 @@ cameras:
   front-porch:
     enabled: true
     ffmpeg:
-      input_args: preset-rtsp-restream-low-latency
+      input_args: preset-rtsp-restream
       inputs:
       - path: rtsp://127.0.0.1:8554/front-porch-nest?video
         roles:
@@ -189,7 +195,7 @@ cameras:
   living-room:
     enabled: true
     ffmpeg:
-      input_args: preset-rtsp-restream-low-latency
+      input_args: preset-rtsp-restream
       inputs:
       - path: rtsp://127.0.0.1:8554/living-room-nest?video
         roles:
@@ -210,7 +216,7 @@ cameras:
   kitchen:
     enabled: true
     ffmpeg:
-      input_args: preset-rtsp-restream-low-latency
+      input_args: preset-rtsp-restream
       inputs:
       - path: rtsp://127.0.0.1:8554/kitchen-nest?video
         roles:


### PR DESCRIPTION
All six cameras showed **No frames received** even after #1708 stabilized the pod. Root cause chain, verified live in-pod:

1. go2rtc's `nest:` producers are **on-demand** — they negotiate SDM/WebRTC only when the first consumer connects (takes seconds).
2. `preset-rtsp-restream-low-latency`'s nobuffer probing gives up before that negotiation finishes → ffmpeg logs `Invalid data found when processing input` → disconnects → producer tears down → next retry is cold again. Infinite loop.
3. Proof: warming `backyard-nest` via the go2rtc API instantly brought that camera to **5.0 fps** while the other five stayed at 0; warming the rest brought them up too.

The Nest WebRTC path itself is fully healthy (OAuth good, H264 flowing — 13MB+ per producer measured; RTP confirmed arriving at the node via tcpdump; Hubble shows to-endpoint FORWARDED, no drops).

This switches the six cameras to the plain `preset-rtsp-restream` (the preset Frigate documents for go2rtc restreams), which rides out the cold start. Streams are currently up only because I hand-warmed them — this makes it survive pod restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)