### PR TITLE
monitoring: send credentials on the Alertmanager→Keep webhook

### DIFF
--- a/monitoring/prometheus-stack/values.yaml
+++ b/monitoring/prometheus-stack/values.yaml
@@ -205,6 +205,12 @@ alertmanager:
         webhook_configs:
           - url: "http://keep-backend.keep.svc.cluster.local:8080/alerts/event/prometheus"
             send_resolved: true
+            # Keep's NOAUTH verifier accepts any credential but rejects NONE —
+            # this placeholder is not a secret, it just has to exist.
+            http_config:
+              basic_auth:
+                username: api_key
+                password: noauth
 # Grafana Configuration
 grafana:
   enabled: true


### PR DESCRIPTION
Follow-up to #1795/#1796, last link in the delivery chain. Keep's NOAUTH verifier (source-verified: `noauth_authverifier.py`) accepts **any** credential but rejects requests carrying **none** — verified live: `Bearer anything` → 200 `[]`, no header → `Missing API Key`. Alertmanager's webhook sends no auth by default, so every notification was rejected.

Adds the documented placeholder basic auth (`username: api_key` / any password) to the webhook. Not a secret — NOAUTH ignores the value.

Post-merge: Watchdog appears as the first row in https://keep.vanillax.me within ~a minute, proving end-to-end delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)