### PR TITLE
posthog: fix postgres exporter readiness deadlock

### DIFF
--- a/my-apps/development/posthog/data-layer/postgres.yaml
+++ b/my-apps/development/posthog/data-layer/postgres.yaml
@@ -86,7 +86,10 @@ spec:
           valueFrom:
             secretKeyRef:
               name: posthog-secrets
-              key: posthog-db-url
+              # The exporter is a sidecar. Using the db Service here creates a
+              # readiness deadlock because the Service does not publish this
+              # pod as an endpoint until every container is ready.
+              key: posthog-exporter-db-url
         ports:
         - containerPort: 9187
           name: metrics

--- a/my-apps/development/posthog/externalsecret.yaml
+++ b/my-apps/development/posthog/externalsecret.yaml
@@ -18,6 +18,7 @@ spec:
     template:
       data:
         posthog-db-url: 'postgres://posthog:{{ index . "posthog-db-password" }}@db:5432/posthog'
+        posthog-exporter-db-url: 'postgres://posthog:{{ index . "posthog-db-password" }}@127.0.0.1:5432/posthog?sslmode=disable'
         posthog-secret: '{{ index . "posthog-secret" }}'
         encryption-salt-keys: '{{ index . "encryption-salt-keys" }}'
         posthog-db-password: '{{ index . "posthog-db-password" }}'


### PR DESCRIPTION
## What changed

- add a dedicated localhost PostgreSQL URL to the PostHog ExternalSecret
- point the postgres-exporter sidecar at `127.0.0.1:5432` instead of the `db` Service

## Root cause

The exporter runs in the PostgreSQL pod but connects through the `db` Service. Kubernetes does not publish that pod as a ready Service endpoint until every container is ready, while the exporter cannot become ready until it can connect to PostgreSQL. This creates a readiness deadlock and removes the PostgreSQL endpoint from the Service.

## Impact

After merge and ArgoCD sync, the exporter connects directly to its colocated PostgreSQL container, the pod can become ready, and PostHog's PostgreSQL Service endpoint is restored.

## Validation

- `git diff --check`
- `kustomize build --enable-helm my-apps/development/posthog`
- live rollout diagnosis confirmed postgres-exporter receives `no route to host` for the unready `db` Service endpoint while PostgreSQL itself is healthy
