### PR TITLE
worldmonitor: bump to sha-0f31bf3

### DIFF
--- a/my-apps/media/worldmonitor/deployment-app.yaml
+++ b/my-apps/media/worldmonitor/deployment-app.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: worldmonitor
-          image: ghcr.io/mitchross/worldmonitor:sha-b8ada8f
+          image: ghcr.io/mitchross/worldmonitor:sha-0f31bf3
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/my-apps/media/worldmonitor/deployment-redis-rest.yaml
+++ b/my-apps/media/worldmonitor/deployment-redis-rest.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: redis-rest
-          image: ghcr.io/mitchross/worldmonitor-redis-rest:sha-b8ada8f
+          image: ghcr.io/mitchross/worldmonitor-redis-rest:sha-0f31bf3
           imagePullPolicy: IfNotPresent
           env:
             - name: SRH_TOKEN

--- a/my-apps/media/worldmonitor/deployment-relay.yaml
+++ b/my-apps/media/worldmonitor/deployment-relay.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: ais-relay
-          image: ghcr.io/mitchross/worldmonitor-relay:sha-b8ada8f
+          image: ghcr.io/mitchross/worldmonitor-relay:sha-0f31bf3
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Lockstep image bump for app/redis-rest/relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)