### PR TITLE
bootstrap: stop one unreachable webhook from wedging the wave train

### DIFF
--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -89,6 +89,28 @@ Block the nuke until every box checks — **you restore *from* these**:
 are **snapshots inside Omni** — apply + sync them *before* machines
 provision, or VMs are built from stale state and must be reprovisioned.
 
+### Gate the wave train on cross-node pod networking
+
+Run this after the Cilium install and **before** `bootstrap-argocd.sh`. Nodes
+reaching `Ready` only proves the kubelet talks to the API server; it does not
+prove that pods on different nodes can talk to each other. A rebuild is exactly
+when that differs — new VMs, new NICs, new placement.
+
+```bash
+kubectl -n kube-system exec ds/cilium -c cilium-agent -- cilium-health status
+```
+
+Every node must report **`1/1` under both `Node` and `Endpoints`**. `Node 1/1`
+with `Endpoints 0/1` is the trap: the node is reachable at its host IP while the
+pod network to it is broken. Node-level checks, `kubectl get nodes`, and ICMP all
+pass in that state.
+
+Do not start the wave train with any node showing `Endpoints 0/1`. Sync waves
+gate on pod readiness, which a broken pod network does not disturb — so the waves
+proceed normally and the failures surface much later as unrelated apps stuck on
+missing Secrets. Fix the network first; it is far cheaper than unwinding a
+half-converged cluster.
+
 **Bootstrap rules** (proven by the 2026-06 rebuilds):
 
 - CRDs first, controllers second, CRs third.

--- a/docs/domains/argocd/entrypoints.md
+++ b/docs/domains/argocd/entrypoints.md
@@ -53,6 +53,35 @@ Operator CRDs early — `SkipDryRunOnMissingResource` is an escape hatch / obser
 never a core fix. `cert-manager` is at **Wave 1** (not 4) so cert-dependent apps (cnpg-barman-plugin,
 Wave 3) can start. Full detail: [cluster DR nuke restore runbook](../../disaster-recovery.md).
 
+## Bootstrap guardrail — Application health does not prove webhook reachability
+
+Waves gate on Argo CD Application health. For a webhook Deployment that means
+**ready replicas == desired** — and kubelet decides readiness by probing the pod
+**locally, on its own node**. Neither signal involves the API server. A webhook
+pod can therefore be `Running`, `Ready`, and its Application `Healthy`, while the
+API server cannot reach it across the pod network. Every later wave then proceeds
+into a webhook that cannot be called.
+
+The blast radius is set by `failurePolicy`, not by the size of the component. A
+cluster-scoped `failurePolicy: Fail` webhook rejects **every** matching write in
+the cluster while unreachable, and an Argo CD sync that aborts applies **none**
+of its resources — so unrelated apps stall waiting on Secrets that were never
+created.
+
+Two rules follow:
+
+- **Fail-closed cluster-scoped webhooks are pinned to the control plane**
+  (`nodeSelector: node-role.kubernetes.io/control-plane` plus the matching
+  `NoSchedule` toleration). The API server calls them node-locally, so no
+  pod-network fault on any other node can break admission. This applies to
+  `cert-manager` and the `cloudnative-pg` operator. Availability is then coupled
+  to the API server's own availability, which is the correct coupling: if the
+  control plane is down, admission is moot.
+- **Do not add a custom Lua health check to probe webhook reachability.** Argo CD
+  configuration stays simple; the reachability signal belongs in alerting
+  (`monitoring/prometheus-stack/admission-webhook-alerts.yaml`, which reads the
+  API server's own `apiserver_admission_webhook_*` metrics), not in the wave gate.
+
 ## Notes
 
 - `project-nomad` is intentionally managed by `appsets/my-apps-appset.yaml` as a single bundled app at `my-apps/home/project-nomad`. Its child folders are resources inside that app, not generated Argo CD Applications.

--- a/infrastructure/controllers/cert-manager/values.yaml
+++ b/infrastructure/controllers/cert-manager/values.yaml
@@ -21,6 +21,20 @@ extraArgs:
   - "--dns01-check-retry-period=10s"
   - "--max-concurrent-challenges=60"
   - "--enable-certificate-owner-ref=true"
+# Pin to the control plane. `webhook.cert-manager.io` is a cluster-scoped
+# failurePolicy: Fail webhook, so if the API server cannot reach it, EVERY
+# cert-manager.io write fails and every sync wave that creates a Certificate
+# stalls. Co-locating with the API server makes that call node-local, so it
+# cannot be broken by a pod-network fault on another node.
+# NEVER remove the toleration: control plane nodes carry a NoSchedule taint.
+nodeSelector:
+  kubernetes.io/os: linux
+  node-role.kubernetes.io/control-plane: ""
+tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+
 # Security context for improved container security - This section is well-configured
 securityContext:
   runAsNonRoot: true
@@ -35,6 +49,15 @@ resources:
     cpu: 20m
     memory: 128Mi
 webhook:
+  # The admission endpoint itself — the component that must stay reachable from
+  # the API server. Same placement as the controller above.
+  nodeSelector:
+    kubernetes.io/os: linux
+    node-role.kubernetes.io/control-plane: ""
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534
@@ -47,6 +70,15 @@ webhook:
       cpu: 15m
       memory: 128Mi
 cainjector:
+  # cainjector populates the webhook's caBundle; a split placement would make
+  # webhook readiness depend on a cross-node call again.
+  nodeSelector:
+    kubernetes.io/os: linux
+    node-role.kubernetes.io/control-plane: ""
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534

--- a/infrastructure/controllers/opentelemetry-operator/kustomization.yaml
+++ b/infrastructure/controllers/opentelemetry-operator/kustomization.yaml
@@ -8,6 +8,33 @@ resources:
   - collector-gateway.yaml
   - collector-gateway-httproute.yaml
   - instrumentation.yaml
+
+# Cold-start deadlock guard. This app ships the operator, its two
+# failurePolicy: Fail webhook configurations, AND the CRs those webhooks must
+# admit. Applied in one pass, the webhook configs register instantly while the
+# operator is still starting, so admitting Instrumentation/OpenTelemetryCollector
+# calls a webhook with zero endpoints -> sync aborts -> the operator's
+# Certificate never applies -> the operator never starts. Permanently.
+#
+# A resource-level sync wave splits the apply: Argo CD applies wave 0 (operator,
+# Certificate, webhook configs) and waits for the Deployment to report Healthy
+# before applying wave 1, by which point the webhook has endpoints.
+# NEVER ship an operator and the CRs its own webhook admits in the same wave.
+patches:
+  - target:
+      kind: Instrumentation
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          argocd.argoproj.io/sync-wave: "1"
+  - target:
+      kind: OpenTelemetryCollector
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          argocd.argoproj.io/sync-wave: "1"
 helmCharts:
   - name: opentelemetry-operator
     repo: https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/infrastructure/database/cloudnative-pg/cloudnative-pg-operator/kustomization.yaml
+++ b/infrastructure/database/cloudnative-pg/cloudnative-pg-operator/kustomization.yaml
@@ -46,6 +46,18 @@ helmCharts:
     namespace: cloudnative-pg
     includeCRDs: true
     valuesInline:
+      # Pin to the control plane. cnpg-webhook-service backs cluster-scoped
+      # failurePolicy: Fail webhooks, so an unreachable operator pod blocks every
+      # postgresql.cnpg.io write cluster-wide. Co-locating with the API server
+      # makes the admission call node-local.
+      # NEVER remove the toleration: control plane nodes carry a NoSchedule taint.
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/control-plane: ""
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       config:
         # Enable job cleanup and set retention policies
         data:

--- a/monitoring/prometheus-stack/admission-webhook-alerts.yaml
+++ b/monitoring/prometheus-stack/admission-webhook-alerts.yaml
@@ -1,0 +1,98 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: admission-webhook-alerts
+  namespace: prometheus-stack
+  labels:
+    app.kubernetes.io/name: kube-prometheus-stack
+    app.kubernetes.io/instance: kube-prometheus-stack
+    app.kubernetes.io/managed-by: Helm
+    prometheus: kube-prometheus-stack-prometheus
+    role: alert-rules
+spec:
+  # Admission-webhook reachability, measured from the API server's own metrics
+  # (job="apiserver") rather than from pod health.
+  #
+  # WHY THIS EXISTS: sync waves gate on ArgoCD Application health, and for a
+  # webhook Deployment that means "ready replicas == desired". A webhook pod can
+  # be Running and Ready — its kubelet probe succeeds because kubelet probes it
+  # locally on the same node — while the API server cannot reach it across the
+  # pod network. Nothing in the wave model observes that gap, so every later wave
+  # marches into a webhook that cannot be called. These rules close it by asking
+  # the only component whose opinion matters: the API server.
+  #
+  # The `code` label is what makes this precise:
+  #   503 = the API server could not reach/complete the call (the failure mode)
+  #   4xx = the webhook was reached and deliberately rejected (normal policy)
+  # Alerting on rejected="true" alone would fire on every legitimate rejection.
+  groups:
+    - name: admission.webhooks
+      rules:
+        # A failurePolicy: Fail webhook the API server cannot reach. Every write
+        # matching its rules is now failing cluster-wide. For cluster-scoped
+        # webhooks (cert-manager, CNPG, Longhorn) this blocks ArgoCD syncs, and
+        # any sync that aborts applies NONE of its resources — so unrelated
+        # components stall waiting on Secrets that were never created.
+        - alert: AdmissionWebhookUnreachable
+          expr: |
+            sum by (name, type) (
+              rate(apiserver_admission_webhook_request_total{rejected="true", code="503"}[5m])
+            ) > 0
+          for: 5m
+          labels:
+            severity: critical
+            component: kube-apiserver
+            category: control-plane
+          annotations:
+            summary: "Admission webhook unreachable: {{ $labels.name }}"
+            description: |
+              The API server has been unable to complete calls to admission
+              webhook {{ $labels.name }} ({{ $labels.type }}) for 5m, returning
+              503. If this webhook is failurePolicy: Fail, every matching
+              create/update in the cluster is now rejected.
+
+              The backing pod is very likely Running and Ready — kubelet probes
+              it node-locally, so pod health does not prove API server
+              reachability. Check the path, not the pod.
+
+              Actions:
+              1. kubectl get validatingwebhookconfiguration,mutatingwebhookconfiguration
+                 -o custom-columns=NAME:.metadata.name,SVC:.webhooks[*].clientConfig.service.name
+              2. Find the backing Service, then confirm it has ready endpoints on a
+                 node the API server can reach:
+                 kubectl -n <ns> get endpointslice -l kubernetes.io/service-name=<svc> \
+                   -o custom-columns=READY:.endpoints[*].conditions.ready,NODE:.endpoints[*].nodeName
+              3. If endpoints exist but are unreachable, suspect cross-node pod
+                 networking rather than the workload:
+                 kubectl -n kube-system exec ds/cilium -c cilium-agent -- cilium-health status
+                 Node reachable + Endpoints 0/1 means the pod network is broken to
+                 that node, not the pod.
+
+        # failurePolicy: Ignore webhooks that the API server gave up on. These
+        # fail SILENTLY — the request is admitted with the webhook skipped, so
+        # defaulting/mutation quietly does not happen and nothing surfaces an
+        # error. Warning rather than critical because writes still succeed.
+        - alert: AdmissionWebhookFailingOpen
+          expr: |
+            sum by (name) (
+              rate(apiserver_admission_webhook_fail_open_count[10m])
+            ) > 0
+          for: 15m
+          labels:
+            severity: warning
+            component: kube-apiserver
+            category: control-plane
+          annotations:
+            summary: "Admission webhook failing open: {{ $labels.name }}"
+            description: |
+              The API server has been skipping admission webhook
+              {{ $labels.name }} for 15m because it could not be called and its
+              failurePolicy is Ignore. Requests are being admitted WITHOUT this
+              webhook running, so any defaulting, mutation, or validation it
+              performs is silently not applied. Resources created during this
+              window may be missing fields the webhook would have set.
+
+              Actions:
+              1. Locate the backing Service and confirm it has ready endpoints.
+              2. After the webhook recovers, re-sync anything created during the
+                 window so the skipped mutation/defaulting is applied.

--- a/monitoring/prometheus-stack/kustomization.yaml
+++ b/monitoring/prometheus-stack/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - longhorn-alerts.yaml # volume/node health (was longhorn-backup-alerts.yaml; dead backup-target alerts dropped 2026-07-06)
   - kopiur-alerts.yaml # kopiur backup staleness/failure alerts (the follow-up promised when volsync-alerts were retired 2026-06-27)
   - argocd-sync-alerts.yaml # ArgoCD control-plane + app-state alerts (stale-sync incident 2026-05-29)
+  - admission-webhook-alerts.yaml # API-server-side webhook reachability; pod health cannot prove it
   - dcgm-exporter.yaml # DCGM GPU monitoring
   - gpu-alerts.yaml # GPU alerting rules
   - performance-cockpit-dashboard.yaml # Default Grafana home: plain-English cluster performance triage


### PR DESCRIPTION
## Problem

Sync waves gate on Argo CD Application health. For a webhook Deployment that means **ready replicas == desired**, and kubelet decides readiness by probing the pod **locally, on its own node**. Neither signal involves the API server.

So a webhook pod can be `Running`, `Ready`, and its Application `Healthy` — while the API server cannot reach it across the pod network. Nothing in the wave model observes that gap, so every later wave marches into a webhook that cannot be called.

The blast radius comes from `failurePolicy`, not component size. A cluster-scoped `failurePolicy: Fail` webhook rejects **every** matching write in the cluster while unreachable, and an Argo CD sync that aborts applies **none** of its resources — so unrelated apps stall on Secrets that were never created.

Observed during a rebuild: `cert-manager` (single replica, cluster-scoped, fail-closed) landed on a node whose pod network was broken. The Application reported `Healthy` throughout. Six apps failed to sync with the identical error:

```
failed calling webhook "webhook.cert-manager.io": context deadline exceeded
```

`keda`, `opentelemetry-operator`, `prometheus-stack`, `vertical-pod-autoscaler`, `cnpg-barman-plugin`, and `temporal-worker-controller` never got their webhook cert Secrets, and their operators sat in `ContainerCreating` on `MountVolume.SetUp failed ... secret not found`. When cert-manager later rescheduled onto a healthy node, the whole cascade unwound on its own — confirming the amplifier was the placement, not the workloads.

## Changes

**Pin fail-closed cluster-scoped webhooks to the control plane** — `cert-manager` (controller, webhook, cainjector) and the `cloudnative-pg` operator. The API server calls them node-locally, so no pod-network fault on any other node can break admission. Webhook availability becomes coupled to API server availability, which is the correct coupling: if the control plane is down, admission is moot.

This needs no extra replicas and no storage — `cert-manager-webhook` is stateless and requests `15m` CPU / `128Mi`. The control plane sits at 15% CPU / 33% memory.

**Fix a cold-start deadlock in the OpenTelemetry operator app.** It shipped, in one sync: the operator, its two `failurePolicy: Fail` webhook configurations, *and* the `Instrumentation`/`OpenTelemetryCollector` CRs those webhooks must admit. The webhook configs register instantly while the operator is still starting, so admitting the CRs calls a webhook with zero endpoints → sync aborts → the operator's `Certificate` never applies → the operator never starts. This is a race on any cold bootstrap, independent of the incident above. It is not permanent — Argo CD retries, so it resolves once the operator's `Certificate` can be created — but until then the operator is down and its `failurePolicy: Ignore` pod webhook is silently skipped on every pod creation. A resource-level sync wave applies the CRs only after the operator reports Healthy, so the window never opens.

**Add admission-webhook alerting** from the API server's own metrics. The `code` label makes it precise:

| code | meaning |
|---|---|
| `503` | API server could not reach/complete the call — the failure mode |
| `4xx` | webhook was reached and deliberately rejected — normal policy |

- `AdmissionWebhookUnreachable` (critical) — `code="503"`, would have fired ~5 min into the incident
- `AdmissionWebhookFailingOpen` (warning) — `failurePolicy: Ignore` webhooks being silently skipped

No Cilium change and no new exporter — `job="apiserver"` is already scraped. Deliberately **not** a custom Lua health check; the reachability signal belongs in alerting, not the wave gate.

**Docs** — a bootstrap guardrail in `entrypoints.md` (Application health does not prove webhook reachability), and a cross-node pod networking gate in `disaster-recovery.md` to run before `bootstrap-argocd.sh`. The runbook previously had no network verification at all; `cilium-health status` showing `Node 1/1` but `Endpoints 0/1` is the trap, and `kubectl get nodes` and ICMP both pass in that state.

## Validation

- `scripts/validate-argocd-apps.sh` — all checks pass (2 warnings pre-existing)
- `scripts/validate-otel-configs.sh` — both collector configs valid
- `kustomize build --enable-helm` on all three changed apps: placement lands on all 4 Deployments; otel renders operator/Certificate/webhooks at wave 0 and the 3 CRs at wave 1
- Both PromQL expressions executed against live Prometheus. During the incident they matched the real failures (`webhook.cert-manager.io` at `code=503`; `mpod.kb.io` failing open while the otel operator was down); in the recovered steady state both match zero series, so neither is noisy
- `cert-manager-startupapicheck` keeps its own scheduling and is unaffected

## Not in scope

- The underlying node fault that triggered this (host-side, being handled separately)
- Cilium MTU: auto-detection pulls Omni's `siderolink` WireGuard device (MTU 1280) into the datapath, so pod MTU is 1280 while the VXLAN path carries only 1230 — packets 1231–1280 are silently dropped cluster-wide. TCP escapes via MSS clamping (1190); UDP and DF traffic do not. Real but latent, and changing Cilium `devices` also moves NodePort/LoadBalancer handling — worth its own PR.
- Longhorn is untouched.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPXRMMKWFXvC5svfaqSwjk
