### PR TITLE
monitoring: simplify performance triage and upgrade Loki

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -161,6 +161,51 @@ Grafana has data, it's the reverse.
 | Alertmanager | https://alertmanager.vanillax.me |
 | Loki | https://loki.vanillax.me |
 
+## Performance Triage
+
+Grafana opens on **START HERE — Cluster Performance**. This is the supported
+front door for performance incidents; do not begin by browsing dashboard
+folders.
+
+1. Read the four red/yellow/green incident cards.
+2. Check whether node CPU, memory, disk, or kubelet pressure is red.
+3. Use the ranked workload panels to find the CPU/RAM consumer or the workload
+   closest to a hard limit.
+4. Click the workload bar. Grafana opens **WHY IS THIS APP SLOW?** with the
+   namespace and workload already selected.
+5. Match CPU throttling, memory growth, restarts, network/filesystem traffic,
+   and the workload's Loki errors on the same time range.
+
+Only two selectors are exposed on the investigator: **Namespace** and
+**Workload**. The pod selector is derived automatically. Specialist dashboards
+remain available from the START HERE instructions for PostHog, Longhorn,
+Argo CD, VPA, GPU, and raw logs.
+
+For PostHog, open **WHY IS POSTHOG SLOW?**. It deliberately keeps all of the
+following on one page:
+
+- Django web/API latency, 5xx rate, and the exact slow/failing view.
+- PostgreSQL connections, cache hit, deadlocks, long transactions, locks,
+  temporary data, and slow `pg_stat_statements` query IDs.
+- Redpanda consumer lag by PostHog consumer group, active consumers, and
+  unavailable partitions.
+- ClickHouse queries, merges, failures, memory, MergeTree parts, CPU, and
+  restarts.
+- PostHog pod CPU/memory and correlated Loki error messages.
+
+PostgreSQL uses a pinned `postgres_exporter` sidecar; Redpanda and ClickHouse
+use their built-in Prometheus endpoints. Query text is not placed in metric
+labels.
+
+The kube-prometheus-stack stock dashboard bundle and the five community
+Kubernetes views are deliberately disabled. They duplicated the same signals
+across global/namespace/node/pod menus and obscured the incident workflow.
+The three GitOps-managed entrypoints are:
+
+- `monitoring/prometheus-stack/performance-cockpit-dashboard.yaml`
+- `monitoring/prometheus-stack/app-performance-dashboard.yaml`
+- `monitoring/prometheus-stack/posthog-performance-dashboard.yaml`
+
 ## Key Files
 
 - Custom ServiceMonitors: `monitoring/prometheus-stack/custom-servicemonitors.yaml`

--- a/monitoring/loki-stack/kustomization.yaml
+++ b/monitoring/loki-stack/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 helmCharts:
   - name: loki
     repo: https://grafana-community.github.io/helm-charts
-    version: 17.4.11
+    version: 18.5.4
     releaseName: loki
     namespace: loki-stack
     valuesFile: values.yaml

--- a/monitoring/prometheus-stack/app-performance-dashboard.yaml
+++ b/monitoring/prometheus-stack/app-performance-dashboard.yaml
@@ -1,0 +1,553 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-performance-dashboard
+  namespace: prometheus-stack
+  labels:
+    grafana_dashboard: "1"
+    app.kubernetes.io/name: grafana-dashboards
+data:
+  app-performance-investigator.json: |
+    {
+      "annotations": { "list": [] },
+      "description": "A focused workload investigator that puts metrics and matching logs on one page.",
+      "editable": false,
+      "graphTooltip": 1,
+      "links": [
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": false,
+          "keepTime": true,
+          "targetBlank": false,
+          "title": "BACK TO START HERE",
+          "type": "link",
+          "url": "/d/performance-cockpit/start-here"
+        }
+      ],
+      "panels": [
+        {
+          "id": 1,
+          "type": "text",
+          "title": "CAUSE DECODER — $namespace / $workload",
+          "gridPos": { "x": 0, "y": 0, "w": 24, "h": 5 },
+          "options": {
+            "mode": "markdown",
+            "content": "## Read the four cards, then match the symptom\n- **CPU high + throttling high:** the CPU limit is choking the app. Raise/remove the limit or reduce work.\n- **Memory climbing + near limit + restarts/OOM:** likely leak, unbounded cache, or too-small limit.\n- **CPU/RAM green + error logs high:** app bug, schema/config problem, or an unhealthy dependency.\n- **Only one pod is bad:** pod/node-local issue. **Every pod is bad:** shared dependency, traffic spike, or rollout.\n\nThe dashboard opened from **START HERE** selects the workload automatically. If you came here directly, use only the two selectors above: **Namespace** and **Workload**."
+          }
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Pods ready",
+          "description": "100% means every selected pod reports Ready.",
+          "gridPos": { "x": 0, "y": 5, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "100 * sum(kube_pod_status_ready{namespace=\"$namespace\",pod=~\"$pod\",condition=\"true\"} == 1) / clamp_min(count(kube_pod_status_ready{namespace=\"$namespace\",pod=~\"$pod\",condition=\"true\"}), 1)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "yellow", "value": 90 },
+                  { "color": "green", "value": 100 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Restarts — selected range",
+          "description": "Container restarts for this workload during the dashboard time range.",
+          "gridPos": { "x": 6, "y": 5, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"$namespace\",pod=~\"$pod\"}[$__range])) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "decimals": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 5 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Memory limit used",
+          "description": "85%+ is urgent OOM risk. No value means the workload has no memory limit.",
+          "gridPos": { "x": 12, "y": 5, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "100 * sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$pod\",container!=\"\",container!=\"POD\"}) / clamp_min(sum(kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$pod\",resource=\"memory\",unit=\"byte\",container!=\"\"}), 1)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 70 },
+                  { "color": "red", "value": 85 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "Error-like log lines — selected range",
+          "description": "Broad error/exception/traceback/failed match. Read the log panel for context.",
+          "gridPos": { "x": 18, "y": 5, "w": 6, "h": 4 },
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "targets": [
+            {
+              "expr": "sum(count_over_time({k8s_namespace_name=\"$namespace\",k8s_pod_name=~\"$pod\"} |~ \"(?i)error|exception|traceback|failed\" [$__range]))",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 100 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 100,
+          "type": "row",
+          "title": "CPU — is the app busy, or is a limit choking it?",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 9, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 6,
+          "type": "timeseries",
+          "title": "CPU used vs request vs hard limit",
+          "description": "Used above request is allowed and mainly means the request is undersized. Used pinned near the hard limit plus throttling means real latency risk. No HARD LIMIT line means no CPU limit.",
+          "gridPos": { "x": 0, "y": 10, "w": 16, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",pod=~\"$pod\",container!=\"\",container!=\"POD\",image!=\"\"}[5m]))",
+              "legendFormat": "ACTUAL CPU",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$pod\",resource=\"cpu\",unit=\"core\",container!=\"\"})",
+              "legendFormat": "REQUEST",
+              "refId": "B"
+            },
+            {
+              "expr": "sum(kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$pod\",resource=\"cpu\",unit=\"core\",container!=\"\"})",
+              "legendFormat": "HARD LIMIT",
+              "refId": "C"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cores",
+              "decimals": 2,
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 12,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 3,
+                "showPoints": "never",
+                "spanNulls": true
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 7,
+          "type": "timeseries",
+          "title": "CPU throttling",
+          "description": "10%+ sustained means the CPU limit is actively blocking work. No line means there is no CPU limit or no throttling.",
+          "gridPos": { "x": 16, "y": 10, "w": 8, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "100 * sum(rate(container_cpu_cfs_throttled_periods_total{namespace=\"$namespace\",pod=~\"$pod\",container!=\"\",container!=\"POD\"}[5m])) / clamp_min(sum(rate(container_cpu_cfs_periods_total{namespace=\"$namespace\",pod=~\"$pod\",container!=\"\",container!=\"POD\"}[5m])), 0.001)",
+              "legendFormat": "throttled",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 10 },
+                  { "color": "red", "value": 25 }
+                ]
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 3,
+                "showPoints": "never",
+                "spanNulls": true,
+                "thresholdsStyle": { "mode": "area" }
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "single", "sort": "none" }
+          }
+        },
+        {
+          "id": 101,
+          "type": "row",
+          "title": "MEMORY — stable cache, steady leak, or hard-limit danger?",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 18, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "Memory used vs request vs hard limit",
+          "description": "A stable plateau is usually cache. A steady climb is leak-shaped. Touching the hard limit causes OOM kills.",
+          "gridPos": { "x": 0, "y": 19, "w": 16, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$pod\",container!=\"\",container!=\"POD\"})",
+              "legendFormat": "ACTUAL MEMORY",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$pod\",resource=\"memory\",unit=\"byte\",container!=\"\"})",
+              "legendFormat": "REQUEST",
+              "refId": "B"
+            },
+            {
+              "expr": "sum(kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$pod\",resource=\"memory\",unit=\"byte\",container!=\"\"})",
+              "legendFormat": "HARD LIMIT",
+              "refId": "C"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 12,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 3,
+                "showPoints": "never",
+                "spanNulls": true
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 9,
+          "type": "bargauge",
+          "title": "Memory by pod right now",
+          "description": "One pod much larger than its peers points to a pod-local leak, backlog, or hot shard.",
+          "gridPos": { "x": 16, "y": 19, "w": 8, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum by(pod) (container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$pod\",container!=\"\",container!=\"POD\"})",
+              "instant": true,
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+          "options": {
+            "displayMode": "gradient",
+            "legend": { "showLegend": false },
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          }
+        },
+        {
+          "id": 102,
+          "type": "row",
+          "title": "DEPENDENCIES AND I/O — is the app waiting on something else?",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 27, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 10,
+          "type": "timeseries",
+          "title": "Network traffic",
+          "description": "Traffic spikes explain load. A flatline during expected traffic can indicate routing or dependency failure.",
+          "gridPos": { "x": 0, "y": 28, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod=~\"$pod\"}[5m]))",
+              "legendFormat": "received",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$namespace\",pod=~\"$pod\"}[5m]))",
+              "legendFormat": "sent",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "Bps" }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 11,
+          "type": "timeseries",
+          "title": "Container filesystem I/O",
+          "description": "Heavy reads/writes can explain latency even when CPU is low. This is container filesystem traffic, not storage latency.",
+          "gridPos": { "x": 12, "y": 28, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum(rate(container_fs_reads_bytes_total{namespace=\"$namespace\",pod=~\"$pod\"}[5m]))",
+              "legendFormat": "read",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(container_fs_writes_bytes_total{namespace=\"$namespace\",pod=~\"$pod\"}[5m]))",
+              "legendFormat": "written",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "Bps" }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 103,
+          "type": "row",
+          "title": "ERRORS — the matching logs, already filtered",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 36, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 12,
+          "type": "timeseries",
+          "title": "Error-like log lines over time",
+          "description": "Correlate spikes with CPU, memory, I/O, and restarts above.",
+          "gridPos": { "x": 0, "y": 37, "w": 24, "h": 6 },
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "targets": [
+            {
+              "expr": "sum by(k8s_pod_name) (count_over_time({k8s_namespace_name=\"$namespace\",k8s_pod_name=~\"$pod\"} |~ \"(?i)error|exception|traceback|failed\" [$__auto]))",
+              "legendFormat": "{{k8s_pod_name}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 13,
+          "type": "logs",
+          "title": "Recent matching errors",
+          "description": "Newest first. Expand a line for labels and full context.",
+          "gridPos": { "x": 0, "y": 43, "w": 24, "h": 14 },
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "targets": [
+            {
+              "expr": "{k8s_namespace_name=\"$namespace\",k8s_pod_name=~\"$pod\"} |~ \"(?i)error|exception|traceback|failed\"",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "dedupStrategy": "exact",
+            "enableLogDetails": true,
+            "prettifyLogMessage": true,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          }
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": ["performance", "kubernetes", "logs", "start-here"],
+      "templating": {
+        "list": [
+          {
+            "type": "datasource",
+            "name": "DS_PROM",
+            "label": "Prometheus",
+            "query": "prometheus",
+            "hide": 2,
+            "current": { "text": "Prometheus", "value": "Prometheus" }
+          },
+          {
+            "type": "datasource",
+            "name": "DS_LOKI",
+            "label": "Loki",
+            "query": "loki",
+            "hide": 2,
+            "current": { "text": "Loki", "value": "Loki" }
+          },
+          {
+            "type": "query",
+            "name": "namespace",
+            "label": "Namespace",
+            "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+            "query": {
+              "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel, namespace)",
+              "refId": "Namespace"
+            },
+            "refresh": 1,
+            "sort": 1,
+            "multi": false,
+            "includeAll": false,
+            "current": { "selected": true, "text": "posthog", "value": "posthog" }
+          },
+          {
+            "type": "query",
+            "name": "workload",
+            "label": "Workload",
+            "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+            "query": {
+              "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{namespace=\"$namespace\"}, workload)",
+              "refId": "Workload"
+            },
+            "refresh": 1,
+            "sort": 1,
+            "multi": true,
+            "includeAll": true,
+            "allValue": ".*",
+            "current": { "selected": true, "text": "All", "value": "$__all" }
+          },
+          {
+            "type": "query",
+            "name": "pod",
+            "label": "Pod",
+            "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+            "query": {
+              "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{namespace=\"$namespace\",workload=~\"$workload\"}, pod)",
+              "refId": "Pod"
+            },
+            "refresh": 1,
+            "sort": 1,
+            "multi": true,
+            "includeAll": true,
+            "allValue": ".*",
+            "hide": 2,
+            "current": { "selected": true, "text": "All", "value": "$__all" }
+          }
+        ]
+      },
+      "time": { "from": "now-6h", "to": "now" },
+      "timezone": "browser",
+      "title": "WHY IS THIS APP SLOW?",
+      "uid": "app-performance-investigator",
+      "version": 1
+    }

--- a/monitoring/prometheus-stack/kustomization.yaml
+++ b/monitoring/prometheus-stack/kustomization.yaml
@@ -14,6 +14,9 @@ resources:
   - argocd-sync-alerts.yaml # ArgoCD control-plane + app-state alerts (stale-sync incident 2026-05-29)
   - dcgm-exporter.yaml # DCGM GPU monitoring
   - gpu-alerts.yaml # GPU alerting rules
+  - performance-cockpit-dashboard.yaml # Default Grafana home: plain-English cluster performance triage
+  - app-performance-dashboard.yaml # Two-selector workload investigation with correlated Loki errors
+  - posthog-performance-dashboard.yaml # PostHog web/Postgres/Kafka/ClickHouse root-cause decoder
   - gpu-dashboard.yaml # Grafana dashboard
   - vpa-recommendations-dashboard.yaml # Active VPA policy and recommendation dashboard
   - trivy-dashboard.yaml # Trivy Operator vulnerability dashboard (Grafana 17813; pairs with monitoring/trivy-operator)

--- a/monitoring/prometheus-stack/performance-cockpit-dashboard.yaml
+++ b/monitoring/prometheus-stack/performance-cockpit-dashboard.yaml
@@ -1,0 +1,679 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: performance-cockpit-dashboard
+  namespace: prometheus-stack
+  labels:
+    grafana_dashboard: "1"
+    app.kubernetes.io/name: grafana-dashboards
+data:
+  performance-cockpit.json: |
+    {
+      "annotations": { "list": [] },
+      "description": "The one-screen starting point for cluster performance incidents. Red cards first, then click a workload to explain it.",
+      "editable": false,
+      "graphTooltip": 1,
+      "links": [
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": false,
+          "keepTime": true,
+          "targetBlank": false,
+          "title": "WHY IS THIS APP SLOW?",
+          "type": "link",
+          "url": "/d/app-performance-investigator/why-is-this-app-slow"
+        }
+      ],
+      "panels": [
+        {
+          "id": 1,
+          "type": "text",
+          "title": "START HERE — four steps, no dashboard scavenger hunt",
+          "gridPos": { "x": 0, "y": 0, "w": 24, "h": 5 },
+          "options": {
+            "mode": "markdown",
+            "content": "## 1. Fix red cards first\n**Cluster red** means the machine is full. **Workload red** means one app is the likely cause. **Alerts red** usually tells you the exact broken component.\n\n## 2. Find the offender\nThe four ranked lists below show who is using CPU/RAM and who is close to a hard limit. **Click any bar** to open the app investigator with the correct namespace and workload already selected.\n\n## 3. Read the cause decoder\nCPU throttling = CPU limit; memory near limit + restarts = likely OOM; resources green + errors = app/dependency/config problem.\n\n## 4. Only then use a specialist view\n[PostHog — web / Postgres / Kafka / ClickHouse](/d/posthog-performance/why-is-posthog-slow) · [Storage / Longhorn](/d/2BCgsldGz/storage) · [Deployments / ArgoCD](/d/qPkgGHg7k/deployments) · [Right-sizing / VPA](/d/vpa-recommendations/right-sizing) · [GPU](/d/gpu-overview/gpu) · [Raw app logs](/d/loki-logs-otel/logs)"
+          }
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Critical alerts",
+          "description": "Do these first. A value of 0 is healthy.",
+          "gridPos": { "x": 0, "y": 5, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            { "expr": "count(max by(alertname,namespace) (ALERTS{alertstate=\"firing\",severity=\"critical\"})) or vector(0)", "instant": true, "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 1 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Performance / reliability warnings",
+          "description": "Security scan findings are intentionally excluded from this performance cockpit.",
+          "gridPos": { "x": 6, "y": 5, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            { "expr": "count(max by(alertname,namespace) (ALERTS{alertstate=\"firing\",severity=\"warning\",category!=\"security\"})) or vector(0)", "instant": true, "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 10 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Pods not ready",
+          "description": "Running or pending pods that are not ready right now.",
+          "gridPos": { "x": 12, "y": 5, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum((kube_pod_status_ready{condition=\"true\"} == 0) * on(namespace,pod) group_left() (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 1 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "Container restarts — 1 hour",
+          "description": "A sudden increase usually means crashes, OOMs, or a bad rollout.",
+          "gridPos": { "x": 18, "y": 5, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            { "expr": "sum(increase(kube_pod_container_status_restarts_total[1h])) or vector(0)", "instant": true, "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "decimals": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 5 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 100,
+          "type": "row",
+          "title": "IS THE CLUSTER ITSELF FULL?",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 9, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 6,
+          "type": "stat",
+          "title": "Busiest node CPU",
+          "description": "If this is red, apps are competing for CPU on at least one node.",
+          "gridPos": { "x": 0, "y": 10, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            { "expr": "max(100 * (1 - avg by(instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))))", "instant": true, "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 70 },
+                  { "color": "red", "value": 85 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 7,
+          "type": "stat",
+          "title": "Fullest node memory",
+          "description": "Above 85% means eviction and OOM risk is getting real.",
+          "gridPos": { "x": 6, "y": 10, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            { "expr": "max(100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))", "instant": true, "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 75 },
+                  { "color": "red", "value": 85 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 8,
+          "type": "stat",
+          "title": "Fullest node disk",
+          "description": "Root or /var filesystem usage. Above 85% risks pod and image failures.",
+          "gridPos": { "x": 12, "y": 10, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "max(100 * (1 - node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs\",mountpoint=~\"/|/var\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs\",mountpoint=~\"/|/var\"}))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 75 },
+                  { "color": "red", "value": 85 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 9,
+          "type": "stat",
+          "title": "Node pressure conditions",
+          "description": "MemoryPressure, DiskPressure, or PIDPressure. Any non-zero value is urgent.",
+          "gridPos": { "x": 18, "y": 10, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum(kube_node_status_condition{condition=~\"MemoryPressure|DiskPressure|PIDPressure\",status=\"true\"} == 1) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 1 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 101,
+          "type": "row",
+          "title": "WHICH WORKLOAD IS CAUSING THE PRESSURE? — click a bar to explain it",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 14, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 10,
+          "type": "bargauge",
+          "title": "Top CPU users — actual cores",
+          "description": "The apps doing the most CPU work right now. High usage is only a problem when node CPU or throttling is also high.",
+          "gridPos": { "x": 0, "y": 15, "w": 12, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "topk(10, sum by(namespace,workload,workload_type) (rate(container_cpu_usage_seconds_total{container!=\"\",container!=\"POD\",image!=\"\"}[5m]) * on(namespace,pod) group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel))",
+              "instant": true,
+              "legendFormat": "{{namespace}} / {{workload}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cores",
+              "decimals": 2,
+              "links": [
+                {
+                  "title": "Explain this workload",
+                  "url": "/d/app-performance-investigator/why-is-this-app-slow?var-namespace=${__field.labels.namespace}&var-workload=${__field.labels.workload}"
+                }
+              ]
+            },
+            "overrides": []
+          },
+          "options": {
+            "displayMode": "gradient",
+            "legend": { "showLegend": false },
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          }
+        },
+        {
+          "id": 11,
+          "type": "bargauge",
+          "title": "Top memory users — actual working set",
+          "description": "The apps consuming the most RAM. Compare this with node memory and the limit-risk panel below.",
+          "gridPos": { "x": 12, "y": 15, "w": 12, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "topk(10, sum by(namespace,workload,workload_type) (container_memory_working_set_bytes{container!=\"\",container!=\"POD\",image!=\"\"} * on(namespace,pod) group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel))",
+              "instant": true,
+              "legendFormat": "{{namespace}} / {{workload}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "links": [
+                {
+                  "title": "Explain this workload",
+                  "url": "/d/app-performance-investigator/why-is-this-app-slow?var-namespace=${__field.labels.namespace}&var-workload=${__field.labels.workload}"
+                }
+              ]
+            },
+            "overrides": []
+          },
+          "options": {
+            "displayMode": "gradient",
+            "legend": { "showLegend": false },
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          }
+        },
+        {
+          "id": 12,
+          "type": "bargauge",
+          "title": "Memory limit risk",
+          "description": "Working set as a percent of the hard memory limit. 85%+ is where OOM risk becomes urgent. Workloads without a limit do not appear.",
+          "gridPos": { "x": 0, "y": 22, "w": 12, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "topk(10, 100 * sum by(namespace,workload,workload_type) (container_memory_working_set_bytes{container!=\"\",container!=\"POD\",image!=\"\"} * on(namespace,pod) group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel) / clamp_min(sum by(namespace,workload,workload_type) (kube_pod_container_resource_limits{resource=\"memory\",unit=\"byte\",container!=\"\"} * on(namespace,pod) group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel), 1))",
+              "instant": true,
+              "legendFormat": "{{namespace}} / {{workload}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 70 },
+                  { "color": "red", "value": 85 }
+                ]
+              },
+              "links": [
+                {
+                  "title": "Explain this workload",
+                  "url": "/d/app-performance-investigator/why-is-this-app-slow?var-namespace=${__field.labels.namespace}&var-workload=${__field.labels.workload}"
+                }
+              ]
+            },
+            "overrides": []
+          },
+          "options": {
+            "displayMode": "lcd",
+            "legend": { "showLegend": false },
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          }
+        },
+        {
+          "id": 13,
+          "type": "bargauge",
+          "title": "CPU throttling risk",
+          "description": "Percent of CPU scheduling periods blocked by a CPU limit. Sustained 10%+ can cause latency even when node CPU looks fine.",
+          "gridPos": { "x": 12, "y": 22, "w": 12, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "topk(10, 100 * sum by(namespace,workload,workload_type) (rate(container_cpu_cfs_throttled_periods_total{container!=\"\",container!=\"POD\"}[5m]) * on(namespace,pod) group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel) / clamp_min(sum by(namespace,workload,workload_type) (rate(container_cpu_cfs_periods_total{container!=\"\",container!=\"POD\"}[5m]) * on(namespace,pod) group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel), 0.001))",
+              "instant": true,
+              "legendFormat": "{{namespace}} / {{workload}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 10 },
+                  { "color": "red", "value": 25 }
+                ]
+              },
+              "links": [
+                {
+                  "title": "Explain this workload",
+                  "url": "/d/app-performance-investigator/why-is-this-app-slow?var-namespace=${__field.labels.namespace}&var-workload=${__field.labels.workload}"
+                }
+              ]
+            },
+            "overrides": []
+          },
+          "options": {
+            "displayMode": "lcd",
+            "legend": { "showLegend": false },
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          }
+        },
+        {
+          "id": 102,
+          "type": "row",
+          "title": "WHAT FAILED? — alerts and errors usually explain the cause",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 29, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 14,
+          "type": "table",
+          "title": "Active alerts",
+          "description": "Critical and warning reliability alerts. Security findings stay in the Trivy dashboard.",
+          "gridPos": { "x": 0, "y": 30, "w": 12, "h": 9 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "max by(alertname,namespace,severity) (ALERTS{alertstate=\"firing\",severity=~\"critical|warning\",category!=\"security\"})",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": { "Time": true, "__name__": true, "Value": true },
+                "indexByName": { "severity": 0, "namespace": 1, "alertname": 2 },
+                "renameByName": { "alertname": "Problem", "namespace": "Namespace", "severity": "Severity" }
+              }
+            },
+            { "id": "sortBy", "options": { "fields": {}, "sort": [{ "field": "Severity", "desc": false }] } }
+          ],
+          "fieldConfig": { "defaults": {}, "overrides": [] },
+          "options": { "cellHeight": "sm", "showHeader": true }
+        },
+        {
+          "id": 15,
+          "type": "bargauge",
+          "title": "Namespaces producing error-like logs — last 5 minutes",
+          "description": "A high count points to the app or dependency to inspect. This is a broad text match, so read the logs before concluding.",
+          "gridPos": { "x": 12, "y": 30, "w": 12, "h": 9 },
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "targets": [
+            {
+              "expr": "topk(10, sum by(k8s_namespace_name) (count_over_time({k8s_namespace_name=~\".+\"} |~ \"(?i)error|exception|traceback|failed\" [5m])))",
+              "legendFormat": "{{k8s_namespace_name}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 10 },
+                  { "color": "red", "value": 100 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "displayMode": "gradient",
+            "legend": { "showLegend": false },
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          }
+        },
+        {
+          "id": 103,
+          "type": "row",
+          "title": "CRASHES AND STUCK PODS — empty tables are good",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 39, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 16,
+          "type": "table",
+          "title": "Containers that restarted — with the last known cause",
+          "description": "OOMKilled is memory pressure. Error usually needs the app logs. Completed is often an intentional Job.",
+          "gridPos": { "x": 0, "y": 40, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "topk(20, (sum by(namespace,pod,container) (increase(kube_pod_container_status_restarts_total[$__range])) * on(namespace,pod,container) group_left(reason) (kube_pod_container_status_last_terminated_reason == 1)) > 0)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": { "Time": true, "__name__": true },
+                "indexByName": { "namespace": 0, "pod": 1, "container": 2, "reason": 3, "Value": 4 },
+                "renameByName": { "namespace": "Namespace", "pod": "Pod", "container": "Container", "reason": "Last cause", "Value": "Restarts" }
+              }
+            }
+          ],
+          "fieldConfig": { "defaults": { "decimals": 0 }, "overrides": [] },
+          "options": { "cellHeight": "sm", "showHeader": true }
+        },
+        {
+          "id": 17,
+          "type": "table",
+          "title": "Pods not ready right now",
+          "description": "If this is empty, every running or pending pod currently reports Ready.",
+          "gridPos": { "x": 12, "y": 40, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum by(namespace,pod) ((kube_pod_status_ready{condition=\"true\"} == 0) * on(namespace,pod) group_left() (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)) > 0",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": { "Time": true, "__name__": true, "Value": true },
+                "indexByName": { "namespace": 0, "pod": 1 },
+                "renameByName": { "namespace": "Namespace", "pod": "Pod" }
+              }
+            }
+          ],
+          "fieldConfig": { "defaults": {}, "overrides": [] },
+          "options": { "cellHeight": "sm", "showHeader": true }
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": ["start-here", "performance", "kubernetes"],
+      "templating": {
+        "list": [
+          {
+            "type": "datasource",
+            "name": "DS_PROM",
+            "label": "Prometheus",
+            "query": "prometheus",
+            "hide": 2,
+            "current": { "text": "Prometheus", "value": "Prometheus" }
+          },
+          {
+            "type": "datasource",
+            "name": "DS_LOKI",
+            "label": "Loki",
+            "query": "loki",
+            "hide": 2,
+            "current": { "text": "Loki", "value": "Loki" }
+          }
+        ]
+      },
+      "time": { "from": "now-6h", "to": "now" },
+      "timezone": "browser",
+      "title": "START HERE — Cluster Performance",
+      "uid": "performance-cockpit",
+      "version": 1
+    }

--- a/monitoring/prometheus-stack/posthog-performance-dashboard.yaml
+++ b/monitoring/prometheus-stack/posthog-performance-dashboard.yaml
@@ -1,0 +1,1060 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: posthog-performance-dashboard
+  namespace: prometheus-stack
+  labels:
+    grafana_dashboard: "1"
+    app.kubernetes.io/name: grafana-dashboards
+data:
+  posthog-performance.json: |
+    {
+      "annotations": { "list": [] },
+      "description": "One-page PostHog root-cause dashboard: web/API, PostgreSQL, Kafka/Redpanda, ClickHouse, workers, and correlated errors.",
+      "editable": false,
+      "graphTooltip": 1,
+      "links": [
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": false,
+          "keepTime": true,
+          "targetBlank": false,
+          "title": "Back to START HERE",
+          "type": "link",
+          "url": "/d/performance-cockpit/start-here-cluster-performance"
+        },
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": false,
+          "keepTime": true,
+          "targetBlank": false,
+          "title": "PostHog pod investigator",
+          "type": "link",
+          "url": "/d/app-performance-investigator/why-is-this-app-slow?var-namespace=posthog"
+        }
+      ],
+      "panels": [
+        {
+          "id": 1,
+          "type": "text",
+          "title": "WHY IS POSTHOG SLOW? — read left to right",
+          "gridPos": { "x": 0, "y": 0, "w": 24, "h": 6 },
+          "options": {
+            "mode": "markdown",
+            "content": "## The first red card identifies the layer\n**WEB/API red + data stores green:** bad release, schema mismatch, dependency address, or application error. Read **Current root-cause errors**.\n\n**POSTGRES red:** connections, a long transaction, locks, deadlocks, or poor cache hit. **KAFKA LAG red:** an ingestion consumer cannot keep up. **CLICKHOUSE red:** analytics queries, merges, parts, or memory are blocking work. **WORKERS red:** a pod is CPU/memory constrained or restarting.\n\n### Healthy guide\nWeb p95 **< 1 s** · HTTP 5xx **< 1%** · Kafka lag **near 0** · Postgres connections **< 70%** · cache hit **> 95%** · no deadlocks · no long transaction **> 60 s**. Click a row title to expand only the layer that is red."
+          }
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "WEB — p95 response",
+          "description": "95% of web requests completed faster than this over 15 minutes.",
+          "gridPos": { "x": 0, "y": 6, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by(le) (rate(django_http_requests_latency_including_middlewares_seconds_bucket{namespace=\"posthog\"}[15m])))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "noValue": "NO WEB METRICS",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 3 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "WEB — HTTP 5xx",
+          "description": "Server-error percentage over 15 minutes. NaN with no requests is healthy/idle.",
+          "gridPos": { "x": 4, "y": 6, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "(100 * sum(rate(django_http_responses_total_by_status_total{namespace=\"posthog\",status=~\"5..\"}[15m])) / sum(rate(django_http_responses_total_by_status_total{namespace=\"posthog\"}[15m]))) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 5 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "KAFKA — worst lag",
+          "description": "Largest unprocessed consumer offset. The Kafka row names the delayed group and topic.",
+          "gridPos": { "x": 8, "y": 6, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "max(clamp_min(max by(redpanda_topic,redpanda_partition) (redpanda_kafka_max_offset{namespace=\"posthog\",redpanda_namespace=\"kafka\"}) - on(redpanda_topic,redpanda_partition) group_right(redpanda_group) max by(redpanda_group,redpanda_topic,redpanda_partition) (redpanda_kafka_consumer_group_committed_offset{namespace=\"posthog\"}), 0)) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "noValue": "NO KAFKA METRICS",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1000 },
+                  { "color": "red", "value": 10000 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "POSTGRES — connections",
+          "description": "Current database connections as a percentage of max_connections.",
+          "gridPos": { "x": 12, "y": 6, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "(100 * max(pg_stat_database_numbackends{namespace=\"posthog\",datname=\"posthog\"}) / max(pg_settings_max_connections{namespace=\"posthog\"})) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "noValue": "NO PG METRICS",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 70 },
+                  { "color": "red", "value": 85 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 6,
+          "type": "stat",
+          "title": "CLICKHOUSE — active work",
+          "description": "Queries plus background merges. Sustained growth points to analytics pressure.",
+          "gridPos": { "x": 16, "y": 6, "w": 4, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "max(ClickHouseMetrics_Query{namespace=\"posthog\"}) + max(ClickHouseMetrics_Merge{namespace=\"posthog\"}) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "noValue": "NO CH METRICS",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 10 },
+                  { "color": "red", "value": 50 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 7,
+          "type": "stat",
+          "title": "ERRORS — last 15m",
+          "description": "PostHog error, exception, timeout, connection-refused, and traceback lines.",
+          "gridPos": { "x": 20, "y": 6, "w": 4, "h": 4 },
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "targets": [
+            {
+              "expr": "sum(count_over_time({k8s_namespace_name=\"posthog\"} |~ \"(?i)error|exception|traceback|timed out|timeout|connection refused\" [15m]))",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 20 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 100,
+          "type": "row",
+          "title": "WEB / API — WHICH SCREEN OR ENDPOINT IS SLOW OR BROKEN?",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 10, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 8,
+          "type": "bargauge",
+          "title": "Slowest endpoints — average over 15m",
+          "description": "The exact PostHog view and HTTP method consuming time. Empty means no recent traffic.",
+          "gridPos": { "x": 0, "y": 11, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "topk(12, (sum by(view,method) (rate(django_http_requests_latency_seconds_by_view_method_sum{namespace=\"posthog\"}[15m])) / sum by(view,method) (rate(django_http_requests_latency_seconds_by_view_method_count{namespace=\"posthog\"}[15m]))) and on(view,method) (sum by(view,method) (increase(django_http_requests_latency_seconds_by_view_method_count{namespace=\"posthog\"}[15m])) > 0))",
+              "instant": true,
+              "legendFormat": "{{method}} {{view}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 3 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "displayMode": "gradient",
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          }
+        },
+        {
+          "id": 9,
+          "type": "bargauge",
+          "title": "Failing endpoints — HTTP 5xx in selected range",
+          "description": "Names the broken PostHog feature instead of showing one anonymous error total.",
+          "gridPos": { "x": 12, "y": 11, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "topk(12, sum by(view,method) (increase(django_http_responses_total_by_status_view_method_total{namespace=\"posthog\",status=~\"5..\"}[$__range])))",
+              "instant": true,
+              "legendFormat": "{{method}} {{view}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 10 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "displayMode": "gradient",
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          }
+        },
+        {
+          "id": 10,
+          "type": "timeseries",
+          "title": "Web p50 / p95 / p99 response time",
+          "description": "A rising tail with green data stores usually means a slow endpoint or application release.",
+          "gridPos": { "x": 0, "y": 19, "w": 12, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by(le) (rate(django_http_requests_latency_including_middlewares_seconds_bucket{namespace=\"posthog\"}[5m])))",
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by(le) (rate(django_http_requests_latency_including_middlewares_seconds_bucket{namespace=\"posthog\"}[5m])))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by(le) (rate(django_http_requests_latency_including_middlewares_seconds_bucket{namespace=\"posthog\"}[5m])))",
+              "legendFormat": "p99",
+              "refId": "C"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 11,
+          "type": "timeseries",
+          "title": "Requests and server errors",
+          "description": "Traffic explains load; 5xx tells you whether users are waiting on a failure.",
+          "gridPos": { "x": 12, "y": 19, "w": 12, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum(rate(django_http_responses_total_by_status_total{namespace=\"posthog\"}[5m]))",
+              "legendFormat": "all responses / sec",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(django_http_responses_total_by_status_total{namespace=\"posthog\",status=~\"5..\"}[5m]))",
+              "legendFormat": "5xx / sec",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "reqps", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 101,
+          "type": "row",
+          "title": "POSTGRES — CONNECTIONS, CACHE, LOCKS, OR A SLOW QUERY?",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 26, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 12,
+          "type": "stat",
+          "title": "Cache hit",
+          "description": "Below 95% means Postgres is going to storage much more often.",
+          "gridPos": { "x": 0, "y": 27, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "(100 * sum(rate(pg_stat_database_blks_hit{namespace=\"posthog\",datname=\"posthog\"}[5m])) / (sum(rate(pg_stat_database_blks_hit{namespace=\"posthog\",datname=\"posthog\"}[5m])) + sum(rate(pg_stat_database_blks_read{namespace=\"posthog\",datname=\"posthog\"}[5m])))) or vector(100)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "noValue": "NO PG METRICS",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "yellow", "value": 90 },
+                  { "color": "green", "value": 95 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 13,
+          "type": "stat",
+          "title": "Deadlocks — 1h",
+          "description": "Any increase means transactions blocked each other and Postgres killed one.",
+          "gridPos": { "x": 6, "y": 27, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum(increase(pg_stat_database_deadlocks{namespace=\"posthog\",datname=\"posthog\"}[1h])) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 1 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 14,
+          "type": "stat",
+          "title": "Oldest active transaction",
+          "description": "Long transactions hold old row versions and can block cleanup.",
+          "gridPos": { "x": 12, "y": 27, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "max(pg_long_running_transactions_oldest_timestamp_seconds{namespace=\"posthog\"}) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 60 },
+                  { "color": "red", "value": 300 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 15,
+          "type": "stat",
+          "title": "Temporary data — 1h",
+          "description": "Large values mean sorts/hashes spilled to disk.",
+          "gridPos": { "x": 18, "y": 27, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum(increase(pg_stat_database_temp_bytes{namespace=\"posthog\",datname=\"posthog\"}[1h])) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1073741824 },
+                  { "color": "red", "value": 5368709120 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 16,
+          "type": "timeseries",
+          "title": "Postgres transactions / sec",
+          "description": "Rollback spikes usually pair with application errors or contention.",
+          "gridPos": { "x": 0, "y": 31, "w": 8, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum(rate(pg_stat_database_xact_commit{namespace=\"posthog\",datname=\"posthog\"}[5m]))",
+              "legendFormat": "committed",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(pg_stat_database_xact_rollback{namespace=\"posthog\",datname=\"posthog\"}[5m]))",
+              "legendFormat": "rolled back",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "ops", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 17,
+          "type": "timeseries",
+          "title": "Postgres locks by mode",
+          "description": "AccessExclusiveLock growth is the dangerous one; it can block normal reads and writes.",
+          "gridPos": { "x": 8, "y": 31, "w": 8, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum by(mode) (pg_locks_count{namespace=\"posthog\",datname=\"posthog\"})",
+              "legendFormat": "{{mode}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 18,
+          "type": "bargauge",
+          "title": "Slow Postgres query IDs — average over 15m",
+          "description": "Query text is intentionally not exported. Use the queryid with pg_stat_statements in the toolbox.",
+          "gridPos": { "x": 16, "y": 31, "w": 8, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "topk(10, rate(pg_stat_statements_seconds_total{namespace=\"posthog\",datname=\"posthog\"}[15m]) / clamp_min(rate(pg_stat_statements_calls_total{namespace=\"posthog\",datname=\"posthog\"}[15m]), 0.000001))",
+              "instant": true,
+              "legendFormat": "query {{queryid}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 0.1 },
+                  { "color": "red", "value": 1 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          }
+        },
+        {
+          "id": 102,
+          "type": "row",
+          "title": "KAFKA / REDPANDA — WHICH CONSUMER IS FALLING BEHIND?",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 38, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 19,
+          "type": "bargauge",
+          "title": "Consumer lag by group",
+          "description": "This is the backlog that makes ingestion and downstream analytics feel delayed.",
+          "gridPos": { "x": 0, "y": 39, "w": 12, "h": 10 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "topk(20, sum by(redpanda_group) (clamp_min(max by(redpanda_topic,redpanda_partition) (redpanda_kafka_max_offset{namespace=\"posthog\",redpanda_namespace=\"kafka\"}) - on(redpanda_topic,redpanda_partition) group_right(redpanda_group) max by(redpanda_group,redpanda_topic,redpanda_partition) (redpanda_kafka_consumer_group_committed_offset{namespace=\"posthog\"}), 0)))",
+              "instant": true,
+              "legendFormat": "{{redpanda_group}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1000 },
+                  { "color": "red", "value": 10000 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          }
+        },
+        {
+          "id": 20,
+          "type": "timeseries",
+          "title": "Lag trend by consumer group",
+          "description": "Rising means the consumer is slower than producers; falling means it is catching up.",
+          "gridPos": { "x": 12, "y": 39, "w": 12, "h": 10 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum by(redpanda_group) (clamp_min(max by(redpanda_topic,redpanda_partition) (redpanda_kafka_max_offset{namespace=\"posthog\",redpanda_namespace=\"kafka\"}) - on(redpanda_topic,redpanda_partition) group_right(redpanda_group) max by(redpanda_group,redpanda_topic,redpanda_partition) (redpanda_kafka_consumer_group_committed_offset{namespace=\"posthog\"}), 0))",
+              "legendFormat": "{{redpanda_group}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 21,
+          "type": "stat",
+          "title": "Unavailable partitions",
+          "description": "Anything above zero is a Redpanda availability problem.",
+          "gridPos": { "x": 0, "y": 49, "w": 6, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum(redpanda_cluster_unavailable_partitions{namespace=\"posthog\"}) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 1 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          }
+        },
+        {
+          "id": 22,
+          "type": "timeseries",
+          "title": "Active consumers by group",
+          "description": "A drop to zero explains growing lag even when Kafka itself is healthy.",
+          "gridPos": { "x": 6, "y": 49, "w": 18, "h": 4 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum by(redpanda_group) (redpanda_kafka_consumer_group_consumers{namespace=\"posthog\"})",
+              "legendFormat": "{{redpanda_group}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "min"], "displayMode": "table", "placement": "right", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 103,
+          "type": "row",
+          "title": "CLICKHOUSE — QUERY, MERGE, PART, OR MEMORY PRESSURE?",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 53, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 23,
+          "type": "timeseries",
+          "title": "Active ClickHouse queries and merges",
+          "description": "Queries are user work; merges are background storage work competing for CPU and I/O.",
+          "gridPos": { "x": 0, "y": 54, "w": 8, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "ClickHouseMetrics_Query{namespace=\"posthog\"}",
+              "legendFormat": "queries",
+              "refId": "A"
+            },
+            {
+              "expr": "ClickHouseMetrics_Merge{namespace=\"posthog\"}",
+              "legendFormat": "merges",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 24,
+          "type": "timeseries",
+          "title": "ClickHouse query successes and failures",
+          "description": "A failure spike is a query/schema/config problem, not a generic capacity issue.",
+          "gridPos": { "x": 8, "y": 54, "w": 8, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "rate(ClickHouseProfileEvents_Query{namespace=\"posthog\"}[5m])",
+              "legendFormat": "queries / sec",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(ClickHouseProfileEvents_FailedQuery{namespace=\"posthog\"}[5m])",
+              "legendFormat": "failed / sec",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "ops", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 25,
+          "type": "timeseries",
+          "title": "ClickHouse memory vs pod limit",
+          "description": "Near 100% with restarts means OOM risk. Tracked memory explains query/cache pressure.",
+          "gridPos": { "x": 16, "y": 54, "w": 8, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "100 * sum(container_memory_working_set_bytes{namespace=\"posthog\",container=\"clickhouse\",image!=\"\"}) / sum(kube_pod_container_resource_limits{namespace=\"posthog\",container=\"clickhouse\",resource=\"memory\"})",
+              "legendFormat": "pod limit used",
+              "refId": "A"
+            },
+            {
+              "expr": "100 * max(ClickHouseMetrics_MemoryTracking{namespace=\"posthog\"}) / sum(kube_pod_container_resource_limits{namespace=\"posthog\",container=\"clickhouse\",resource=\"memory\"})",
+              "legendFormat": "ClickHouse tracked",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 26,
+          "type": "timeseries",
+          "title": "MergeTree parts pressure",
+          "description": "A rising maximum part count means inserts are creating parts faster than merges can combine them.",
+          "gridPos": { "x": 0, "y": 61, "w": 12, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "ClickHouseAsyncMetrics_MaxPartCountForPartition{namespace=\"posthog\"}",
+              "legendFormat": "max parts / partition",
+              "refId": "A"
+            },
+            {
+              "expr": "ClickHouseMetrics_PartsTemporary{namespace=\"posthog\"}",
+              "legendFormat": "temporary parts",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 27,
+          "type": "timeseries",
+          "title": "ClickHouse CPU and restarts",
+          "description": "High CPU plus merges means storage maintenance; high CPU plus queries means analytics load.",
+          "gridPos": { "x": 12, "y": 61, "w": 12, "h": 7 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"posthog\",container=\"clickhouse\",image!=\"\"}[5m]))",
+              "legendFormat": "CPU cores",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"posthog\",container=\"clickhouse\"}[1h]))",
+              "legendFormat": "restarts / hour",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 104,
+          "type": "row",
+          "title": "WORKERS / PODS — IS ONE COMPONENT SATURATED OR CRASHING?",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 68, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 28,
+          "type": "timeseries",
+          "title": "CPU by PostHog component",
+          "description": "Names the pod consuming CPU. Sustained flat-topping suggests worker saturation.",
+          "gridPos": { "x": 0, "y": 69, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "topk(15, sum by(pod) (rate(container_cpu_usage_seconds_total{namespace=\"posthog\",container!=\"\",container!=\"POD\",image!=\"\"}[5m])))",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "cores", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 29,
+          "type": "timeseries",
+          "title": "Memory by PostHog component",
+          "description": "Names the pod consuming RAM. Correlate a limit approach with restarts/OOMs.",
+          "gridPos": { "x": 12, "y": 69, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "targets": [
+            {
+              "expr": "topk(15, sum by(pod) (container_memory_working_set_bytes{namespace=\"posthog\",container!=\"\",container!=\"POD\",image!=\"\"}))",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "bytes", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 105,
+          "type": "row",
+          "title": "CURRENT ROOT-CAUSE ERRORS — READ THE MESSAGE, NOT 89 MORE MENUS",
+          "collapsed": false,
+          "gridPos": { "x": 0, "y": 77, "w": 24, "h": 1 },
+          "panels": []
+        },
+        {
+          "id": 30,
+          "type": "timeseries",
+          "title": "Error-like lines by pod",
+          "description": "The pod with the spike is the component to inspect in the log panel below.",
+          "gridPos": { "x": 0, "y": 78, "w": 24, "h": 6 },
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "targets": [
+            {
+              "expr": "sum by(k8s_pod_name) (count_over_time({k8s_namespace_name=\"posthog\"} |~ \"(?i)error|exception|traceback|timed out|timeout|connection refused\" [$__auto]))",
+              "legendFormat": "{{k8s_pod_name}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
+          "options": {
+            "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 31,
+          "type": "logs",
+          "title": "Actual PostHog errors — newest first",
+          "description": "This is where schema mismatch, connection refused, timeouts, OOM clues, and failing migrations become plain text.",
+          "gridPos": { "x": 0, "y": 84, "w": 24, "h": 16 },
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "targets": [
+            {
+              "expr": "{k8s_namespace_name=\"posthog\"} |~ \"(?i)error|exception|traceback|timed out|timeout|connection refused\"",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "dedupStrategy": "exact",
+            "enableLogDetails": true,
+            "prettifyLogMessage": true,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          }
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": ["posthog", "performance", "root-cause", "start-here"],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "hide": 2,
+            "includeAll": false,
+            "label": "Prometheus",
+            "multi": false,
+            "name": "DS_PROM",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": true,
+            "type": "datasource"
+          },
+          {
+            "current": {},
+            "hide": 2,
+            "includeAll": false,
+            "label": "Loki",
+            "multi": false,
+            "name": "DS_LOKI",
+            "options": [],
+            "query": "loki",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": true,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": { "from": "now-6h", "to": "now" },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "WHY IS POSTHOG SLOW?",
+      "uid": "posthog-performance",
+      "version": 1
+    }

--- a/monitoring/prometheus-stack/values.yaml
+++ b/monitoring/prometheus-stack/values.yaml
@@ -237,8 +237,36 @@ grafana:
       searchNamespace: ALL
       label: grafana_dashboard
       labelValue: "1"
-  # Default dashboards
-  defaultDashboardsEnabled: true
+  # Community dashboards are downloaded onto Grafana's persistent data volume.
+  # Removing a gnetId from values does not remove the old JSON file, so prune
+  # only the retired dashboard files before Grafana's downloader runs.
+  extraInitContainers:
+    - name: prune-retired-dashboards
+      image: docker.io/library/busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/sh", "-ec"]
+      args:
+        - |
+          find /var/lib/grafana/dashboards/kubernetes \
+            -maxdepth 1 -type f -name '*.json' -delete 2>/dev/null || true
+          find /var/lib/grafana/dashboards/infrastructure \
+            -maxdepth 1 -type f -name 'vpa-autoscaling.json' -delete 2>/dev/null || true
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        runAsNonRoot: true
+        runAsUser: 472
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+        - name: storage
+          mountPath: /var/lib/grafana
+  # The chart's stock dashboard bundle is intentionally disabled. It added
+  # two dozen overlapping Kubernetes boards and made incident triage a search
+  # problem. The GitOps-managed performance cockpit is the starting point;
+  # specialist boards stay available when the cockpit links to them.
+  defaultDashboardsEnabled: false
   defaultDashboardsTimezone: UTC
   # Community dashboards - auto-provisioned from grafana.com
   dashboardProviders:
@@ -249,7 +277,7 @@ grafana:
         orgId: 1
         folder: 'Kubernetes'
         type: file
-        disableDeletion: true
+        disableDeletion: false
         editable: false
         options:
           path: /var/lib/grafana/dashboards/kubernetes
@@ -257,7 +285,7 @@ grafana:
         orgId: 1
         folder: 'Infrastructure'
         type: file
-        disableDeletion: true
+        disableDeletion: false
         editable: false
         options:
           path: /var/lib/grafana/dashboards/infrastructure
@@ -265,32 +293,15 @@ grafana:
         orgId: 1
         folder: 'Logging'
         type: file
-        disableDeletion: true
+        disableDeletion: false
         editable: false
         options:
           path: /var/lib/grafana/dashboards/logging
   dashboards:
-    kubernetes:
-      k8s-views-global:
-        gnetId: 15757
-        revision: 37
-        datasource: Prometheus
-      k8s-views-namespaces:
-        gnetId: 15758
-        revision: 34
-        datasource: Prometheus
-      k8s-views-nodes:
-        gnetId: 15759
-        revision: 29
-        datasource: Prometheus
-      k8s-views-pods:
-        gnetId: 15760
-        revision: 28
-        datasource: Prometheus
-      node-exporter-full:
-        gnetId: 1860
-        revision: 36
-        datasource: Prometheus
+    # The broad community Kubernetes boards duplicated the same signals across
+    # global/namespace/node/pod screens. The performance cockpit plus its
+    # workload investigator replace that maze.
+    kubernetes: {}
     # Loki dashboards moved to custom ConfigMaps (loki-logs-dashboard.yaml)
     # because community dashboards use Promtail's 'job' label but we use OTEL
     # which sends logs with 'service_name' label instead
@@ -307,10 +318,6 @@ grafana:
       cloudnative-pg:
         gnetId: 20417
         revision: 3
-        datasource: Prometheus
-      vpa-autoscaling:
-        gnetId: 22168
-        revision: 1
         datasource: Prometheus
   # Additional data sources configuration
   additionalDataSources:
@@ -337,6 +344,10 @@ grafana:
   grafana.ini:
     server:
       root_url: https://grafana.vanillax.me
+    dashboards:
+      # The dashboard sidecar writes this GitOps-managed file into the shared
+      # /tmp/dashboards volume. Opening Grafana now lands on the cockpit.
+      default_home_dashboard_path: /tmp/dashboards/performance-cockpit.json
     security:
       allow_embedding: true
       cookie_secure: true

--- a/my-apps/development/posthog/config/clickhouse/config.xml
+++ b/my-apps/development/posthog/config/clickhouse/config.xml
@@ -23,6 +23,17 @@
     <max_connections>4096</max_connections>
     <keep_alive_timeout>3</keep_alive_timeout>
 
+    <!-- Built-in Prometheus endpoint for query, merge, memory, disk, and error
+         pressure. This is intentionally a dedicated port so it cannot expose
+         the SQL-over-HTTP endpoint through the monitoring ServiceMonitor. -->
+    <prometheus>
+        <endpoint>/metrics</endpoint>
+        <port>9363</port>
+        <metrics>true</metrics>
+        <events>true</events>
+        <asynchronous_metrics>true</asynchronous_metrics>
+    </prometheus>
+
     <openSSL>
         <server>
             <certificateFile>/etc/clickhouse-server/server.crt</certificateFile>

--- a/my-apps/development/posthog/core/servicemonitor.yaml
+++ b/my-apps/development/posthog/core/servicemonitor.yaml
@@ -17,3 +17,64 @@ spec:
       path: /metrics
       interval: 30s
       scrapeTimeout: 10s
+---
+# Postgres exporter sidecar on the db Service. Includes connection saturation,
+# locks, cache hit/read activity, deadlocks, table churn, and pg_stat_statements.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: posthog-postgres
+  namespace: posthog
+  labels:
+    app.kubernetes.io/name: posthog
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: posthog
+      app.kubernetes.io/component: db
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+---
+# Redpanda publishes consumer offsets and topic high-water marks at
+# /public_metrics. The dashboard computes lag using Redpanda's documented
+# PromQL so the exact delayed group/topic is visible.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: posthog-kafka
+  namespace: posthog
+  labels:
+    app.kubernetes.io/name: posthog
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: posthog
+      app.kubernetes.io/component: kafka
+  endpoints:
+    - port: metrics
+      path: /public_metrics
+      interval: 30s
+      scrapeTimeout: 10s
+---
+# ClickHouse's built-in exporter shows active queries/merges, memory, parts,
+# disk space, ProfileEvents, and exceptions without a third-party exporter.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: posthog-clickhouse
+  namespace: posthog
+  labels:
+    app.kubernetes.io/name: posthog
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: posthog
+      app.kubernetes.io/component: clickhouse
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/my-apps/development/posthog/data-layer/clickhouse.yaml
+++ b/my-apps/development/posthog/data-layer/clickhouse.yaml
@@ -69,6 +69,8 @@ spec:
           name: tcp
         - containerPort: 9181
           name: keeper
+        - containerPort: 9363
+          name: metrics
         livenessProbe:
           exec:
             command:
@@ -154,6 +156,9 @@ spec:
   - port: 9000
     targetPort: 9000
     name: tcp
+  - port: 9363
+    targetPort: metrics
+    name: metrics
   selector:
     app.kubernetes.io/name: posthog
     app.kubernetes.io/component: clickhouse

--- a/my-apps/development/posthog/data-layer/kafka.yaml
+++ b/my-apps/development/posthog/data-layer/kafka.yaml
@@ -128,6 +128,12 @@ spec:
     name: proxy
   - port: 33145
     name: rpc
+  # Redpanda's Prometheus-compatible public metrics endpoint. It includes
+  # committed consumer offsets and partition high-water marks, so Grafana can
+  # calculate lag without another exporter.
+  - port: 9644
+    targetPort: admin
+    name: metrics
   selector:
     app.kubernetes.io/name: posthog
     app.kubernetes.io/component: kafka

--- a/my-apps/development/posthog/data-layer/postgres.yaml
+++ b/my-apps/development/posthog/data-layer/postgres.yaml
@@ -71,6 +71,43 @@ spec:
         volumeMounts:
         - name: postgres-data
           mountPath: /var/lib/postgresql/data
+      # Read-only Prometheus view of Postgres health. Keep query text disabled:
+      # queryid is enough to find expensive statements without putting SQL or
+      # values into a high-cardinality metric label.
+      - name: postgres-exporter
+        image: quay.io/prometheuscommunity/postgres-exporter:v0.19.1@sha256:e96064f876226d94bb6ce48a4c4b3dd76edba91168ec1ab024e5c4b959310b0f
+        imagePullPolicy: IfNotPresent
+        args:
+        - --collector.long_running_transactions
+        - --collector.stat_statements
+        - --collector.stat_statements.limit=25
+        env:
+        - name: DATA_SOURCE_NAME
+          valueFrom:
+            secretKeyRef:
+              name: posthog-secrets
+              key: posthog-db-url
+        ports:
+        - containerPort: 9187
+          name: metrics
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
       volumes:
       - name: postgres-data
         persistentVolumeClaim:
@@ -87,6 +124,9 @@ spec:
   - name: postgres
     port: 5432
     targetPort: 5432
+  - name: metrics
+    port: 9187
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: posthog
     app.kubernetes.io/component: db


### PR DESCRIPTION
## What changed

- Make `START HERE — Cluster Performance` the Grafana home dashboard.
- Add a two-selector `WHY IS THIS APP SLOW?` workload investigator with correlated Loki errors.
- Add a one-page `WHY IS POSTHOG SLOW?` cause decoder for Django web/API, PostgreSQL, Redpanda/Kafka lag, ClickHouse, workers, and actual error messages.
- Expose PostgreSQL health through a pinned `postgres_exporter` sidecar.
- Scrape Redpanda's built-in `/public_metrics` endpoint and ClickHouse's built-in Prometheus endpoint.
- Retire the broad stock/community Kubernetes dashboard maze while keeping specialist dashboards linked from the cockpit.
- Fold in Renovate PR #1735: upgrade the Grafana Community Loki Helm chart from `17.4.11` to `18.5.4`.

## Why

The existing Grafana experience made performance incidents a dashboard-navigation problem and did not collect enough PostHog data-store telemetry to answer which subsystem caused a slowdown. The Loki 18 upgrade is included in this same observability rollout as requested, instead of landing through a separate dependency PR.

The live investigation that shaped this dashboard found PostgreSQL healthy (2/100 connections, about 99.95% cache hit, no waiting locks/deadlocks, low statement latency), all Redpanda consumer groups stable with zero lag, and ClickHouse at about 15 ms p95 for non-insert queries. The visible failures were instead application/deployment mismatches: an older web digest expected a PostgreSQL column that the in-flight migration had not created, and the logs feature used its default localhost ClickHouse host. The new page makes this distinction visible instead of blaming capacity.

## User impact

Grafana opens on one supported incident workflow. PostHog operators can identify the failing endpoint, delayed consumer group, PostgreSQL pressure, ClickHouse pressure, saturated pod, or exact error text without browsing folders.

Operational note: applying this PR changes the Postgres pod template (exporter sidecar), the ClickHouse config hash (metrics endpoint), Grafana configuration, and the Loki chart major version. Argo CD will restart those workloads during sync; data PVCs and Loki's external S3 storage configuration are unchanged.

## Validation

- Parsed all three dashboard JSON documents.
- Parsed the ClickHouse XML configuration.
- Rendered `my-apps/development/posthog` with Kustomize.
- Rendered `monitoring/prometheus-stack` with Kustomize + Helm.
- Rendered `monitoring/loki-stack` with Loki chart `18.5.4` and the existing values.
- Parsed all 36 PostHog dashboard PromQL expressions through the live Prometheus API.
- Parsed all three PostHog dashboard LogQL expressions through the live Loki API.
- Verified referenced Django metric names from the live web endpoint.
- Verified referenced ClickHouse metric/event names from live `system.metrics`, `system.asynchronous_metrics`, and `system.events`.
- Verified the Redpanda lag expression against Redpanda's documented metric labels and the live public metrics endpoint.
- Full combined Cluster CI passes: Kustomize rendering/schema validation, VPA safety/coverage, ArgoCD topology, TrueNAS CSI contract, Renovate config, OpenTelemetry configs, and shell lint.