### PR TITLE
storage: trim Dell Talos worker

### DIFF
--- a/infrastructure/storage/talos-fstrim/cronjob-dell.yaml
+++ b/infrastructure/storage/talos-fstrim/cronjob-dell.yaml
@@ -1,0 +1,83 @@
+# The Dell worker stores both Talos EPHEMERAL data and its Longhorn disk under
+# /var. Schedule it after the dual-RTX worker to avoid simultaneous Longhorn
+# maintenance I/O across both nodes.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: talos-fstrim-dell
+  namespace: talos-fstrim
+  labels:
+    app.kubernetes.io/name: talos-fstrim
+    app.kubernetes.io/component: node-maintenance
+    app.kubernetes.io/instance: dell-worker
+spec:
+  schedule: "30 5 * * 0"
+  timeZone: America/Detroit
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: talos-fstrim
+            app.kubernetes.io/component: node-maintenance
+            app.kubernetes.io/instance: dell-worker
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          terminationGracePeriodSeconds: 30
+          nodeSelector:
+            node.vanillax.dev/class: dell-gpu
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+            - key: gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          hostPID: true
+          containers:
+            - name: fstrim
+              image: docker.io/library/alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+
+                  echo "[fstrim] $(date -u +%Y-%m-%dT%H:%M:%SZ) trimming /var"
+                  nsenter --mount=/proc/1/ns/mnt -- \
+                    /usr/local/sbin/fstrim --verbose /var
+                  echo "[fstrim] $(date -u +%Y-%m-%dT%H:%M:%SZ) /var completed"
+              securityContext:
+                privileged: true
+                readOnlyRootFilesystem: true
+              resources:
+                requests:
+                  cpu: 5m
+                  memory: 8Mi
+                limits:
+                  cpu: 100m
+                  memory: 32Mi
+              volumeMounts:
+                - name: dev
+                  mountPath: /dev
+                - name: host
+                  mountPath: /host
+                  readOnly: true
+          volumes:
+            - name: dev
+              hostPath:
+                path: /dev
+                type: Directory
+            - name: host
+              hostPath:
+                path: /
+                type: Directory

--- a/infrastructure/storage/talos-fstrim/kustomization.yaml
+++ b/infrastructure/storage/talos-fstrim/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: talos-fstrim
 resources:
   - namespace.yaml
   - cronjob.yaml
+  - cronjob-dell.yaml


### PR DESCRIPTION
## What changed

- add a second Talos `fstrim` CronJob for the Dell GPU worker
- select the node through the stable `node.vanillax.dev/class=dell-gpu` label
- trim only `/var`, which contains both Talos EPHEMERAL data and this node's Longhorn disk
- schedule it Sundays at 05:30 America/Detroit, one hour after the dual-RTX worker job
- retain the existing overlap prevention, zero-retry policy, one-hour deadline, pinned image, and explicit host mount namespace entry

## Why

Proxmox `192.168.10.16` VM 100 has discard pass-through enabled, but Talos reports zero completed discards. The 100 GiB thin LV is 97.82% mapped while `/var` still has roughly 18 GiB free, demonstrating the same unreclaimed-block condition already fixed for the dual-RTX worker.

The existing CronJob selects only `gpu-worker=true`, so it cannot run on the Dell worker. Staggering the new job avoids simultaneous Longhorn maintenance I/O across both nodes.

## Validation

- `kustomize build infrastructure/storage/talos-fstrim`
- Kubernetes server-side dry-run of the rendered manifests
- kubeconform v0.7.0 strict validation against Kubernetes 1.36.3
- `bash scripts/validate-argocd-apps.sh`
- verified the selector resolves to exactly one Ready Dell worker with `util-linux-tools` 2.42.2

No live trim was executed as part of this PR.