### PR TITLE
monitoring: disable Coroot latency SLO on project-nomad redis

### DIFF
--- a/my-apps/home/project-nomad/redis/deployment.yaml
+++ b/my-apps/home/project-nomad/redis/deployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: project-nomad-redis
   annotations:
-    # Blocking queue pops (~5s) read as slow requests to Coroot's L7 eBPF
-    # latency SLI at the 500ms default; 10s keeps a real stall visible.
-    coroot.com/slo-latency-threshold: "10s"
+    # NOMAD's blocking queue pops park longer than 10s — Coroot's max latency
+    # bucket — so no threshold works; latency SLO off, availability SLO stays.
+    coroot.com/slo-latency-objective: "0%"
 spec:
   strategy:
     type: Recreate


### PR DESCRIPTION
## Why
Coroot incident `rqdi55vs` reopened on `project-nomad/redis` after #1800: the 10s latency threshold applied correctly, but ~9% of requests still exceed it. NOMAD's blocking queue pops park longer than 10s — which is Coroot's **maximum** latency bucket — so no threshold value can accommodate this workload.

## Fix
Same treatment as temporal-frontend/matching in #1800: `coroot.com/slo-latency-objective: "0%"` disables the latency SLO. The availability SLO stays active, so a genuinely dead redis still opens an incident.

immich-valkey and posthog kafka have stayed resolved on their 10s thresholds — only this one needed upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)