### PR TITLE
litellm: fix OOMKilled crash loop (bump memory limits)

### DIFF
--- a/my-apps/ai/litellm/deployment.yaml
+++ b/my-apps/ai/litellm/deployment.yaml
@@ -51,9 +51,9 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
-            limits:
               memory: 512Mi
+            limits:
+              memory: 1536Mi
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
## Summary
- Follow-up to #1764. The litellm pod OOMKilled (exit 137) within ~11s of starting on every attempt — 512Mi limit was too tight for LiteLLM's Python/FastAPI stack + cost-map load at boot.
- Bumped requests 256Mi→512Mi, limits 512Mi→1536Mi.

## Test plan
- [ ] After merge, confirm pod reaches `Running`/`Ready` without OOMKilled: `kubectl get pods -n litellm -w`