### PR TITLE
versatiles: serve /styles via a separate HTTPRoute (fix ArgoCD ignoreDifferences flap)

### DIFF
--- a/my-apps/maps/versatiles/httproute-styles.yaml
+++ b/my-apps/maps/versatiles/httproute-styles.yaml
@@ -1,17 +1,6 @@
-# Separate HTTPRoute for the pre-generated MapLibre styles (map-styles nginx).
-#
-# Why its own route instead of a second rule on versatiles-route: adding a rule
-# to an EXISTING route's `.spec.rules` array does not sync in this cluster —
-# ArgoCD's global HTTPRoute ignoreDifferences (`.spec.rules[].backendRefs[]`) +
-# ServerSideApply + Cilium co-managing the route makes an array-length change
-# flap and revert (argo-cd#25284). A freshly CREATED single-rule route is not
-# subject to that (versatiles-route itself proves single-rule routes sync fine).
-#
-# Gateway API merges HTTPRoutes that share a hostname on the same listener and
-# resolves by path precedence, so `/styles/*` here wins over versatiles-route's
-# `/`. DNS for maps.vanillax.me is already owned by versatiles-route's
-# external-dns label — this route intentionally omits external-dns to avoid a
-# duplicate-owner conflict; it only needs the parentRef + hostname to attach.
+# /styles/* -> map-styles nginx. Separate route from versatiles-route (Gateway
+# API merges same-hostname routes by path precedence). DNS owned by
+# versatiles-route, so no external-dns label here.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/my-apps/maps/versatiles/httproute-styles.yaml
+++ b/my-apps/maps/versatiles/httproute-styles.yaml
@@ -1,0 +1,39 @@
+# Separate HTTPRoute for the pre-generated MapLibre styles (map-styles nginx).
+#
+# Why its own route instead of a second rule on versatiles-route: adding a rule
+# to an EXISTING route's `.spec.rules` array does not sync in this cluster —
+# ArgoCD's global HTTPRoute ignoreDifferences (`.spec.rules[].backendRefs[]`) +
+# ServerSideApply + Cilium co-managing the route makes an array-length change
+# flap and revert (argo-cd#25284). A freshly CREATED single-rule route is not
+# subject to that (versatiles-route itself proves single-rule routes sync fine).
+#
+# Gateway API merges HTTPRoutes that share a hostname on the same listener and
+# resolves by path precedence, so `/styles/*` here wins over versatiles-route's
+# `/`. DNS for maps.vanillax.me is already owned by versatiles-route's
+# external-dns label — this route intentionally omits external-dns to avoid a
+# duplicate-owner conflict; it only needs the parentRef + hostname to attach.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: map-styles-route
+  namespace: versatiles
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-external
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - "maps.vanillax.me"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /styles
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: map-styles
+          port: 8080
+          weight: 1

--- a/my-apps/maps/versatiles/httproute.yaml
+++ b/my-apps/maps/versatiles/httproute.yaml
@@ -17,13 +17,7 @@ spec:
   hostnames:
     - "maps.vanillax.me"
   rules:
-    # NOTE: /styles/* is served by a SEPARATE HTTPRoute (httproute-styles.yaml),
-    # NOT a second rule here. Adding a rule to this existing route's array does
-    # not sync: ArgoCD's global HTTPRoute ignoreDifferences (on
-    # .spec.rules[].backendRefs[]) + ServerSideApply + Cilium co-management makes
-    # array-length changes flap and revert (argo-cd#25284). A fresh single-rule
-    # route creates cleanly; Gateway API merges routes on the same hostname by
-    # path precedence, so /styles still wins over "/".
+    # /styles/* is a separate route (httproute-styles.yaml).
     - matches:
         - path:
             type: PathPrefix

--- a/my-apps/maps/versatiles/httproute.yaml
+++ b/my-apps/maps/versatiles/httproute.yaml
@@ -17,19 +17,13 @@ spec:
   hostnames:
     - "maps.vanillax.me"
   rules:
-    # Pre-generated MapLibre style JSONs (map-styles nginx). More specific than
-    # "/", so Gateway API routes /styles/* here and everything else to the
-    # versatiles server below.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /styles
-      backendRefs:
-        - group: ""
-          kind: Service
-          name: map-styles
-          port: 8080
-          weight: 1
+    # NOTE: /styles/* is served by a SEPARATE HTTPRoute (httproute-styles.yaml),
+    # NOT a second rule here. Adding a rule to this existing route's array does
+    # not sync: ArgoCD's global HTTPRoute ignoreDifferences (on
+    # .spec.rules[].backendRefs[]) + ServerSideApply + Cilium co-management makes
+    # array-length changes flap and revert (argo-cd#25284). A fresh single-rule
+    # route creates cleanly; Gateway API merges routes on the same hostname by
+    # path precedence, so /styles still wins over "/".
     - matches:
         - path:
             type: PathPrefix

--- a/my-apps/maps/versatiles/kustomization.yaml
+++ b/my-apps/maps/versatiles/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - style-server.yaml
   - style-server-service.yaml
   - httproute.yaml
+  - httproute-styles.yaml
 
 configMapGenerator:
   # Hash-suffixed names are the update mechanism: editing DATASET_URL below


### PR DESCRIPTION
## Problem

[#1720](https://github.com/mitchross/talos-argocd-proxmox/pull/1720) added `/styles` as a **second rule on the existing `versatiles-route`** — but it never actually synced. The app sits `OutOfSync` while ArgoCD reports the sync "Succeeded", and `https://maps.vanillax.me/styles/*` returns **404** (served by versatiles, not the `map-styles` nginx). The added rule flaps in and reverts.

Root cause: this cluster has a **global `ignoreDifferences` on `HTTPRoute`** (`argocd-cm`, covering `.spec.rules[].backendRefs[].{group,kind,weight}`). Combined with `ServerSideApply` + Cilium co-managing the route, **mutating an existing route's `rules` array** hits [argo-cd#25284](https://github.com/argoproj/argo-cd/issues/25284) — the array-length change can't be applied consistently.

## Fix

Move `/styles` to its **own single-rule HTTPRoute** (`map-styles-route`) instead of adding a rule to `versatiles-route`:
- A **freshly created** single-rule route isn't subject to the array-mutation bug — `versatiles-route` itself proves single-rule routes sync fine.
- Gateway API **merges HTTPRoutes on the same hostname** and resolves by **path precedence**, so `/styles/*` still wins over `versatiles-route`'s `/`.
- `versatiles-route` reverts to its original single `/` rule.
- The new route **omits `external-dns`** (DNS for `maps.vanillax.me` is already owned by `versatiles-route`) to avoid a duplicate-owner conflict; it only needs the `parentRef` + hostname to attach.

## Verification

- `map-styles` nginx already serves correctly in-cluster (200, `application/json`, CORS `*`) — confirmed by in-pod `curl`. This PR only fixes the public routing.
- `kubectl kustomize` renders two routes: `versatiles-route` (single `/`) + `map-styles-route` (`/styles`).
- Post-merge: `curl -sI https://maps.vanillax.me/styles/light.json` → 200 + `application/json` + `access-control-allow-origin: *`; root/tiles unaffected.

Does **not** touch the global `ignoreDifferences` config (that's the separate parked `wip/argocd-httproute-ignorediff` discussion) — this is a self-contained workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)