### PR TITLE
docs: refresh version pins (Cilium 1.19.6, ArgoCD 10.2.1, Talos v1.13.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,16 @@ ArgoCD deploys in strict order so dependencies land before the things that need 
 2. **An Omni service-account key** stored in 1Password (item `talos-prod-sa`) — see [Cluster Access](#cluster-access-omni-service-account) to create one
 3. **Local tools**: `omnictl`, `talosctl`, `kubectl`, `kustomize`, Cilium CLI (`cilium` or `cilium-cli`), 1Password CLI (`op`), and `helm`
 
-### Version pins (as of 2026-06-28)
+### Version pins
 
 | Component | Version | Source of truth |
 |-----------|---------|-----------------|
 | Omni server + `omnictl` | `v1.9.0` | `omni/omni/omni.env.example` |
 | Talos Linux | `v1.13.7` | `omni/cluster-template/cluster-template-singlenode-gpu.yaml` |
 | Kubernetes | `v1.36.3` | `omni/cluster-template/cluster-template-singlenode-gpu.yaml` |
-| Cilium | `1.19.5` | `infrastructure/networking/cilium/kustomization.yaml` |
+| Cilium | `1.19.6` | `infrastructure/networking/cilium/kustomization.yaml` |
 | Gateway API CRDs | `v1.4.1` | bootstrap commands below |
-| ArgoCD Helm chart | `10.1.3` (Argo CD `v3.4.5`) | `scripts/bootstrap-argocd.sh` |
+| ArgoCD Helm chart | `10.2.1` (Argo CD `v3.4.5`) | `scripts/bootstrap-argocd.sh` |
 | Proxmox provider | `latest@sha256:96433a…` | `omni/proxmox-provider/docker-compose.yml` |
 
 Keep the Omni server and local `omnictl` on the **same** release — mismatched versions fail with obscure gRPC errors.
@@ -121,7 +121,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/downloa
 kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
 
 # 5. Cilium CNI (see step 5 below for the full flag list)
-cilium-cli install --version 1.19.5 --set cluster.name=talos-singlenode-gpu-prod ...
+cilium-cli install --version 1.19.6 --set cluster.name=talos-singlenode-gpu-prod ...
 
 # 6. Pre-seed 1Password secrets
 kubectl create namespace 1passwordconnect
@@ -214,7 +214,7 @@ Omni provisions Talos without a CNI. Install Cilium to get networking up:
 
 ```bash
 cilium-cli install \
-    --version 1.19.5 \
+    --version 1.19.6 \
     --set cluster.name=talos-singlenode-gpu-prod \
     --set ipam.mode=kubernetes \
     --set kubeProxyReplacement=true \
@@ -241,7 +241,7 @@ kubectl get nodes
 
 > Three settings here **must match** the values ArgoCD will render at Wave 0 (`infrastructure/networking/cilium/`), or Wave 0 fights the CLI install:
 > - **Routing mode matches by default**: the CLI's default (`tunnel`/vxlan) equals `values.yaml`'s `routingMode: tunnel`. If the managed values ever change routing mode, add the matching `--set routingMode=...` here or Wave 0 restarts every agent mid-bootstrap.
-> - **`--version 1.19.5`** must match `infrastructure/networking/cilium/kustomization.yaml`. A mismatch makes ArgoCD upgrade Cilium at Wave 0, regenerating some Hubble certs but not others → `x509: certificate signed by unknown authority` blocks every later wave.
+> - **`--version 1.19.6`** must match `infrastructure/networking/cilium/kustomization.yaml`. A mismatch makes ArgoCD upgrade Cilium at Wave 0, regenerating some Hubble certs but not others → `x509: certificate signed by unknown authority` blocks every later wave.
 > - **`cluster.name`** must match `values.yaml` (Hubble cert SANs). Run without it and certs are issued for `default`/`kind-kind` → TLS failures.
 > - **Hubble stays disabled at bootstrap on purpose** — ArgoCD enables it at Wave 0 so it's the sole owner of the Hubble TLS certs (no CLI-vs-ArgoCD cert mismatch).
 >

--- a/docs/domains/networking/wifi-proxmox-talos-worker.md
+++ b/docs/domains/networking/wifi-proxmox-talos-worker.md
@@ -68,13 +68,13 @@ The machine class deliberately carries **no** `ip=` kernel argument
 
 The GTX 1050 Ti is Pascal (compute capability 6.1). NVIDIA moved Pascal to the
 580 legacy/LTS branch; the 595 unified production driver used by the RTX 3090
-worker does not drive it. Talos `v1.13.4` resolves the Dell worker's extensions
+worker does not drive it. Talos `v1.13.7` resolves the Dell worker's extensions
 as a matched pair:
 
-| Extension | Talos `v1.13.4` image |
+| Extension | Talos `v1.13.7` image |
 |---|---|
-| `siderolabs/nonfree-kmod-nvidia-lts` | `580.159.04-v1.13.4` |
-| `siderolabs/nvidia-container-toolkit-lts` | `580.159.04-v1.19.1` |
+| `siderolabs/nonfree-kmod-nvidia-lts` | `580.173.02-v1.13.7` |
+| `siderolabs/nvidia-container-toolkit-lts` | `580.173.02-v1.19.1` |
 
 Never mix the production kernel module with the LTS toolkit. The Threadripper
 worker deliberately remains on the production pair.

--- a/omni/README.md
+++ b/omni/README.md
@@ -144,7 +144,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/downloa
 kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
 
 cilium-cli install \
-    --version 1.19.5 \
+    --version 1.19.6 \
     --set cluster.name=talos-prod-cluster \
     --set ipam.mode=kubernetes \
     --set kubeProxyReplacement=true \

--- a/omni/docs/CILIUM_CNI.md
+++ b/omni/docs/CILIUM_CNI.md
@@ -113,7 +113,7 @@ Simple installation without Gateway API support:
 
 ```bash
 cilium install \
-    --version 1.19.5 \
+    --version 1.19.6 \
     --set cluster.name=talos-prod-cluster \
     --set ipam.mode=kubernetes \
     --set kubeProxyReplacement=true \
@@ -136,7 +136,7 @@ kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/re
 
 # Then install Cilium
 cilium install \
-    --version 1.19.5 \
+    --version 1.19.6 \
     --set cluster.name=talos-prod-cluster \
     --set ipam.mode=kubernetes \
     --set kubeProxyReplacement=true \
@@ -162,7 +162,7 @@ kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/re
 
 # Install Cilium with Hubble
 cilium install \
-    --version 1.19.5 \
+    --version 1.19.6 \
     --set cluster.name=talos-prod-cluster \
     --set ipam.mode=kubernetes \
     --set kubeProxyReplacement=true \
@@ -680,7 +680,7 @@ cilium version
 
 ```bash
 # Upgrade to specific version (must match chart version in infrastructure/networking/cilium/kustomization.yaml)
-cilium upgrade --version 1.19.5
+cilium upgrade --version 1.19.6
 
 # Or latest
 cilium upgrade
@@ -789,7 +789,7 @@ Enable service mesh features:
 
 ```bash
 cilium install \
-  --version 1.19.5 \
+  --version 1.19.6 \
   --set cluster.name=talos-prod-cluster \
   --set kubeProxyReplacement=true \
   --set ingressController.enabled=true \

--- a/omni/docs/TROUBLESHOOTING.md
+++ b/omni/docs/TROUBLESHOOTING.md
@@ -406,10 +406,10 @@ See the GPU machine classes in `../machine-classes/` and the patches in `../clus
 **Solution 1**: Use custom ISO with extensions pre-baked
 ```bash
 docker run --rm -i \
-  ghcr.io/siderolabs/imager:v1.13.0 \
+  ghcr.io/siderolabs/imager:v1.13.7 \
   iso \
-  --system-extension-image ghcr.io/siderolabs/nonfree-kmod-nvidia-production:v1.13.0 \
-  --system-extension-image ghcr.io/siderolabs/nvidia-container-toolkit-production:v1.13.0
+  --system-extension-image ghcr.io/siderolabs/nonfree-kmod-nvidia-production:595.71.05-v1.13.7 \
+  --system-extension-image ghcr.io/siderolabs/nvidia-container-toolkit-production:595.71.05-v1.19.1
 ```
 
 **Solution 2**: Check Proxmox console/tty settings

--- a/omni/omni/omni.env.example
+++ b/omni/omni/omni.env.example
@@ -15,11 +15,10 @@ OMNI_ACCOUNT_UUID=00000000-0000-0000-0000-000000000000
 NAME=omni-prod
 
 # Omni Docker image version
-# Check https://github.com/siderolabs/omni/releases for latest
-# v1.9.0: streaming maintenance-mode Talos install/upgrade (LifecycleService API,
-#   needs Talos >=1.13.0); default Talos bumped to 1.13.5, k8s to 1.36.1. New
-#   per-class etcd and per-machine log rate limits ship off by default. Keep the
-#   companion omnictl on the operator's machine at the same version.
+# Check https://github.com/siderolabs/omni/releases for latest.
+# Drives Talos install/upgrade through the LifecycleService API, so the cluster
+# must be on Talos >=1.13.0. Keep the operator's omnictl on this exact version —
+# a mismatch fails with obscure gRPC errors.
 OMNI_IMG_TAG=v1.9.0
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

Refresh version pins across docs and config examples to match current cluster state.

## Changes

| Component | Old | New |
|-----------|-----|-----|
| Cilium | `1.19.5` | `1.19.6` |
| ArgoCD Helm chart | `10.1.3` | `10.2.1` |
| Talos Linux | `v1.13.4` | `v1.13.7` |
| NVIDIA LTS driver | `580.159.04` | `580.173.02` |
| NVIDIA production driver | `v1.13.0` | `595.71.05-v1.13.7` |

## Files

- `README.md` — version table + bootstrap commands
- `docs/domains/networking/wifi-proxmox-talos-worker.md` — GPU worker extension versions
- `omni/README.md` — Cilium install command
- `omni/docs/CILIUM_CNI.md` — all Cilium version references
- `omni/docs/TROUBLESHOOTING.md` — ISO build imager/extensions tags
- `omni/omni/omni.env.example` — cleaned up Omni version comment

> No manifests changed — docs and examples only. No ArgoCD sync triggered.