### PR TITLE
monitoring: add Coroot CE trial (isolated, disposable)

### DIFF
--- a/monitoring/coroot/coroot.yaml
+++ b/monitoring/coroot/coroot.yaml
@@ -1,0 +1,80 @@
+# Coroot CE trial: embedded Prometheus (2d) keeps its high-cardinality eBPF
+# metrics out of the main prometheus-stack instance, and every volume is
+# reclaimPolicy Delete — removing this directory leaves zero residue.
+# AI RCA is enterprise-only and intentionally absent; CE inspections only.
+apiVersion: coroot.com/v1
+kind: Coroot
+metadata:
+  name: coroot
+  namespace: coroot
+spec:
+  communityEdition: {}
+  metricsRefreshInterval: 30s
+  storage:
+    size: 10Gi
+    className: longhorn
+    reclaimPolicy: Delete
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+  prometheus:
+    retention: 2d
+    storage:
+      size: 10Gi
+      className: longhorn
+      reclaimPolicy: Delete
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+  clickhouse:
+    replicas: 1
+    storage:
+      size: 10Gi
+      className: longhorn
+      reclaimPolicy: Delete
+    resources:
+      requests:
+        cpu: 200m
+        memory: 768Mi
+      limits:
+        memory: 2Gi
+    keeper:
+      replicas: 1
+      storage:
+        size: 2Gi
+        className: longhorn
+        reclaimPolicy: Delete
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+  nodeAgent:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+      limits:
+        memory: 1Gi
+    tolerations:
+      - operator: Exists
+  clusterAgent:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+  logsTTL: 3d
+  tracesTTL: 3d
+  profilesTTL: 3d
+  service:
+    type: ClusterIP
+    port: 8080

--- a/monitoring/coroot/httproute.yaml
+++ b/monitoring/coroot/httproute.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: coroot
+  namespace: coroot
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-internal-technitium
+      namespace: gateway
+  hostnames:
+    - coroot.vanillax.me
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          # operator names all resources <cr-name>-coroot
+          name: coroot-coroot
+          port: 8080
+          weight: 1

--- a/monitoring/coroot/kustomization.yaml
+++ b/monitoring/coroot/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: coroot
+
+resources:
+  - namespace.yaml
+  - coroot.yaml
+  - httproute.yaml
+
+helmCharts:
+  - name: coroot-operator
+    repo: https://coroot.github.io/helm-charts
+    version: 0.9.8
+    releaseName: coroot-operator
+    includeCRDs: true

--- a/monitoring/coroot/namespace.yaml
+++ b/monitoring/coroot/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: coroot
+  labels:
+    # node-agent is a privileged hostPID DaemonSet (eBPF probes)
+    pod-security.kubernetes.io/enforce: privileged

--- a/scripts/vpa-exemptions.yaml
+++ b/scripts/vpa-exemptions.yaml
@@ -66,6 +66,8 @@ namespaceExemptions:
     reason: "Bootstrap certificate controllers are chart-owned."
   - namespace: cloudnative-pg
     reason: "Database operators own their controller resources."
+  - namespace: coroot
+    reason: "Disposable Coroot CE trial; workloads are operator-materialized with explicit CR resources."
   - namespace: csi-driver-nfs
     reason: "CSI controllers are chart-owned."
   - namespace: csi-driver-smb


### PR DESCRIPTION
## What

Deploys **Coroot Community Edition** as a 2-week side-by-side trial of a click-to-diagnose observability UI (`https://coroot.vanillax.me`, internal gateway only). Part of the observability RCA overhaul plan (PR-1 of 4 — full plan in Mink: `projects/talos-argocd-proxmox/observability-rca-overhaul-execution-plan-2026-07-26`).

- `monitoring/coroot/` — auto-discovered by the monitoring AppSet (wave 5, ns `coroot`)
- `coroot-operator` chart pinned at **0.9.8** (operator 1.9.6), CR verified against the CRD schema
- **Isolation by design**: embedded Prometheus (2d retention, 10Gi) so Coroot's high-cardinality eBPF metrics never touch the main prometheus-stack instance; single-replica ClickHouse (10Gi) + keeper (2Gi); logs/traces/profiles TTL 3d
- All volumes `reclaimPolicy: Delete` → rollback = delete this directory, zero residue
- Namespace is PSS-privileged: node-agent is a privileged hostPID eBPF DaemonSet (tolerates all taints → runs on all 3 nodes)
- `scripts/vpa-exemptions.yaml`: `coroot` namespace exemption (operator-materialized workloads, explicit CR resources)

## Resource budget

Requests total ≈ **700m CPU / ~2.0Gi RAM** (server 100m/256Mi, embedded Prometheus 100m/512Mi, ClickHouse 200m/768Mi, keeper 50m/128Mi, cluster-agent 50m/128Mi, node-agent 100m/200Mi ×3 nodes). Memory-limits only, per repo convention.

## What this is NOT

- Not a replacement for kube-prometheus-stack/Grafana — pure side-by-side.
- Coroot's AI RCA is **enterprise-only** ($1/core/mo) and intentionally absent; CE gives heuristic "inspections" + service map. The AI investigation layer arrives separately (HolmesGPT, PR-2).
- No login secret provisioned: first visit prompts to set the admin password (internal-only route).

## Verification (post-merge)

```
kubectl -n coroot get pods                 # operator, coroot, clickhouse, keeper, prometheus, cluster-agent, node-agent x3
kubectl top pods -n coroot --sum           # expect < ~2.5Gi live
# open https://coroot.vanillax.me → set admin password → service map should show vllm, immich, frigate, ...
```

Expect a kopiur backup-coverage CI **warning** for the operator-created PVCs (trial data is disposable; PVCs aren't in the git render so they can't carry the exempt annotations) — intentional.

## Success criteria (evaluated ~2 weeks)

Does "open Coroot → click the red service → read the inspection" beat the Grafana cockpit for time-to-diagnosis? If yes → consider promoting (external Prometheus mode, backups). If no → delete the directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)