### PR TITLE
monitoring: fix root causes behind the first Keep alert triage

### DIFF
--- a/infrastructure/controllers/vertical-pod-autoscaler-observability/prometheus-rules.yaml
+++ b/infrastructure/controllers/vertical-pod-autoscaler-observability/prometheus-rules.yaml
@@ -31,6 +31,14 @@ spec:
                 or
               kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu
             )
+              unless on (namespace, target_name)
+            (
+              # GPU scale-swap parks whole Deployments at replicas: 0; a VPA
+              # with no pods can never have a recommendation — not a fault.
+              label_replace(kube_deployment_spec_replicas, "target_name", "$1", "deployment", "(.*)") == 0
+                or
+              label_replace(kube_statefulset_replicas, "target_name", "$1", "statefulset", "(.*)") == 0
+            )
           # Avoid paging during the recommender's normal initial sampling
           # window; sustained absence indicates a missing/incompatible target.
           for: 4h

--- a/infrastructure/storage/container-registry/gc-cronjob.yaml
+++ b/infrastructure/storage/container-registry/gc-cronjob.yaml
@@ -35,12 +35,12 @@ spec:
           serviceAccountName: registry-gc
           containers:
             - name: gc
-              # bitnami/kubectl:1.31 was deleted from Docker Hub in Bitnami's
-              # 2025+ catalog purge (legacy tags removed / moved to
-              # bitnamilegacy/) -> ImagePullBackOff every weekly run. Switched
-              # to the official Kubernetes-hosted image (registry.k8s.io won't
-              # vanish like Docker Hub Bitnami), SHA-pinned per repo policy.
-              image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+              # NOT registry.k8s.io/kubectl: that image is distroless (no
+              # /bin/bash, no /bin/sh) so this script dies in seconds with
+              # StartError — every weekly run failed silently after the
+              # Bitnami-purge switch. alpine/k8s ships kubectl + bash.
+              # (bitnami/kubectl itself was purged from Docker Hub in 2025.)
+              image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
               command: [/bin/bash, -euo, pipefail, -c]
               args:
                 - |

--- a/monitoring/prometheus-stack/dcgm-exporter.yaml
+++ b/monitoring/prometheus-stack/dcgm-exporter.yaml
@@ -36,7 +36,10 @@ spec:
         feature.node.kubernetes.io/pci-0300_10de.present: "true"
       containers:
         - name: dcgm-exporter
-          image: nvcr.io/nvidia/k8s/dcgm-exporter:3.3.5-3.4.0-ubuntu22.04
+          # 3.3.5 emitted DCGM_FI_DEV_XID_ERRORS twice per GPU — every scrape
+          # dropped 1-2 duplicate-timestamp samples and kept
+          # PrometheusDuplicateTimestamps permanently firing.
+          image: nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04@sha256:17e9d49093f2d86d90260eec3c07b18b3f78fc5eadef3c8ab26a24fa5a9c1b2c
           ports:
             - name: http-metrics
               containerPort: 9400

--- a/monitoring/prometheus-stack/values.yaml
+++ b/monitoring/prometheus-stack/values.yaml
@@ -8,6 +8,13 @@ global:
 # CRD Configuration - Essential for proper functioning
 crds:
   enabled: true
+defaultRules:
+  disabled:
+    # Effectively a single-worker cluster: these fire when requests exceed
+    # N-1 nodes' capacity, i.e. they demand failover headroom that cannot
+    # exist here. Actual utilization alerts (NodeMemoryRequestsHigh) remain.
+    KubeCPUOvercommit: true
+    KubeMemoryOvercommit: true
 # Prometheus Configuration
 prometheus:
   enabled: true
@@ -190,9 +197,8 @@ alertmanager:
     retention: 72h
     configSecret: ""
   # Delivery destination is the Keep console (keep.vanillax.me) — web UI, not
-  # chat/email. Keep runs AUTH_TYPE=NO_AUTH, so no credential is needed on
-  # this webhook. Watchdog stays visible in Keep but its severity=none never
-  # matches the Holmes-RCA workflow filter.
+  # chat/email. Watchdog and InfoInhibitor are Alertmanager-internal plumbing
+  # and route to null; everything else lands in the Keep feed.
   config:
     route:
       receiver: "keep"
@@ -200,6 +206,16 @@ alertmanager:
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 4h
+      # This list REPLACES the chart's default child routes, so Watchdog->null
+      # must be restated here. InfoInhibitor is a routing artifact (it exists
+      # only to inhibit info-severity alerts) — never deliver it.
+      routes:
+        - receiver: "null"
+          matchers:
+            - alertname = "Watchdog"
+        - receiver: "null"
+          matchers:
+            - alertname = "InfoInhibitor"
     receivers:
       # The chart merges its default Watchdog->null child route into this
       # config, but this receivers list REPLACES the chart's — omitting

--- a/monitoring/trivy-operator/values.yaml
+++ b/monitoring/trivy-operator/values.yaml
@@ -87,7 +87,9 @@ resources:
     memory: 128Mi
   limits:
     cpu: 500m
-    memory: 512Mi
+    # 512Mi OOM-killed the operator ~2.5min after every start (exit 137)
+    # once the report count grew; it never stayed up long enough to reconcile.
+    memory: 1Gi
 
 trivy:
   image:

--- a/my-apps/home/paperless-ngx/externalsecret.yaml
+++ b/my-apps/home/paperless-ngx/externalsecret.yaml
@@ -26,3 +26,12 @@ spec:
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None
+    # paperless-ngx >= 2.18 refuses to start without a non-default
+    # PAPERLESS_SECRET_KEY (the :latest digest bump crossed that line).
+    - secretKey: PAPERLESS_SECRET_KEY
+      remoteRef:
+        key: paperless-ngx-credentials
+        property: secret_key
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
First full triage of the Keep feed (keep.vanillax.me) + Coroot after the alert pipeline came online (#1795–#1798). Every firing alert traced to a root cause; this PR fixes the five that are fixable in git, plus alert-plumbing noise.

## Real defects fixed

| Alert(s) | Root cause | Fix |
|---|---|---|
| `KubePodCrashLooping` paperless-ngx (532 restarts, +3 cascade alerts) | paperless ≥ 2.18 hard-fails without `PAPERLESS_SECRET_KEY` (`:latest` digest bump crossed the line); ES only synced DB creds | Wire `PAPERLESS_SECRET_KEY` from 1Password — **manual step: add a `secret_key` field to the `paperless-ngx-credentials` item** (generate: `python3 -c "import secrets; print(secrets.token_urlsafe(64))"`) |
| `KubernetesPodCrashLooping` trivy-operator | OOM-killed (exit 137) at 512Mi ~2.5 min after every start | Memory limit → 1Gi |
| `KubeJobFailed` registry-gc ×2 | `registry.k8s.io/kubectl` is distroless — `/bin/bash` doesn't exist (verified with a live probe: `StartError: stat /bin/bash: no such file`); every weekly GC died in 4s since the Bitnami purge switch | Image → `alpine/k8s:1.36.2` (kubectl + bash), SHA-pinned |
| `PrometheusDuplicateTimestamps` | dcgm-exporter 3.3.5 emits `DCGM_FI_DEV_XID_ERRORS` twice per GPU (verified in live scrape output; 2 dupes/scrape on the dual-3090 node, 1 on the single) | Bump to `4.5.2-4.8.1-ubuntu22.04`, SHA-pinned. Verify post-merge: `curl -s http://192.168.10.177:9400/metrics \| grep -v '^#' \| awk '{print $1}' \| sort \| uniq -d` should output nothing |
| `VPAMissingRecommendation` frigate | VPA targets a GPU scale-swap Deployment parked at `replicas: 0` — no pods can ever produce a recommendation | Rule now excludes scaled-to-zero Deployments/StatefulSets |

## Alert-plumbing cleanup (prometheus-stack values)

- **Watchdog + InfoInhibitor → null**: both are Alertmanager-internal plumbing; InfoInhibitor was landing in the Keep feed as noise. Watchdog must be restated because a custom `route.routes` list replaces the chart's default.
- **Disable `KubeCPUOvercommit`/`KubeMemoryOvercommit`**: they alert when requests exceed N-1 nodes' capacity — meaningless on an effectively single-worker cluster (actual usage is fine: 45% CPU / 63% mem requested). `NodeMemoryRequestsHigh` still covers real pressure.

## Observed, not fixed here

- `TargetDown`/`PrometheusTargetDown` `rpi4-solar` (epever-solar): physical device at home is unreachable — nothing to fix in git.
- Old failed `registry-gc` Jobs keep `KubeJobFailed` firing until deleted (`kubectl -n kube-system delete job registry-gc-29740560 registry-gc-29750640`) or the next Sunday run succeeds and history rotates.
- Coroot: PostHog Kafka latency critical (947ms), memory-leak heuristic warnings on keep-backend/keep-postgres/radar-ng-worker/coroot itself — worth watching, not GitOps-actionable.

All six kustomizations render clean locally (`kustomize build --enable-helm`); rendered Alertmanager secret verified to contain both null routes + intact inhibit rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)