### PR TITLE
fix(frigate): enable GO2RTC_ALLOW_ARBITRARY_EXEC for Nest AUD wrappers

### DIFF
--- a/my-apps/home/frigate/deployment.yaml
+++ b/my-apps/home/frigate/deployment.yaml
@@ -39,6 +39,13 @@ spec:
         # (compute,utility) leaves ffmpeg hwaccel without the decoder libs.
         - name: NVIDIA_DRIVER_CAPABILITIES
           value: "compute,video,utility"
+        # Frigate 0.17 disables go2rtc exec: sources by default (security). The
+        # Nest cameras REQUIRE the exec ffmpeg wrapper streams (config.yml
+        # *-restream: AUD insertion for the AUD-less Nest H264) — without this
+        # var go2rtc silently strips every wrapper and cameras get no frames.
+        # The exec commands are static and repo-controlled, so this is safe here.
+        - name: GO2RTC_ALLOW_ARBITRARY_EXEC
+          value: "true"
         - name: FRIGATE_MQTT_USER
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## The last blocker
#1719 added the correct exec ffmpeg wrappers (AUD insertion for Nest's AUD-less H264 — validated: 132 decoded frames), but Frigate 0.17 **disables go2rtc `exec:` sources by default for security**. go2rtc logged:

```
Stream 'backyard-restream' uses a restricted source (exec) which is disabled by default for security.
Set GO2RTC_ALLOW_ARBITRARY_EXEC=true to enable arbitrary exec sources.
Stream 'backyard-restream' was removed because all sources were restricted.
```

So all six wrappers were silently stripped from the generated go2rtc config, and Frigate's ffmpeg failed with `Error opening input file rtsp://127.0.0.1:8554/backyard-restream` → 0 fps. Confirmed by inspecting `/dev/shm/go2rtc.yaml` in the pod (only `*-nest` streams present, no `*-restream`).

## Fix
Add `GO2RTC_ALLOW_ARBITRARY_EXEC=true` to the Frigate deployment env. The exec commands are static and defined in `config.yml` in this repo (not user/remote input), so enabling them is safe — it's the exact remedy go2rtc's error names.

## After merge
This should complete the Nest camera fix (root cause chain: config-rot #1708 → wrong wrapper tool #1710/#1712 → AUD-insert wrappers #1719 → **this: let go2rtc run them**). Watch all six reach real fps once the exec wrappers warm the on-demand Nest producers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)