### PR TITLE
monitoring: fix Keep AUTH_TYPE (NOAUTH, not NO_AUTH)

### DIFF
--- a/monitoring/keep/values.yaml
+++ b/monitoring/keep/values.yaml
@@ -33,7 +33,7 @@ backend:
     - name: PORT
       value: "8080"
     - name: AUTH_TYPE
-      value: NO_AUTH
+      value: NOAUTH
     - name: KEEP_API_URL
       value: https://keep.vanillax.me/v2
     - name: PUSHER_APP_ID
@@ -101,7 +101,7 @@ frontend:
     - name: NEXTAUTH_URL
       value: https://keep.vanillax.me
     - name: AUTH_TYPE
-      value: NO_AUTH
+      value: NOAUTH
     - name: API_URL_CLIENT
       value: /v2
     - name: VERCEL


### PR DESCRIPTION
Follow-up to #1795. Keep's auth enum is `NOAUTH = "noauth"` (verified in `keep/identitymanager/identitymanagerfactory.py`; the value is lowercased at load). My `NO_AUTH` failed to resolve, so the API required keys — blocking the UI (`Missing API Key`) and Alertmanager webhook ingestion. Two-line env fix, both backend and frontend.

Post-merge: alerts should appear at https://keep.vanillax.me within ~a minute (Watchdog proves delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)