### PR TITLE
monitoring: tune Coroot SLOs for long-poll and blocking-queue workloads

### DIFF
--- a/my-apps/development/posthog/data-layer/kafka.yaml
+++ b/my-apps/development/posthog/data-layer/kafka.yaml
@@ -37,6 +37,10 @@ metadata:
     app.kubernetes.io/name: posthog
     app.kubernetes.io/component: kafka
   annotations:
+    # Consumer fetch long-polls read as slow requests to Coroot's L7 eBPF
+    # latency SLI at the 500ms default; 10s keeps a real stall visible.
+    coroot.com/slo-latency-threshold: "10s"
+  annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: 1

--- a/my-apps/development/temporal/kustomization.yaml
+++ b/my-apps/development/temporal/kustomization.yaml
@@ -50,3 +50,21 @@ patches:
       - op: add
         path: /metadata/annotations/argocd.argoproj.io~1hook-delete-policy
         value: BeforeHookCreation
+  # frontend + matching serve gRPC long-polls (60s+ by design), which
+  # Coroot's L7 latency SLI reads as permanently slow — its histogram tops
+  # out at 10s, so no threshold can fit. Disable latency SLO; availability
+  # SLO stays active.
+  - target:
+      kind: Deployment
+      name: temporal-frontend
+    patch: |
+      - op: add
+        path: /metadata/annotations/coroot.com~1slo-latency-objective
+        value: "0%"
+  - target:
+      kind: Deployment
+      name: temporal-matching
+    patch: |
+      - op: add
+        path: /metadata/annotations/coroot.com~1slo-latency-objective
+        value: "0%"

--- a/my-apps/home/project-nomad/redis/deployment.yaml
+++ b/my-apps/home/project-nomad/redis/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: project-nomad
   labels:
     app: project-nomad-redis
+  annotations:
+    # Blocking queue pops (~5s) read as slow requests to Coroot's L7 eBPF
+    # latency SLI at the 500ms default; 10s keeps a real stall visible.
+    coroot.com/slo-latency-threshold: "10s"
 spec:
   strategy:
     type: Recreate

--- a/my-apps/media/immich/deployment-valkey.yaml
+++ b/my-apps/media/immich/deployment-valkey.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     app.kubernetes.io/name: immich
     app.kubernetes.io/component: valkey
+  annotations:
+    # BullMQ blocking queue pops (~5s) read as slow requests to Coroot's L7
+    # eBPF latency SLI at the 500ms default; 10s keeps a real stall visible.
+    coroot.com/slo-latency-threshold: "10s"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
All five open Coroot incidents (temporal-matching 66%, temporal-frontend 59%, kafka 9.4%, immich-valkey 45%, nomad-redis 45%) are one false-positive class: Coroot's L7 eBPF latency SLI counts **intentional waits** against the 99%-under-500ms default. Every incident shows `availability_impact: 0%` — nothing is actually failing.

| Workload | Wait pattern | Fix |
|---|---|---|
| temporal-frontend / temporal-matching | gRPC task-queue long-polls block 60s+ by design — beyond Coroot's largest histogram bucket (10s), so no threshold can fit | `coroot.com/slo-latency-objective: "0%"` (latency SLO off, availability SLO stays) — via Kustomize patch since the chart owns the Deployments |
| immich-valkey / nomad-redis | BullMQ-style blocking queue pops (~5s) | `coroot.com/slo-latency-threshold: "10s"` — a genuinely wedged cache still burns |
| posthog kafka | Consumer fetch long-polls | `coroot.com/slo-latency-threshold: "10s"` |

Context: the three "19h-old" incidents opened at the exact moment the Coroot node-agent started observing (Coroot was deployed Jul 26 ~22:00 UTC) — they're chronic measurement artifacts, not a regression. The temporal pair flaps every ~40min as the traffic mix shifts between real calls and idle polls.

Annotation-defined SLOs override the Coroot UI (per docs); this keeps SLO policy in git. Renders verified — annotations land on exactly temporal-frontend and temporal-matching, no other chart Deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)