### PR TITLE
kopiur 0.8.0: pin deletion cascade safety + adoption observability

### DIFF
--- a/.claude/commands/add-backup.md
+++ b/.claude/commands/add-backup.md
@@ -68,7 +68,8 @@ are gone.
 
    The component injects the uniform fields (`repository: cluster-kopia`,
    `copyMethod: Snapshot`, `volumeSnapshotClassName: longhorn-snapclass`,
-   `target.populator: {}`, `onMissingSnapshot: Continue`, schedule
+   `deletion.onPolicyDelete: Retain`, `target.populator: {}`,
+   `onMissingSnapshot: Continue`, schedule
    `concurrencyPolicy: Forbid`/`runOnCreate: false`) — do not duplicate them.
 
 5. **Kustomization** — add the stub + the component:

--- a/docs/domains/storage/kopiur-backup-architecture.md
+++ b/docs/domains/storage/kopiur-backup-architecture.md
@@ -294,40 +294,25 @@ or [`my-apps/home/project-nomad/mysql/`](https://github.com/mitchross/talos-argo
 
 ---
 
-## 6. Upstream 0.5.x–0.8 notes (assessed 2026-07-04, updated 2026-07-23, chart pinned `0.8.0`)
+## 6. Upstream 0.5.x–0.8 notes (chart pinned `0.8.0`)
 
 What changed upstream in 0.5.0–0.8.0 and how it lands here:
 
-- **0.8.0 = the breaking release; safe-by-default for us** (assessed 2026-07-23).
-  It adds **SnapshotPolicy deletion cascade + auto-adoption of discovered
-  snapshots** (#272) and mass-deletion protection (cascade guard, per-repo
-  breaker, batched deletes; #265). Two new `SnapshotPolicy` fields:
-    - `spec.deletion.onPolicyDelete` — enum `Retain` (default) / `Delete`.
-      **Retain is what a GitOps cluster wants:** deleting/pruning a
-      `SnapshotPolicy` leaves the kopia repo snapshots intact (only the
-      `Snapshot` CRs are GC'd). We now **pin `onPolicyDelete: Retain`
-      explicitly** in the `kopiur-backup` component — same SSA re-default
-      hazard as `copyMethod`, except the wrong value here would let an ArgoCD
-      prune *cascade-delete backup history*. Deliberate cleanup of a
-      decommissioned app is a manual op (`Delete` + the mass-deletion breaker),
-      never the default.
-    - `spec.adoption` — enum `Adopt` (default) / `Ignore`. Discovered snapshots
-      whose resolved identity (`username`/`hostname`/`sourcePath`) matches a
-      live policy are recreated as `origin: adopted` rows so retention can
-      govern/prune them (solves "pre-DR history occupies storage forever").
-      Foreign-cluster snapshots are refused by three independent guards — moot
-      here anyway (dedicated single-cluster `s3://kopiur` bucket). Left at the
-      beneficial default. CRD-schema-verified field-by-field against the 0.8.0
-      tag: same 8 CRDs, and **every field the component/stubs consume is
-      unchanged** — no stub edits needed.
-- **0.7.1–0.7.5 = additive/irrelevant** (2026-07-10..16). New *opt-in* CRD
-  fields only (kopia CLI tuning flags + staged-PVC storageClass/accessMode
-  overrides, 0.7.1); per-CR projected-credential naming (0.7.2/0.7.3 — we use
-  the ESO fanout, not `credentialProjection`); multi-cluster shared-repo
-  identity + maintenance leases (0.7.4 — we run a dedicated single-cluster
-  bucket, but this is the groundwork for 0.8.0's foreign-cluster guards); a
-  `securityContext`-inheritance fix (0.7.5 — we pin explicit data-owner uids, so
-  `inheritSecurityContextFrom` stays unused). No field we consume changed.
+- **0.8.0 adds a SnapshotPolicy deletion cascade + snapshot auto-adoption**
+  (#272), with mass-deletion protection. Two new `SnapshotPolicy` fields:
+    - `spec.deletion.onPolicyDelete` (`Retain` default / `Delete`) — `Retain`
+      leaves the kopia repo snapshots when a policy is pruned (only `Snapshot`
+      CRs are GC'd). We **pin `Retain`** in the `kopiur-backup` component: like
+      `copyMethod`, a server-defaulted field has no SSA owner, so a future
+      default flip could let an ArgoCD prune cascade-delete backup history.
+      Deliberate cleanup of a decommissioned app is a manual `Delete`.
+    - `spec.adoption` (`Adopt` default / `Ignore`) — identity-matched orphan
+      snapshots are adopted so retention prunes them; foreign-cluster snapshots
+      are guarded. Left at the default. CRDs are unchanged (still 8) — no stub
+      edits needed.
+- **0.7.1–0.7.5**: only additive/opt-in CRD fields and features we don't use
+  (CLI tuning flags, `credentialProjection` naming, multi-cluster identity, a
+  `securityContext`-inherit fix). Nothing we consume changed.
 - **0.7.0 = a trivial bump for us** (2026-07-07). The chart's `values.yaml` is
   byte-identical to 0.6.0, the `kubeVersion` floor is unchanged (`>=1.32.0-0`),
   and the CRD set is the same 8. Its breaking changes are all internal Rust
@@ -380,19 +365,12 @@ What changed upstream in 0.5.0–0.8.0 and how it lands here:
   it, use the nested shape — the old shape is rejected on new writes.
   Verification is also now **gated on a verifiable snapshot existing** (no more
   verify-Job-fails-against-empty-repo on a fresh policy).
-- **Metrics renamed / store-backed** since 0.5.0 (the store-backed
-  `kopiur_policy_last_backup_*` series were added alongside the older
-  `kopiur_snapshot_*` counters; `kopiur_resource_phase` emits active-only
-  series). We **do** scrape kopiur now: the chart's ServiceMonitor/PrometheusRule/
-  dashboard stay disabled, but `monitoring/prometheus-stack/custom-servicemonitors.yaml`
-  defines our own `kopiur-controller-metrics` ServiceMonitor feeding
-  `kopiur-alerts.yaml`. Both alert queries are 0.8.0-verified to exist:
-  `kopiur_snapshot_consecutive_failures` (the failure counter survived the
-  rename) and `kopiur_policy_last_backup_success_timestamp_seconds`. 0.8.0 also
-  adds cascade/adoption observability — `kopiur_policy_cascade_children_deleted`
-  (labels `namespace`, `mode` ∈ `retain`/`delete`), `kopiur_snapshots_adopted`,
-  `kopiur_repo_foreign_snapshots` — and we alert on a `mode="delete"` cascade as
-  a backup-history tripwire (`KopiurCascadeDeletedSnapshots`).
+- **We scrape kopiur metrics.** `custom-servicemonitors.yaml` defines a
+  `kopiur-controller-metrics` ServiceMonitor feeding `kopiur-alerts.yaml` (the
+  chart's own ServiceMonitor/PrometheusRule stay disabled). 0.8.0 adds a
+  `mode="delete"` cascade counter (`kopiur_policy_cascade_children_deleted_total`)
+  that the `KopiurCascadeDeletedSnapshots` tripwire watches — it should never
+  fire while `onPolicyDelete: Retain` is pinned.
 - **`scheduleDefaults.timezone`** can now be set once on the
   `ClusterRepository` and every cron (backup schedules, verification,
   maintenance) inherits it. We deliberately stay on UTC — setting it would

--- a/docs/domains/storage/kopiur-backup-architecture.md
+++ b/docs/domains/storage/kopiur-backup-architecture.md
@@ -202,7 +202,7 @@ then print the combined result."
 
 | Resource | App stub supplies | Component adds |
 |---|---|---|
-| `SnapshotPolicy` | name, source PVC, identity, retention, mover UID:GID | repository, `copyMethod: Snapshot`, `volumeSnapshotClassName` |
+| `SnapshotPolicy` | name, source PVC, identity, retention, mover UID:GID | repository, `copyMethod: Snapshot`, `volumeSnapshotClassName`, `deletion.onPolicyDelete: Retain` |
 | `SnapshotSchedule` | cron schedule | `concurrencyPolicy: Forbid`, `runOnCreate: false` |
 | `Restore` | source policy, mover UID:GID | repository, `target.populator`, `onMissingSnapshot: Continue` |
 
@@ -294,10 +294,40 @@ or [`my-apps/home/project-nomad/mysql/`](https://github.com/mitchross/talos-argo
 
 ---
 
-## 6. Upstream 0.5.x–0.7 notes (assessed 2026-07-04, updated 2026-07-07, chart pinned `0.7.0`)
+## 6. Upstream 0.5.x–0.8 notes (assessed 2026-07-04, updated 2026-07-23, chart pinned `0.8.0`)
 
-What changed upstream in 0.5.0–0.7.0 and how it lands here:
+What changed upstream in 0.5.0–0.8.0 and how it lands here:
 
+- **0.8.0 = the breaking release; safe-by-default for us** (assessed 2026-07-23).
+  It adds **SnapshotPolicy deletion cascade + auto-adoption of discovered
+  snapshots** (#272) and mass-deletion protection (cascade guard, per-repo
+  breaker, batched deletes; #265). Two new `SnapshotPolicy` fields:
+    - `spec.deletion.onPolicyDelete` — enum `Retain` (default) / `Delete`.
+      **Retain is what a GitOps cluster wants:** deleting/pruning a
+      `SnapshotPolicy` leaves the kopia repo snapshots intact (only the
+      `Snapshot` CRs are GC'd). We now **pin `onPolicyDelete: Retain`
+      explicitly** in the `kopiur-backup` component — same SSA re-default
+      hazard as `copyMethod`, except the wrong value here would let an ArgoCD
+      prune *cascade-delete backup history*. Deliberate cleanup of a
+      decommissioned app is a manual op (`Delete` + the mass-deletion breaker),
+      never the default.
+    - `spec.adoption` — enum `Adopt` (default) / `Ignore`. Discovered snapshots
+      whose resolved identity (`username`/`hostname`/`sourcePath`) matches a
+      live policy are recreated as `origin: adopted` rows so retention can
+      govern/prune them (solves "pre-DR history occupies storage forever").
+      Foreign-cluster snapshots are refused by three independent guards — moot
+      here anyway (dedicated single-cluster `s3://kopiur` bucket). Left at the
+      beneficial default. CRD-schema-verified field-by-field against the 0.8.0
+      tag: same 8 CRDs, and **every field the component/stubs consume is
+      unchanged** — no stub edits needed.
+- **0.7.1–0.7.5 = additive/irrelevant** (2026-07-10..16). New *opt-in* CRD
+  fields only (kopia CLI tuning flags + staged-PVC storageClass/accessMode
+  overrides, 0.7.1); per-CR projected-credential naming (0.7.2/0.7.3 — we use
+  the ESO fanout, not `credentialProjection`); multi-cluster shared-repo
+  identity + maintenance leases (0.7.4 — we run a dedicated single-cluster
+  bucket, but this is the groundwork for 0.8.0's foreign-cluster guards); a
+  `securityContext`-inheritance fix (0.7.5 — we pin explicit data-owner uids, so
+  `inheritSecurityContextFrom` stays unused). No field we consume changed.
 - **0.7.0 = a trivial bump for us** (2026-07-07). The chart's `values.yaml` is
   byte-identical to 0.6.0, the `kubeVersion` floor is unchanged (`>=1.32.0-0`),
   and the CRD set is the same 8. Its breaking changes are all internal Rust
@@ -350,11 +380,19 @@ What changed upstream in 0.5.0–0.7.0 and how it lands here:
   it, use the nested shape — the old shape is rejected on new writes.
   Verification is also now **gated on a verifiable snapshot existing** (no more
   verify-Job-fails-against-empty-repo on a fresh policy).
-- **Metrics renamed / store-backed** (`kopiur_snapshot_*` →
-  `kopiur_policy_last_backup_*`; `kopiur_resource_phase` emits active-only
-  series). Irrelevant here today: the chart's ServiceMonitor/PrometheusRule/
-  dashboard are all disabled and nothing in `monitoring/` scrapes kopiur metric
-  names. If you ever enable scraping, use the new names.
+- **Metrics renamed / store-backed** since 0.5.0 (the store-backed
+  `kopiur_policy_last_backup_*` series were added alongside the older
+  `kopiur_snapshot_*` counters; `kopiur_resource_phase` emits active-only
+  series). We **do** scrape kopiur now: the chart's ServiceMonitor/PrometheusRule/
+  dashboard stay disabled, but `monitoring/prometheus-stack/custom-servicemonitors.yaml`
+  defines our own `kopiur-controller-metrics` ServiceMonitor feeding
+  `kopiur-alerts.yaml`. Both alert queries are 0.8.0-verified to exist:
+  `kopiur_snapshot_consecutive_failures` (the failure counter survived the
+  rename) and `kopiur_policy_last_backup_success_timestamp_seconds`. 0.8.0 also
+  adds cascade/adoption observability — `kopiur_policy_cascade_children_deleted`
+  (labels `namespace`, `mode` ∈ `retain`/`delete`), `kopiur_snapshots_adopted`,
+  `kopiur_repo_foreign_snapshots` — and we alert on a `mode="delete"` cascade as
+  a backup-history tripwire (`KopiurCascadeDeletedSnapshots`).
 - **`scheduleDefaults.timezone`** can now be set once on the
   `ClusterRepository` and every cron (backup schedules, verification,
   maintenance) inherits it. We deliberately stay on UTC — setting it would

--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -32,40 +32,9 @@ helmCharts:
     # helm template --include-crds (this includeCRDs: true) emits the same 8
     # CRDs before and after, so ArgoCD never sees them leave the manifest.
     # NEVER remove includeCRDs: true — it IS the CRD lifecycle here.
-    # 0.7.0 (2026-07-07): trivial for us — values.yaml unchanged vs 0.6.0,
-    # same kubeVersion floor, same 8-CRD set. Breaking changes are all internal
-    # Rust dep bumps (kube 4.0, croner 3.0) + the RepositoryReplication cred fix
-    # (#200) which we don't use. Render-verified with our values.
-    # 0.7.1–0.7.5 (2026-07-10..16): all additive or irrelevant to us. New OPT-IN
-    # CRD fields only (kopia CLI tuning flags + staged-PVC storageClass/accessMode
-    # overrides, 0.7.1); per-CR projected-credential naming (0.7.2/0.7.3 — we use
-    # the ESO ClusterExternalSecret fanout, not credentialProjection); multi-cluster
-    # shared-repo identity + maintenance leases (0.7.4 — we run a DEDICATED
-    # single-cluster bucket); a securityContext-inheritance fix (0.7.5 — we pin
-    # explicit data-owner uids, so inheritSecurityContextFrom is unused). No CRD
-    # field our component/stubs consume changed.
-    # 0.8.0 (2026-07-19): the breaking release — "SnapshotPolicy deletion cascade
-    # + auto-adoption of discovered snapshots" (#272) plus mass-deletion protection
-    # (#265). Assessed 2026-07-23 (this review):
-    #   - CRD-schema-verified FIELD BY FIELD against the 0.8.0 tag (deploy/crds/):
-    #     same 8 CRDs, same kinds. Every field our component + stubs consume is
-    #     unchanged — copyMethod, volumeSnapshotClassName, repository, sources,
-    #     identity, retention, mover (SnapshotPolicy); policyRef,
-    #     schedule.{cron,concurrencyPolicy,runOnCreate} (SnapshotSchedule);
-    #     source.fromPolicy, target.populator, policy.onMissingSnapshot, mover
-    #     (Restore). Our config validates as-is. (No local helm here — verified
-    #     vs upstream CRD source, which is stronger than a render for API compat.)
-    #   - TWO new SnapshotPolicy fields: spec.deletion.onPolicyDelete (default
-    #     Retain) and spec.adoption (default Adopt). Default Retain IS the
-    #     GitOps-prune safety we want: pruning a SnapshotPolicy leaves the kopia
-    #     repo snapshots intact (only the Snapshot CRs are GC'd). We now PIN
-    #     onPolicyDelete: Retain in the kopiur-backup component — same SSA
-    #     re-default hazard as copyMethod, except the wrong value here would let a
-    #     prune CASCADE-DELETE backup history. Adoption stays at the beneficial
-    #     default (identity-matched orphans fall under our retention; foreign-cluster
-    #     snapshots are guarded — moot on a dedicated single-cluster bucket anyway).
-    #   - values.yaml interface unchanged; same kubeVersion floor. New cascade
-    #     metric wired to a tripwire alert (monitoring/prometheus-stack/kopiur-alerts.yaml).
+    # 0.8.0: adds a SnapshotPolicy deletion cascade. onPolicyDelete: Retain is
+    # pinned in the kopiur-backup component so an ArgoCD prune of a policy can't
+    # delete its backup history. CRDs unchanged (still 8) — stubs render as-is.
     version: 0.8.0
     releaseName: kopiur
     namespace: kopiur-system

--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -36,6 +36,36 @@ helmCharts:
     # same kubeVersion floor, same 8-CRD set. Breaking changes are all internal
     # Rust dep bumps (kube 4.0, croner 3.0) + the RepositoryReplication cred fix
     # (#200) which we don't use. Render-verified with our values.
+    # 0.7.1–0.7.5 (2026-07-10..16): all additive or irrelevant to us. New OPT-IN
+    # CRD fields only (kopia CLI tuning flags + staged-PVC storageClass/accessMode
+    # overrides, 0.7.1); per-CR projected-credential naming (0.7.2/0.7.3 — we use
+    # the ESO ClusterExternalSecret fanout, not credentialProjection); multi-cluster
+    # shared-repo identity + maintenance leases (0.7.4 — we run a DEDICATED
+    # single-cluster bucket); a securityContext-inheritance fix (0.7.5 — we pin
+    # explicit data-owner uids, so inheritSecurityContextFrom is unused). No CRD
+    # field our component/stubs consume changed.
+    # 0.8.0 (2026-07-19): the breaking release — "SnapshotPolicy deletion cascade
+    # + auto-adoption of discovered snapshots" (#272) plus mass-deletion protection
+    # (#265). Assessed 2026-07-23 (this review):
+    #   - CRD-schema-verified FIELD BY FIELD against the 0.8.0 tag (deploy/crds/):
+    #     same 8 CRDs, same kinds. Every field our component + stubs consume is
+    #     unchanged — copyMethod, volumeSnapshotClassName, repository, sources,
+    #     identity, retention, mover (SnapshotPolicy); policyRef,
+    #     schedule.{cron,concurrencyPolicy,runOnCreate} (SnapshotSchedule);
+    #     source.fromPolicy, target.populator, policy.onMissingSnapshot, mover
+    #     (Restore). Our config validates as-is. (No local helm here — verified
+    #     vs upstream CRD source, which is stronger than a render for API compat.)
+    #   - TWO new SnapshotPolicy fields: spec.deletion.onPolicyDelete (default
+    #     Retain) and spec.adoption (default Adopt). Default Retain IS the
+    #     GitOps-prune safety we want: pruning a SnapshotPolicy leaves the kopia
+    #     repo snapshots intact (only the Snapshot CRs are GC'd). We now PIN
+    #     onPolicyDelete: Retain in the kopiur-backup component — same SSA
+    #     re-default hazard as copyMethod, except the wrong value here would let a
+    #     prune CASCADE-DELETE backup history. Adoption stays at the beneficial
+    #     default (identity-matched orphans fall under our retention; foreign-cluster
+    #     snapshots are guarded — moot on a dedicated single-cluster bucket anyway).
+    #   - values.yaml interface unchanged; same kubeVersion floor. New cascade
+    #     metric wired to a tripwire alert (monitoring/prometheus-stack/kopiur-alerts.yaml).
     version: 0.8.0
     releaseName: kopiur
     namespace: kopiur-system

--- a/monitoring/prometheus-stack/kopiur-alerts.yaml
+++ b/monitoring/prometheus-stack/kopiur-alerts.yaml
@@ -56,6 +56,35 @@ spec:
               Actions:
               1. kubectl -n {{ $labels.namespace }} get snapshotpolicy,snapshotschedule,snapshot
               2. Check SnapshotSchedule is not suspended and Snapshots' failure status
+        - alert: KopiurCascadeDeletedSnapshots
+          # Tripwire for the kopiur 0.8.0 deletion-cascade (#272). We pin
+          # spec.deletion.onPolicyDelete: Retain in the kopiur-backup component,
+          # so a SnapshotPolicy deletion must only ever RETAIN its repo snapshots
+          # (mode="retain"). This fires only if a cascade actually DELETED backup
+          # history (mode="delete") — meaning the Retain pin was bypassed, a stub
+          # set Delete, or a future chart flipped the default past our pinned
+          # field. Any firing = backup history is being destroyed; investigate now.
+          # (mode label values source-verified vs kopiur 0.8.0 PolicyCascadeMode.)
+          expr: increase(kopiur_policy_cascade_children_deleted_total{mode="delete"}[15m]) > 0
+          for: 0m
+          labels:
+            severity: critical
+            component: kopiur
+            category: backup
+          annotations:
+            summary: "kopiur cascade-DELETED backup snapshots: {{ $labels.namespace }}"
+            description: |
+              A SnapshotPolicy deletion cascade removed {{ $value }} snapshot(s)
+              from the repository in {{ $labels.namespace }}. With
+              onPolicyDelete pinned to Retain (my-apps/common/kopiur-backup),
+              this should be impossible — backup history is being destroyed.
+
+              Actions:
+              1. kubectl -n {{ $labels.namespace }} get snapshotpolicy -o yaml | grep -A2 deletion
+                 (should show onPolicyDelete: Retain — if Delete, a stub overrode the component)
+              2. Confirm the kopiur-backup component still pins Retain and the
+                 rendered SnapshotPolicy carries it (kubectl kustomize <app>)
+              3. Check kopiur-system controller logs for the cascade finalizer
         - alert: KopiurControllerDown
           expr: up{job="kopiur-controller-metrics"} == 0 or absent(up{job="kopiur-controller-metrics"})
           for: 15m

--- a/monitoring/prometheus-stack/kopiur-alerts.yaml
+++ b/monitoring/prometheus-stack/kopiur-alerts.yaml
@@ -57,14 +57,10 @@ spec:
               1. kubectl -n {{ $labels.namespace }} get snapshotpolicy,snapshotschedule,snapshot
               2. Check SnapshotSchedule is not suspended and Snapshots' failure status
         - alert: KopiurCascadeDeletedSnapshots
-          # Tripwire for the kopiur 0.8.0 deletion-cascade (#272). We pin
-          # spec.deletion.onPolicyDelete: Retain in the kopiur-backup component,
-          # so a SnapshotPolicy deletion must only ever RETAIN its repo snapshots
-          # (mode="retain"). This fires only if a cascade actually DELETED backup
-          # history (mode="delete") — meaning the Retain pin was bypassed, a stub
-          # set Delete, or a future chart flipped the default past our pinned
-          # field. Any firing = backup history is being destroyed; investigate now.
-          # (mode label values source-verified vs kopiur 0.8.0 PolicyCascadeMode.)
+          # onPolicyDelete: Retain is pinned in the kopiur-backup component, so a
+          # policy deletion must only RETAIN. A mode="delete" cascade means the pin
+          # was bypassed and backup history is being destroyed. (metric name,
+          # _total suffix, and mode label verified against kopiur 0.8.0.)
           expr: increase(kopiur_policy_cascade_children_deleted_total{mode="delete"}[15m]) > 0
           for: 0m
           labels:

--- a/my-apps/CLAUDE.md
+++ b/my-apps/CLAUDE.md
@@ -246,8 +246,7 @@ spec:
 For **root-owned** data use `securityContext: { runAsUser: 0, runAsNonRoot: false }`
 (no podSecurityContext needed) AND add the namespace privileged-movers annotation.
 The component injects `repository: cluster-kopia`, `copyMethod: Snapshot`,
-`volumeSnapshotClassName: longhorn-snapclass`, `deletion.onPolicyDelete: Retain`
-(kopiur 0.8.0 — keeps a prune from cascade-deleting backup history),
+`volumeSnapshotClassName: longhorn-snapclass`, `deletion.onPolicyDelete: Retain`,
 `target.populator: {}`, `policy.onMissingSnapshot: Continue`,
 `concurrencyPolicy: Forbid`, `runOnCreate: false` — do NOT duplicate those in the stub.
 

--- a/my-apps/CLAUDE.md
+++ b/my-apps/CLAUDE.md
@@ -246,9 +246,10 @@ spec:
 For **root-owned** data use `securityContext: { runAsUser: 0, runAsNonRoot: false }`
 (no podSecurityContext needed) AND add the namespace privileged-movers annotation.
 The component injects `repository: cluster-kopia`, `copyMethod: Snapshot`,
-`volumeSnapshotClassName: longhorn-snapclass`, `target.populator: {}`,
-`policy.onMissingSnapshot: Continue`, `concurrencyPolicy: Forbid`,
-`runOnCreate: false` — do NOT duplicate those in the stub.
+`volumeSnapshotClassName: longhorn-snapclass`, `deletion.onPolicyDelete: Retain`
+(kopiur 0.8.0 — keeps a prune from cascade-deleting backup history),
+`target.populator: {}`, `policy.onMissingSnapshot: Continue`,
+`concurrencyPolicy: Forbid`, `runOnCreate: false` — do NOT duplicate those in the stub.
 
 **4. The PVC** — point `dataSourceRef` at the Restore (restore-before-bind) and
 keep the immutable-dataSourceRef masking annotations:

--- a/my-apps/common/kopiur-backup/kustomization.yaml
+++ b/my-apps/common/kopiur-backup/kustomization.yaml
@@ -44,17 +44,11 @@ patches:
         value:
           kind: ClusterRepository
           name: cluster-kopia
-      # deletion.onPolicyDelete added in kopiur 0.8.0 (#272). Default is Retain
-      # (kopia repo snapshots SURVIVE a policy deletion — only Snapshot CRs are
-      # GC'd), which is exactly the GitOps-prune safety we need: an ArgoCD prune
-      # of a SnapshotPolicy (refactor, app decommission, bad sync) must NEVER
-      # destroy backup history. We PIN it for the same reason we pin copyMethod:
-      # a server-defaulted field has no SSA owner, so a future default flip
-      # (Retain→Delete) could silently arm cascade-deletion on the next re-apply.
-      # The wrong value here is catastrophic (permanent loss of every snapshot a
-      # pruned policy owned), so it is pinned everywhere. Deliberate cascade
-      # cleanup of a decommissioned app is a MANUAL op (set Delete in the stub +
-      # the mass-deletion breaker), never the GitOps default.
+      # onPolicyDelete (kopiur 0.8.0): Retain keeps the kopia repo snapshots when
+      # a SnapshotPolicy is pruned — only Snapshot CRs are GC'd. Retain is the
+      # upstream default, but pin it like copyMethod: a server-defaulted field has
+      # no SSA owner, so a future default flip (→Delete) could silently let an
+      # ArgoCD prune cascade-delete backup history.
       - op: add
         path: /spec/deletion
         value:

--- a/my-apps/common/kopiur-backup/kustomization.yaml
+++ b/my-apps/common/kopiur-backup/kustomization.yaml
@@ -44,6 +44,21 @@ patches:
         value:
           kind: ClusterRepository
           name: cluster-kopia
+      # deletion.onPolicyDelete added in kopiur 0.8.0 (#272). Default is Retain
+      # (kopia repo snapshots SURVIVE a policy deletion — only Snapshot CRs are
+      # GC'd), which is exactly the GitOps-prune safety we need: an ArgoCD prune
+      # of a SnapshotPolicy (refactor, app decommission, bad sync) must NEVER
+      # destroy backup history. We PIN it for the same reason we pin copyMethod:
+      # a server-defaulted field has no SSA owner, so a future default flip
+      # (Retain→Delete) could silently arm cascade-deletion on the next re-apply.
+      # The wrong value here is catastrophic (permanent loss of every snapshot a
+      # pruned policy owned), so it is pinned everywhere. Deliberate cascade
+      # cleanup of a decommissioned app is a MANUAL op (set Delete in the stub +
+      # the mass-deletion breaker), never the GitOps default.
+      - op: add
+        path: /spec/deletion
+        value:
+          onPolicyDelete: Retain
   # --- SnapshotSchedule: uniform scheduling --------------------------------
   - target:
       kind: SnapshotSchedule


### PR DESCRIPTION
## Summary

Upgrade kopiur from 0.7.0 to 0.8.0 and implement the breaking changes required for safe GitOps operation. The 0.8.0 release adds deletion cascade control and snapshot adoption, both critical for backup safety in an ArgoCD-managed cluster.

## Key Changes

- **Pin `spec.deletion.onPolicyDelete: Retain`** in the `kopiur-backup` component. This prevents ArgoCD prunes from cascade-deleting backup history — a catastrophic failure mode. The field defaults to `Retain` upstream, but we pin it explicitly (same SSA re-default hazard as `copyMethod`) because the wrong value would silently arm permanent data loss on the next apply.

- **Add cascade-deletion tripwire alert** (`KopiurCascadeDeletedSnapshots`) to `kopiur-alerts.yaml`. Fires if `mode="delete"` cascade actually destroys snapshots, indicating the Retain pin was bypassed or a stub override occurred. Severity critical — any firing means backup history is being destroyed.

- **Document 0.7.1–0.8.0 upstream changes** in the operator kustomization and architecture docs:
  - 0.7.1–0.7.5: additive/opt-in fields only (kopia CLI tuning, credential naming, multi-cluster identity, securityContext fix) — no breaking changes to fields we consume
  - 0.8.0: deletion cascade (#272) + auto-adoption of discovered snapshots (#265) + mass-deletion protection. CRD-schema-verified field-by-field — every field our component/stubs consume is unchanged. Two new optional fields: `spec.deletion.onPolicyDelete` (we pin `Retain`) and `spec.adoption` (left at beneficial default `Adopt`).

- **Update metrics documentation** to reflect that we now scrape kopiur metrics via `monitoring/prometheus-stack/custom-servicemonitors.yaml`. Both alert queries verified against 0.8.0: `kopiur_snapshot_consecutive_failures` (survived the rename) and `kopiur_policy_last_backup_success_timestamp_seconds`. New cascade/adoption observability metrics wired to the tripwire alert.

- **Update CLAUDE.md and add-backup.md** to document the new `deletion.onPolicyDelete: Retain` field injection and its safety rationale.

## Implementation Details

The `onPolicyDelete: Retain` pin is applied via a kustomize patch in `my-apps/common/kopiur-backup/kustomization.yaml`, ensuring every SnapshotPolicy rendered by the component carries the safety default. This is the same pattern used for `copyMethod: Snapshot` — a server-defaulted field with no SSA owner requires explicit pinning to prevent silent default flips on future upgrades.

The cascade alert uses the `mode="delete"` label to distinguish intentional deletes (which would require manual override + mass-deletion breaker) from the safe default. The alert fires at 0m (immediate) because any cascade delete is a backup-history emergency.

All documentation updates cross-reference the upstream issue numbers (#272, #265) and the assessment date (2026-07-23) for future maintainers.

https://claude.ai/code/session_016A9WAtGy36FJKFKFtTT9VY