### PR TITLE
worldmonitor: bump app/redis-rest/relay to sha-7f0ba26

### DIFF
--- a/my-apps/media/worldmonitor/deployment-app.yaml
+++ b/my-apps/media/worldmonitor/deployment-app.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: worldmonitor
-          image: ghcr.io/mitchross/worldmonitor:sha-0f31bf3
+          image: ghcr.io/mitchross/worldmonitor:sha-7f0ba26
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/my-apps/media/worldmonitor/deployment-redis-rest.yaml
+++ b/my-apps/media/worldmonitor/deployment-redis-rest.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: redis-rest
-          image: ghcr.io/mitchross/worldmonitor-redis-rest:sha-0f31bf3
+          image: ghcr.io/mitchross/worldmonitor-redis-rest:sha-7f0ba26
           imagePullPolicy: IfNotPresent
           env:
             - name: SRH_TOKEN

--- a/my-apps/media/worldmonitor/deployment-relay.yaml
+++ b/my-apps/media/worldmonitor/deployment-relay.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: ais-relay
-          image: ghcr.io/mitchross/worldmonitor-relay:sha-0f31bf3
+          image: ghcr.io/mitchross/worldmonitor-relay:sha-7f0ba26
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Follow-up to the mitchross/worldmonitor upstream sync (mitchross/worldmonitor#5, merged), which published a fresh `sha-7f0ba26` build across all three images (`worldmonitor`, `worldmonitor-relay`, `worldmonitor-redis-rest`). This bumps the three deployment manifests to match so the cluster tracks the new upstream sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)