### PR TITLE
argocd: kopiur Restore health — AwaitingClaim is a healthy steady state

### DIFF
--- a/infrastructure/controllers/argocd/values.yaml
+++ b/infrastructure/controllers/argocd/values.yaml
@@ -161,6 +161,18 @@ configs:
         elseif obj.status.phase ~= nil then
           hs.message = "Restore phase: " .. obj.status.phase
         end
+        -- Passive populator on a live cluster: AwaitingClaim=True means the
+        -- Restore idles until a rebuild-time PVC claims it via dataSourceRef.
+        -- That is its healthy steady state — without this, adding backup to an
+        -- app whose PVC already exists hangs every sync on the wave gate.
+        if hs.status == "Progressing" and obj.status.conditions ~= nil then
+          for _, c in ipairs(obj.status.conditions) do
+            if c.type == "AwaitingClaim" and c.status == "True" then
+              hs.status = "Healthy"
+              hs.message = "Passive populator awaiting PVC claim (live-cluster steady state)"
+            end
+          end
+        end
       end
       return hs
     # Strimzi Kafka has no built-in Argo health assessment. Walk (`ipairs`) its


### PR DESCRIPTION
Passive populators (backup added to an app whose PVC already exists) sit AwaitingClaim until the next rebuild. The phase-only health Lua reported Progressing forever, hanging sync wave gates. First hit: posthog postgres-data (#1762). ignore-healthcheck on the resource doesn't help — wave gating uses the resource health check regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)