### PR TITLE
Add LiteLLM proxy for pi-agent LLM logging to PostHog

### DIFF
--- a/my-apps/ai/litellm/configmap.yaml
+++ b/my-apps/ai/litellm/configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+  namespace: litellm
+data:
+  config.yaml: |
+    model_list:
+      - model_name: qwen3.6-27b
+        litellm_params:
+          model: hosted_vllm/qwen3.6-27b
+          api_base: http://vllm-service.vllm.svc.cluster.local:8080/v1
+          api_key: "vllm-no-key-required"
+        model_info:
+          # Self-hosted — pin explicitly rather than rely on LiteLLM's cost map.
+          input_cost_per_token: 0
+          output_cost_per_token: 0
+      - model_name: kimi-k3
+        litellm_params:
+          model: moonshot/kimi-k3
+          api_key: os.environ/MOONSHOT_API_KEY
+        model_info:
+          # Kimi K3 pricing (moonshot.ai, 2026-07): $3/M input, $15/M output.
+          # Set explicitly since the model may be too new for LiteLLM's built-in cost map.
+          input_cost_per_token: 0.000003
+          output_cost_per_token: 0.000015
+
+    litellm_settings:
+      success_callback: ["posthog"]
+      failure_callback: ["posthog"]
+      # Kimi K3 fixes temperature/top_p/n/presence_penalty/frequency_penalty
+      # server-side and rejects overrides — drop rather than error if a
+      # client sends them.
+      drop_params: true
+
+    general_settings:
+      master_key: os.environ/LITELLM_MASTER_KEY

--- a/my-apps/ai/litellm/deployment.yaml
+++ b/my-apps/ai/litellm/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm
+  namespace: litellm
+  labels:
+    app: litellm
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: litellm
+  template:
+    metadata:
+      labels:
+        app: litellm
+    spec:
+      containers:
+        - name: litellm
+          image: ghcr.io/berriai/litellm:v1.93.0
+          args: ["--config", "/app/config.yaml", "--port", "4000"]
+          ports:
+            - name: http
+              containerPort: 4000
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: litellm-secrets
+          env:
+            # In-cluster PostHog capture endpoint — bypasses the external
+            # gateway hairpin (same pattern as my-apps/media/redlib).
+            - name: POSTHOG_API_URL
+              value: "http://capture.posthog.svc.cluster.local:3000"
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+          livenessProbe:
+            httpGet:
+              path: /health/liveliness
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+      volumes:
+        - name: config
+          configMap:
+            name: litellm-config

--- a/my-apps/ai/litellm/externalsecret.yaml
+++ b/my-apps/ai/litellm/externalsecret.yaml
@@ -1,0 +1,29 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm-secrets
+  namespace: litellm
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: litellm-secrets
+    creationPolicy: Owner
+  data:
+    # 1Password item "litellm" — create with these three fields.
+    # master_key / posthog_api_key: any generated string is fine.
+    # moonshot_api_key: from https://platform.moonshot.ai (Kimi K3 access).
+    - secretKey: LITELLM_MASTER_KEY
+      remoteRef:
+        key: litellm
+        property: master_key
+    - secretKey: MOONSHOT_API_KEY
+      remoteRef:
+        key: litellm
+        property: moonshot_api_key
+    - secretKey: POSTHOG_API_KEY
+      remoteRef:
+        key: litellm
+        property: posthog_api_key

--- a/my-apps/ai/litellm/httproute.yaml
+++ b/my-apps/ai/litellm/httproute.yaml
@@ -1,0 +1,29 @@
+# INTERNAL route (local network only, via gateway-internal) — mirrors vllm.
+# Only your own machines need to reach this; no reason to expose it externally.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: litellm-route
+  namespace: litellm
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway-internal-technitium
+    namespace: gateway
+  hostnames:
+  - "litellm.vanillax.me"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      request: 30m            # long generations
+      backendRequest: 30m
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: litellm-service
+      port: 4000
+      weight: 1

--- a/my-apps/ai/litellm/kustomization.yaml
+++ b/my-apps/ai/litellm/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: litellm
+
+# List EVERY file here — unlisted YAML is never deployed (Kustomize only renders what's listed).
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/my-apps/ai/litellm/namespace.yaml
+++ b/my-apps/ai/litellm/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: litellm

--- a/my-apps/ai/litellm/service.yaml
+++ b/my-apps/ai/litellm/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm-service
+  namespace: litellm
+  labels:
+    app: litellm
+spec:
+  selector:
+    app: litellm
+  ports:
+    - name: http              # CRITICAL — HTTPRoute matches by port name; fails silently without it
+      protocol: TCP
+      port: 4000
+      targetPort: http
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- New `my-apps/ai/litellm/` GitOps app: self-hosted LiteLLM proxy sitting between pi-coding-agent and its two backends — self-hosted vLLM (`qwen3.6-27b`) and Moonshot's Kimi K3 API.
- LiteLLM's `success_callback`/`failure_callback: ["posthog"]` sends every request (tokens, cost, latency, model) to the in-cluster PostHog instance's LLM Analytics product — feeds the Clusters/Playground views too, no extra setup needed.
- Kimi K3 pricing pinned explicitly ($3/M in, $15/M out) since the model may be too new for LiteLLM's built-in cost map; vLLM pinned to $0 since it's self-hosted.
- `drop_params: true` set because Kimi K3 fixes `temperature`/`top_p`/etc. server-side and rejects overrides rather than ignoring them.
- Internal-only `HTTPRoute` (`litellm.vanillax.me`, `gateway-internal-technitium`) — mirrors the vLLM app's pattern, no external exposure needed.
- Secrets (`master_key`, `moonshot_api_key`, `posthog_api_key`) come from the 1Password item `litellm` in vault `homelab-prod` via the standard `ExternalSecret` pattern.

## Test plan
- [x] `kubectl kustomize my-apps/ai/litellm/` renders cleanly
- [x] `ghcr.io/berriai/litellm:v1.93.0` confirmed to exist on GHCR
- [x] 1Password item `litellm` confirmed retrievable (`op item get`) with all three fields
- [ ] After ArgoCD syncs: `kubectl get externalsecret,pods -n litellm`, confirm `litellm-secrets` resolves
- [ ] Hit `https://litellm.vanillax.me/v1/models` with the master key, confirm both `qwen3.6-27b` and `kimi-k3` list
- [ ] Send a completion through pi (`~/.pi/agent/models.json` provider `vanillax-litellm`) and confirm it shows up in PostHog → AI engineering → LLM analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)