### PR TITLE
monitoring: add Keep alert console — the dashboard for alerts + Holmes RCA

### DIFF
--- a/monitoring/keep/externalsecret.yaml
+++ b/monitoring/keep/externalsecret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: keep-db-secret
+  namespace: keep
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: keep-db-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        password: "{{ .password }}"
+        connection-string: "postgresql+psycopg2://keep:{{ .password }}@keep-postgres:5432/keep"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: keep
+        property: password

--- a/monitoring/keep/httproute.yaml
+++ b/monitoring/keep/httproute.yaml
@@ -1,0 +1,58 @@
+# Same path split the chart's nginx Ingress performs (prefix stripped before
+# the backend): /v2 -> API, /websocket -> soketi, / -> UI.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: keep
+  namespace: keep
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-internal-technitium
+      namespace: gateway
+  hostnames:
+    - keep.vanillax.me
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v2
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: keep-backend
+          port: 8080
+          weight: 1
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /websocket
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: keep-websocket
+          port: 6001
+          weight: 1
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: keep-frontend
+          port: 3000
+          weight: 1

--- a/monitoring/keep/kustomization.yaml
+++ b/monitoring/keep/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: keep
+
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - postgres/deployment.yaml
+  - postgres/service.yaml
+  - postgres/pvc.yaml
+  - httproute.yaml
+  - vpa.yaml
+
+helmCharts:
+  - name: keep
+    repo: https://keephq.github.io/helm-charts
+    version: 0.1.96
+    releaseName: keep
+    valuesFile: values.yaml
+    includeCRDs: true
+
+# The chart's pre-delete hook Job (no disable flag) deletes every keep-*
+# secret in the namespace. ArgoCD has no pre-delete phase, so it would apply
+# as a normal resource and nuke the ESO-managed keep-db-secret on every sync.
+patches:
+  - target:
+      kind: Job
+      name: delete-keep-secrets
+    patch: |-
+      $patch: delete
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: delete-keep-secrets

--- a/monitoring/keep/namespace.yaml
+++ b/monitoring/keep/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keep

--- a/monitoring/keep/postgres/deployment.yaml
+++ b/monitoring/keep/postgres/deployment.yaml
@@ -1,0 +1,83 @@
+# Plain Postgres for Keep (gitea pattern, minus kopiur: alert history is
+# monitoring data, and providers/workflows re-provision from git).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keep-postgres
+  namespace: keep
+  labels:
+    app: keep-postgres
+spec:
+  strategy:
+    type: Recreate # RWO PVC — RollingUpdate deadlocks on Multi-Attach
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keep-postgres
+  template:
+    metadata:
+      labels:
+        app: keep-postgres
+    spec:
+      terminationGracePeriodSeconds: 60
+      securityContext:
+        fsGroup: 999 # postgres uid:gid in the official image
+      containers:
+        - name: postgres
+          # Pin MAJOR.MINOR — majors need a manual dump/restore (see the
+          # gitea-postgres comment; #1621 crashlooped on a stale data dir).
+          image: postgres:18.4
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              value: "keep"
+            - name: POSTGRES_USER
+              value: "keep"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keep-db-secret
+                  key: password
+            - name: POSTGRES_INITDB_ARGS
+              value: "--data-checksums"
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          startupProbe:
+            exec:
+              command: ["pg_isready", "-U", "keep", "-d", "keep"]
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "keep", "-d", "keep"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "keep", "-d", "keep"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: keep-postgres-data

--- a/monitoring/keep/postgres/pvc.yaml
+++ b/monitoring/keep/postgres/pvc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keep-postgres-data
+  namespace: keep
+  labels:
+    app: keep-postgres
+    backup-exempt: "true"
+  annotations:
+    storage.vanillax.dev/backup-exempt-reason: "Alert history is monitoring data; providers/workflows re-provision from git"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn

--- a/monitoring/keep/postgres/service.yaml
+++ b/monitoring/keep/postgres/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keep-postgres
+  namespace: keep
+  labels:
+    app: keep-postgres
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+  selector:
+    app: keep-postgres

--- a/monitoring/keep/values.yaml
+++ b/monitoring/keep/values.yaml
@@ -1,0 +1,135 @@
+# Keep is the web alert console: Alertmanager webhooks land here, and a
+# provisioned workflow asks HolmesGPT to investigate criticals, attaching the
+# RCA to the alert (visible in the UI). No chat/text receivers by design.
+global:
+  # Chart only ships nginx/haproxy/traefik Ingress; this cluster is Gateway
+  # API. httproute.yaml replicates the prefix-strip the nginx template does.
+  ingress:
+    enabled: false
+
+# Chart DB floats mysql:latest with an empty password — replaced by the
+# pinned plain-Postgres in postgres/ (gitea pattern).
+database:
+  enabled: false
+
+backend:
+  enabled: true
+  waitForDatabase:
+    enabled: true
+    # init container resolves the DB host from the DATABASE_NAME env var
+    port: 5432
+  databaseConnectionStringFromSecret:
+    enabled: true
+    secretName: keep-db-secret
+    secretKey: connection-string
+  # This list REPLACES the chart default wholesale — DATABASE_CONNECTION_STRING
+  # must stay absent (injected from the secret above; a duplicate env wins
+  # unpredictably).
+  env:
+    - name: DATABASE_NAME
+      value: keep-postgres
+    - name: SECRET_MANAGER_TYPE
+      value: k8s
+    - name: PORT
+      value: "8080"
+    - name: AUTH_TYPE
+      value: NO_AUTH
+    - name: KEEP_API_URL
+      value: https://keep.vanillax.me/v2
+    - name: PUSHER_APP_ID
+      value: "1"
+    - name: PUSHER_APP_KEY
+      value: keepappkey
+    - name: PUSHER_APP_SECRET
+      value: keepappsecret
+    - name: PUSHER_HOST
+      value: keep-websocket
+    - name: PUSHER_PORT
+      value: "6001"
+    - name: PROMETHEUS_MULTIPROC_DIR
+      value: /tmp/prometheus
+    - name: POSTHOG_DISABLED
+      value: "true"
+    - name: SENTRY_DISABLED
+      value: "true"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 1Gi
+  provision:
+    providers:
+      vllm-local:
+        type: vllm
+        authentication:
+          api_url: http://vllm-service.vllm.svc.cluster.local:8080/v1
+          api_key: none
+    workflows:
+      - id: holmes-rca
+        name: Holmes RCA on critical alerts
+        description: >-
+          Ask HolmesGPT to investigate every critical alert and attach the
+          evidence-based root cause to the alert.
+        triggers:
+          - type: alert
+            filters:
+              - key: severity
+                value: critical
+        actions:
+          - name: holmes-investigate
+            provider:
+              type: http
+              with:
+                url: http://holmes-holmes.holmesgpt.svc.cluster.local/api/chat
+                method: POST
+                body:
+                  ask: >-
+                    Investigate this Kubernetes alert and state the root cause
+                    with the evidence you found, then one recommended fix.
+                    Alert: {{ alert.name }}. Namespace: {{ alert.namespace }}.
+                    Description: {{ alert.description }}.
+            enrich_alert:
+              - key: ai_rca
+                value: "{{ results.analysis }}"
+
+frontend:
+  enabled: true
+  env:
+    - name: NEXTAUTH_SECRET
+      value: secret
+    - name: NEXTAUTH_URL
+      value: https://keep.vanillax.me
+    - name: AUTH_TYPE
+      value: NO_AUTH
+    - name: API_URL_CLIENT
+      value: /v2
+    - name: VERCEL
+      value: "1"
+    - name: ENV
+      value: development
+    - name: NODE_ENV
+      value: development
+    - name: HOSTNAME
+      value: 0.0.0.0
+    - name: PUSHER_APP_KEY
+      value: keepappkey
+    - name: FRIGADE_DISABLED
+      value: "true"
+    - name: POSTHOG_DISABLED
+      value: "true"
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+websocket:
+  enabled: true
+  resources:
+    requests:
+      cpu: 25m
+      memory: 128Mi
+    limits:
+      memory: 256Mi

--- a/monitoring/keep/vpa.yaml
+++ b/monitoring/keep/vpa.yaml
@@ -1,0 +1,88 @@
+# VPA policies are owned with this application so Argo prunes them with it.
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: keep-backend
+  namespace: keep
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: keep-backend
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "1"
+          memory: 2Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: keep-frontend
+  namespace: keep
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: keep-frontend
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "1"
+          memory: 1Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: keep-websocket
+  namespace: keep
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: keep-websocket
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "1"
+          memory: 512Mi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: keep-postgres
+  namespace: keep
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: keep-postgres
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "1"
+          memory: 2Gi

--- a/monitoring/prometheus-stack/values.yaml
+++ b/monitoring/prometheus-stack/values.yaml
@@ -188,11 +188,23 @@ alertmanager:
       fsGroup: 65534
     # Retention
     retention: 72h
-    # Alert rules are visible in Prometheus, Grafana, and the internal
-    # Alertmanager UI. Delivery remains the chart's explicit null receiver
-    # until a real destination Secret is chosen; do not ship localhost webhook
-    # placeholders that look configured but discard every notification.
     configSecret: ""
+  # Delivery destination is the Keep console (keep.vanillax.me) — web UI, not
+  # chat/email. Keep runs AUTH_TYPE=NO_AUTH, so no credential is needed on
+  # this webhook. Watchdog stays visible in Keep but its severity=none never
+  # matches the Holmes-RCA workflow filter.
+  config:
+    route:
+      receiver: "keep"
+      group_by: ["alertname", "namespace"]
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+    receivers:
+      - name: "keep"
+        webhook_configs:
+          - url: "http://keep-backend.keep.svc.cluster.local:8080/alerts/event/prometheus"
+            send_resolved: true
 # Grafana Configuration
 grafana:
   enabled: true


### PR DESCRIPTION
## What

**PR-3 of the observability RCA overhaul** (PR-1 Coroot #1793 ✅ merged, PR-2 Holmes #1794 ✅ merged; plan in Mink).

This is the answer to "where is the Holmes dashboard": **`https://keep.vanillax.me`** — a self-hosted web alert console. What it delivers:

1. **Alerts finally land somewhere.** Alertmanager's receiver has been `null` since inception — all 43 rules evaluated into the void. This PR wires the first real receiver: a webhook to Keep. Every alert (firing + resolved) now appears as a row in a web UI. No Discord, no texts — a dashboard, as requested.
2. **Critical alerts get automatic AI root-cause analysis.** A git-provisioned Keep workflow POSTs each critical alert to HolmesGPT (`/api/chat`), which investigates using kubectl/Prometheus/Loki/Tempo and the result is **attached to the alert in the UI** (`ai_rca` enrichment field). Watchdog/info/warning don't trigger investigations (GPU protection: vLLM `--max-num-seqs 2`).
3. **vLLM is registered as a Keep AI provider** for future workflow use.

## Design decisions

- Chart pinned `keephq/keep` **0.1.96** (app 0.52.1). `AUTH_TYPE=NO_AUTH` — internal gateway only, single-operator homelab (same trust model as other internal dashboards).
- **Chart's bundled DB rejected** (`mysql:latest`, empty password — violates pinning + secret rules). Replaced with plain pinned **Postgres 18.4** per the gitea pattern; PVC is backup-exempt (alert history is monitoring data; providers/workflows re-provision from git — same philosophy as Prometheus/Loki/Tempo PVCs).
- **Chart's `delete-keep-secrets` pre-delete hook Job is patched out** — ArgoCD has no pre-delete phase, so it would deploy as a normal resource and delete every `keep-*` secret in the namespace (including the ESO-managed `keep-db-secret`) on every sync. No disable flag upstream; kustomize `$patch: delete`.
- Chart ships Ingress-only (nginx/haproxy/traefik); disabled, replaced by an HTTPRoute reproducing the same prefix-strip routing (`/v2`→backend, `/websocket`→soketi, `/`→frontend) via Gateway API `URLRewrite` filters.
- Keep + Holmes telemetry envs disabled (`POSTHOG_DISABLED`, `SENTRY_DISABLED`, `FRIGADE_DISABLED`).
- Alertmanager `config` merges with the chart's stock inhibition rules (verified in render: critical→warning/info inhibition preserved, Keep receiver present).

## ⚠️ Manual step BEFORE merge

Create 1Password item **`keep`** in vault `homelab-prod` with one field: **`password`** (any strong value — it becomes the Postgres password). Until it exists, the ExternalSecret won't materialize and the backend waits on the DB.

## Resource budget

backend 100m/512Mi, frontend 50m/256Mi, websocket 25m/128Mi, postgres 50m/256Mi → **~225m / ~1.2Gi requests** (+5Gi Longhorn). VPAs on all four.

## Verification (post-merge)

```
kubectl -n keep get externalsecret,pods      # secret Ready, 4 deployments Running
# open https://keep.vanillax.me → alert feed appears (Watchdog will be there — proof of delivery)
kubectl -n prometheus-stack exec alertmanager-kube-prometheus-stack-alertmanager-0 -- \
  amtool config show | head -20               # receiver: keep
# fire a test: any critical (or temporarily patch a rule) → row in Keep → ai_rca field populates after Holmes finishes
```

Known tuning knobs if needed post-deploy: Holmes response field name in the enrichment (`{{ results.analysis }}`) and the HTTP step timeout vs long investigations — both one-line workflow edits in `values.yaml`.

## Rollback

Revert the PR: Alertmanager returns to the null receiver, `monitoring/keep/` prunes clean (PVC included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)