### PR TITLE
Replace global Kopiur health Lua with a scoped restore gate

### DIFF
--- a/infrastructure/controllers/argocd/values.yaml
+++ b/infrastructure/controllers/argocd/values.yaml
@@ -138,43 +138,6 @@ configs:
         end
       end
       return hs
-    # kopiur Restore has no built-in Argo health assessment. Keep it Progressing
-    # while kopiur resolves and hydrates the volume, report Completed as Healthy,
-    # and preserve the controller's failure message when phase=Failed. This
-    # gates later waves for operator-owned PVCs such as Kafka: kopiur restores
-    # the exact PVC first, and the workload must not mount it until completion.
-    resource.customizations.health.kopiur.home-operations.com_Restore: |
-      hs = {}
-      hs.status = "Progressing"
-      hs.message = "Waiting for restore controller"
-      if obj.status ~= nil then
-        if obj.status.phase == "Completed" then
-          hs.status = "Healthy"
-          hs.message = "Restore completed"
-        elseif obj.status.phase == "Failed" then
-          hs.status = "Degraded"
-          if obj.status.failure ~= nil and obj.status.failure.message ~= nil then
-            hs.message = obj.status.failure.message
-          else
-            hs.message = "Restore failed"
-          end
-        elseif obj.status.phase ~= nil then
-          hs.message = "Restore phase: " .. obj.status.phase
-        end
-        -- Passive populator on a live cluster: AwaitingClaim=True means the
-        -- Restore idles until a rebuild-time PVC claims it via dataSourceRef.
-        -- That is its healthy steady state — without this, adding backup to an
-        -- app whose PVC already exists hangs every sync on the wave gate.
-        if hs.status == "Progressing" and obj.status.conditions ~= nil then
-          for _, c in ipairs(obj.status.conditions) do
-            if c.type == "AwaitingClaim" and c.status == "True" then
-              hs.status = "Healthy"
-              hs.message = "Passive populator awaiting PVC claim (live-cluster steady state)"
-            end
-          end
-        end
-      end
-      return hs
     # Strimzi Kafka has no built-in Argo health assessment. Walk (`ipairs`) its
     # condition list and translate Ready=True to Healthy or NotReady=True to
     # Degraded. Until either condition exists, remain Progressing. Because the

--- a/my-apps/development/kafka/README.md
+++ b/my-apps/development/kafka/README.md
@@ -78,8 +78,9 @@ domains.
 
 The deterministic Strimzi claim `data-0-dev-kafka-dual-role-0` has a daily
 kopiur recovery point. Kafka uses kopiur's direct-PVC variant because Strimzi,
-not Git, normally creates the claim; the Argo health gate ensures restoration
-finishes before Kafka mounts it. The capacity and storage class are copied from
+not Git, normally creates the claim. A namespace-scoped Sync Job waits for the
+Restore's standard `Ready=True` condition before Argo advances from wave -1 to
+the Strimzi resources in wave 0. The capacity and storage class are copied from
 the node-pool declaration with Kustomize replacements so the live and restore
 contracts cannot drift independently.
 

--- a/my-apps/development/kafka/kopiur/kafka-data.yaml
+++ b/my-apps/development/kafka/kopiur/kafka-data.yaml
@@ -54,7 +54,8 @@ metadata:
   name: kafka-data-restore
   namespace: kafka
   annotations:
-    # Argo's kopiur health customization holds wave 0 until this is Completed.
+    # The namespace-scoped restore gate in wave -1 waits for Ready=True before
+    # Strimzi lands in wave 0; Argo itself needs no Kopiur health customization.
     argocd.argoproj.io/sync-wave: "-2"
 spec:
   source:

--- a/my-apps/development/kafka/kopiur/restore-gate.yaml
+++ b/my-apps/development/kafka/kopiur/restore-gate.yaml
@@ -1,0 +1,86 @@
+# Kafka is the one kopiur exception that restores a PVC directly because
+# Strimzi owns the claim manifest. Keep this dependency local: apply the Restore
+# in wave -2, wait on kopiur's standard Ready condition here in wave -1, then
+# allow the KafkaNodePool and Kafka resources to land in wave 0.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-restore-gate
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kafka-restore-gate
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+rules:
+  - apiGroups:
+      - kopiur.home-operations.com
+    resources:
+      - restores
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kafka-restore-gate
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kafka-restore-gate
+subjects:
+  - kind: ServiceAccount
+    name: kafka-restore-gate
+    namespace: kafka
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kafka-restore-gate
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  activeDeadlineSeconds: 3600
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: kafka-restore-gate
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: wait
+          image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+          args:
+            - wait
+            - --for=condition=Ready
+            - --timeout=55m
+            - restore.kopiur.home-operations.com/kafka-data-restore
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi

--- a/my-apps/development/kafka/kustomization.yaml
+++ b/my-apps/development/kafka/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - demo-seed-job.yaml
   - kafka-ui.yaml
   - kopiur/kafka-data.yaml
+  - kopiur/restore-gate.yaml
 configMapGenerator:
   # Keep executable logic and sample payloads out of Kubernetes YAML. The
   # generated name hash automatically gives each Job revision its exact files.

--- a/my-apps/development/posthog/kopiur/postgres-data.yaml
+++ b/my-apps/development/posthog/kopiur/postgres-data.yaml
@@ -52,11 +52,6 @@ kind: Restore
 metadata:
   name: postgres-data-restore
   namespace: posthog
-  annotations:
-    # Passive populator on a live cluster: Ready only flips when a rebuilt PVC
-    # claims it via dataSourceRef, so it idles AwaitingClaim forever here and
-    # would hang every sync. Real DR gating is the PVC bind, not this health.
-    argocd.argoproj.io/ignore-healthcheck: "true"
 spec:
   source:
     fromPolicy:


### PR DESCRIPTION
## What changed

- remove the cluster-wide Argo CD health customization for Kopiur `Restore` resources, including the unsafe `AwaitingClaim=True -> Healthy` branch from #1767
- remove PostHog's ineffective `ignore-healthcheck` workaround
- add a Kafka-local Sync Job that waits for Kopiur's standard `Ready=True` condition before Strimzi resources are applied
- document the explicit Kafka order: RBAC wave -3, Restore wave -2, wait gate wave -1, Strimzi wave 0

## Why

`AwaitingClaim` is a Kopiur domain condition that intentionally survives later phase writes. A global Argo health rule can therefore misclassify an actively `Resolving` or `Restoring` populator as Healthy.

More importantly, Kopiur lifecycle policy does not belong in global Argo configuration. Passive restore-before-bind already has a Kubernetes-native gate: the claiming PVC remains Pending until population and binding complete. Kafka is the only direct-PVC exception because Strimzi owns its claim, so its dependency is now explicit and local to that application.

## Validation

- Kustomize 5.8.1 render: Argo CD, Kafka, PostHog
- kubeconform 0.7.0 strict validation against Kubernetes 1.36.2: 0 invalid, 0 errors
- `scripts/validate-argocd-apps.sh`: passed
- `scripts/validate-kopiur-coverage.py`: Kafka and PostHog passed with 0 warnings and 0 failures
- verified rendered sync waves and confirmed the Argo ConfigMap contains no Kopiur health customization

Draft for owner review; do not merge automatically.