### PR TITLE
monitoring: restore null receiver in Alertmanager config

### DIFF
--- a/monitoring/prometheus-stack/values.yaml
+++ b/monitoring/prometheus-stack/values.yaml
@@ -201,6 +201,11 @@ alertmanager:
       group_interval: 5m
       repeat_interval: 4h
     receivers:
+      # The chart merges its default Watchdog->null child route into this
+      # config, but this receivers list REPLACES the chart's — omitting
+      # "null" fails operator validation ("undefined receiver") and the old
+      # config silently stays live.
+      - name: "null"
       - name: "keep"
         webhook_configs:
           - url: "http://keep-backend.keep.svc.cluster.local:8080/alerts/event/prometheus"


### PR DESCRIPTION
The chart merges its Watchdog->null child route into alertmanager.config,
but the custom receivers list replaces the chart's — without "null" the
operator rejects the whole config ("undefined receiver") and the previous
config stays live silently.

Completes #1797 — the squash merge landed before this commit was pushed, so the operator was still rejecting the config (`undefined receiver "null" used in route`, verified in operator logs at 15:07 UTC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)