### PR TITLE
storage: schedule Talos fstrim

### DIFF
--- a/infrastructure/controllers/argocd/apps/appsets/infrastructure-appset.yaml
+++ b/infrastructure/controllers/argocd/apps/appsets/infrastructure-appset.yaml
@@ -54,6 +54,7 @@ spec:
       # Longhorn stays default; static/pre-existing NFS stays on nfs.csi.k8s.io.
       - path: infrastructure/storage/truenas-csi
       - path: infrastructure/storage/local-storage
+      - path: infrastructure/storage/talos-fstrim
       # NOTE: longhorn and snapshot-controller are NOT listed here.
       # They have dedicated standalone Applications at Wave 1 (longhorn-app.yaml,
       # snapshot-controller-app.yaml) so storage is healthy before the

--- a/infrastructure/storage/talos-fstrim/cronjob.yaml
+++ b/infrastructure/storage/talos-fstrim/cronjob.yaml
@@ -1,0 +1,93 @@
+# Proxmox discard=on only passes through discard requests that the guest sends,
+# while Talos does not schedule fstrim itself. Keep the targets explicit:
+# fstrim --all would also walk kubelet-mounted Longhorn workload filesystems.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: talos-fstrim
+  namespace: talos-fstrim
+  labels:
+    app.kubernetes.io/name: talos-fstrim
+    app.kubernetes.io/component: node-maintenance
+spec:
+  # The initial reclaim saturated host I/O while releasing hundreds of GiB.
+  # Run future, incremental passes in a quiet local-time maintenance window.
+  schedule: "30 4 * * 0"
+  timeZone: America/Detroit
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: talos-fstrim
+            app.kubernetes.io/component: node-maintenance
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          terminationGracePeriodSeconds: 30
+          # These three filesystems exist together only on the dual-RTX worker.
+          nodeSelector:
+            gpu-worker: "true"
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+            - key: gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          hostPID: true
+          containers:
+            - name: fstrim
+              image: docker.io/library/alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+
+                  for target in \
+                    /var \
+                    /var/mnt/longhorn-nvme1 \
+                    /var/mnt/longhorn-ssd-flash
+                  do
+                    echo "[fstrim] $(date -u +%Y-%m-%dT%H:%M:%SZ) trimming ${target}"
+                    nsenter --mount=/proc/1/ns/mnt -- \
+                      /usr/local/sbin/fstrim --verbose "${target}"
+                  done
+
+                  echo "[fstrim] $(date -u +%Y-%m-%dT%H:%M:%SZ) all targets completed"
+              securityContext:
+                privileged: true
+                readOnlyRootFilesystem: true
+              resources:
+                requests:
+                  cpu: 5m
+                  memory: 8Mi
+                limits:
+                  cpu: 100m
+                  memory: 32Mi
+              volumeMounts:
+                # This matches Talos's own util-linux extension test pod. The
+                # fstrim binary lives on the host at /usr/local/sbin/fstrim.
+                - name: dev
+                  mountPath: /dev
+                - name: host
+                  mountPath: /host
+                  readOnly: true
+          volumes:
+            - name: dev
+              hostPath:
+                path: /dev
+                type: Directory
+            - name: host
+              hostPath:
+                path: /
+                type: Directory

--- a/infrastructure/storage/talos-fstrim/kustomization.yaml
+++ b/infrastructure/storage/talos-fstrim/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: talos-fstrim
+resources:
+  - namespace.yaml
+  - cronjob.yaml

--- a/infrastructure/storage/talos-fstrim/namespace.yaml
+++ b/infrastructure/storage/talos-fstrim/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: talos-fstrim
+  labels:
+    pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
## What changed

- add a privileged, GitOps-managed Talos `fstrim` CronJob for the dual-RTX worker
- trim `/var`, `/var/mnt/longhorn-nvme1`, and `/var/mnt/longhorn-ssd-flash` sequentially
- schedule the job Sundays at 04:30 America/Detroit with overlap prevention, no retries, and a one-hour deadline
- add the application to the explicit infrastructure ApplicationSet

## Why

Proxmox discard pass-through was enabled, but Talos did not issue TRIM. Guest and host discard counters remained at zero while the thin pools retained blocks that Talos had already freed.

A one-off privileged pod validated the exact `nsenter` plus Talos `util-linux-tools` path. The run reduced `nvme0-vmstore` from 94.85% to 67.30% and `nvme1-vmstore` from 62.50% to 20.40%. Because the initial backlog caused substantial I/O pressure, the permanent job runs in a quiet local-time maintenance window and processes targets sequentially.

## Validation

- `kustomize build infrastructure/storage/talos-fstrim`
- `kubeconform v0.7.0 -strict -kubernetes-version 1.36.3`
- `kubectl apply --dry-run=client`
- `bash scripts/validate-argocd-apps.sh`
- live one-off fstrim on the target Talos worker, followed by Proxmox thin-pool verification
