### PR TITLE
monitoring: fix Holmes RCA enrichment template path

### DIFF
--- a/monitoring/keep/values.yaml
+++ b/monitoring/keep/values.yaml
@@ -91,7 +91,7 @@ backend:
                     Description: {{ alert.description }}.
             enrich_alert:
               - key: ai_rca
-                value: "{{ results.analysis }}"
+                value: "{{ results.body.analysis }}"
 
 frontend:
   enabled: true


### PR DESCRIPTION
Final link in the alert→RCA chain. Verified end-to-end today: Alertmanager→Keep delivery works (29 alerts in the feed), the workflow triggers on criticals, and Holmes answers with a correct investigation (live-verified: response has an `analysis` key, e.g. it correctly enumerated the 3 cluster nodes via kubectl). But Keep's http provider returns `result["body"] = response.json()` (source-verified in `http_provider.py`), so the enrichment template `{{ results.analysis }}` rendered empty and `ai_rca` never landed — `{{ results.body.analysis }}` is the correct path.

Post-merge the backend re-provisions the workflow; the next critical alert gets `ai_rca` attached in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)