### PR TITLE
fix(argocd): ignore kopiur SnapshotPolicy sources[].readOnly drift

### DIFF
--- a/infrastructure/controllers/argocd/apps/appsets/my-apps-appset.yaml
+++ b/infrastructure/controllers/argocd/apps/appsets/my-apps-appset.yaml
@@ -120,6 +120,7 @@ spec:
         - /spec/groupBy
         jqPathExpressions:
         - .spec.sources[].sourcePathStrategy
+        - .spec.sources[].readOnly
 
       info:
       - name: 'Description'


### PR DESCRIPTION
The kopiur controller injects `readOnly: true` on each SnapshotPolicy source entry after apply, causing cosmetic OutOfSync on every backed-up app. Add it to the ApplicationSet ignoreDifferences alongside the already-ignored sourcePathStrategy.

Fixes 20 of 22 OutOfSync my-apps apps (PostHog has additional genuine drift, opentelemetry-operator is a separate HTTPRoute issue).