### PR TITLE
posthog: skip argocd healthcheck on passive Restore (unblocks sync)

### DIFF
--- a/my-apps/development/posthog/kopiur/postgres-data.yaml
+++ b/my-apps/development/posthog/kopiur/postgres-data.yaml
@@ -52,6 +52,11 @@ kind: Restore
 metadata:
   name: postgres-data-restore
   namespace: posthog
+  annotations:
+    # Passive populator on a live cluster: Ready only flips when a rebuilt PVC
+    # claims it via dataSourceRef, so it idles AwaitingClaim forever here and
+    # would hang every sync. Real DR gating is the PVC bind, not this health.
+    argocd.argoproj.io/ignore-healthcheck: "true"
 spec:
   source:
     fromPolicy:


### PR DESCRIPTION
The postgres-data Restore is a passive populator — on a live cluster it sits AwaitingClaim until a rebuild-time PVC claims it via dataSourceRef. ArgoCD's condition-based health reads that as Progressing and the sync operation hangs on 'waiting for healthy state'. ignore-healthcheck skips it; the PVC's own restore-before-bind is the actual DR gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)