### PR TITLE
fix(frigate): roll back to 0.17.1 (last-known-good Nest stack)

### DIFF
--- a/my-apps/home/frigate/config.yml
+++ b/my-apps/home/frigate/config.yml
@@ -122,7 +122,7 @@ cameras:
     ffmpeg:
       input_args: preset-rtsp-restream
       inputs:
-      - path: rtsp://127.0.0.1:8554/backyard-restream
+      - path: rtsp://127.0.0.1:8554/backyard-nest?video
         roles:
         - detect
         - record
@@ -144,7 +144,7 @@ cameras:
     ffmpeg:
       input_args: preset-rtsp-restream
       inputs:
-      - path: rtsp://127.0.0.1:8554/garage-inside-restream
+      - path: rtsp://127.0.0.1:8554/garage-inside-nest?video
         roles:
         - detect
         - record
@@ -164,7 +164,7 @@ cameras:
     ffmpeg:
       input_args: preset-rtsp-restream
       inputs:
-      - path: rtsp://127.0.0.1:8554/garage-outside-restream
+      - path: rtsp://127.0.0.1:8554/garage-outside-nest?video
         roles:
         - detect
         - record
@@ -184,7 +184,7 @@ cameras:
     ffmpeg:
       input_args: preset-rtsp-restream
       inputs:
-      - path: rtsp://127.0.0.1:8554/front-porch-restream
+      - path: rtsp://127.0.0.1:8554/front-porch-nest?video
         roles:
         - detect
         - record
@@ -219,7 +219,7 @@ cameras:
     ffmpeg:
       input_args: preset-rtsp-restream
       inputs:
-      - path: rtsp://127.0.0.1:8554/living-room-restream
+      - path: rtsp://127.0.0.1:8554/living-room-nest?video
         roles:
         - detect
         - record
@@ -240,7 +240,7 @@ cameras:
     ffmpeg:
       input_args: preset-rtsp-restream
       inputs:
-      - path: rtsp://127.0.0.1:8554/kitchen-restream
+      - path: rtsp://127.0.0.1:8554/kitchen-nest?video
         roles:
         - detect
         - record

--- a/my-apps/home/frigate/deployment.yaml
+++ b/my-apps/home/frigate/deployment.yaml
@@ -23,7 +23,14 @@ spec:
       runtimeClassName: nvidia
       containers:
       - name: frigate
-        image: ghcr.io/blakeblackshear/frigate:0.17.2
+        # 0.17.2 rolled back to 0.17.1: the 0.17.2 bump auto-merged 2026-06-28 while
+        # frigate sat at replicas:0 and its first real run (2026-07-19) could never
+        # decode the Nest WebRTC streams (keyframe starvation on every consumer
+        # type; go2rtc 1.9.9/1.9.10/1.9.14 all identical). 0.17.1 is the stack
+        # that demonstrably served these cameras through April 2026. Keep Renovate
+        # off this until the regression is bisected.
+        # renovate: ignore
+        image: ghcr.io/blakeblackshear/frigate:0.17.1
         imagePullPolicy: IfNotPresent
         env:
         - name: TZ


### PR DESCRIPTION
Decisive experiment after tonight's forensics. **0.17.2 never served these cameras** — it auto-merged while frigate sat at `replicas: 0` (April 27 → tonight). Its first run starves every consumer of keyframes: P-frames flow, SPS/PPS/IDR only exist in the first seconds of each Nest WebRTC session, and nothing recovers.

Ruled out with live evidence tonight: Nest OAuth (producers continuously pull H264), the Wi-Fi/media-bridge path (0% loss; RTP confirmed at node and pod), restream presets (#1710), ffmpeg 5.0 vs 7.0, go2rtc 1.9.9 / 1.9.10 / 1.9.14, and wrapper transcode streams (#1712 — inherits the same starvation).

This rolls the image to **0.17.1** and returns camera inputs to the April-proven direct `*-nest?video` form (wrapper streams stay defined but unused). `renovate: ignore` pins it until the regression is bisected. The debug go2rtc binary override has been removed from /config, so whatever image runs uses its bundled pairing.

**If 0.17.1 works:** regression bounded to the 0.17.2 image → bisect later at leisure.
**If 0.17.1 also fails:** the environment changed (prime suspect: Google altered Nest WebRTC keyframe/PLI behavior since April — would affect other users; check frigate/go2rtc issue trackers for June–July reports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)