### PR TITLE
storage: retire single-worker assumptions that broke the rebuild

### DIFF
--- a/infrastructure/controllers/1passwordconnect/values.yaml
+++ b/infrastructure/controllers/1passwordconnect/values.yaml
@@ -1,4 +1,19 @@
 connect:
+  # Every ExternalSecret resolves through this. At 1 replica it kept landing on
+  # the solar-powered shed node, so a cloudy day stalled secret refresh
+  # cluster-wide. No shared state between replicas, so this scales freely.
+  replicas: 2
+  # `preferred`, not `required`: a required rule would wedge the 2nd replica
+  # Pending forever if the cluster ever drops to one worker.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app: onepassword-connect
+            topologyKey: kubernetes.io/hostname
   api:
     enabled: true
     resources:
@@ -22,6 +37,10 @@ connect:
 
 operator:
   create: true
+  # Stays at 1 — do NOT scale to match connect above. Chart 2.4.1 gives the
+  # operator no leader election and no `leases` RBAC, so a 2nd replica is an
+  # uncoordinated reconciler racing the first (and racing to autoRestart the same
+  # Deployments). It's also off the ExternalSecret path — that hits the connect API.
   # This is the correct parameter for the operator token
   token:
     name: "1password-operator-token"    # This sets the secret name for the operator token

--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -46,3 +46,26 @@ helmCharts:
     # "chart requires kubeVersion >=1.32.0-0". Keep loosely in step with the
     # real cluster version (omni/cluster-template/cluster-template.yaml).
     kubeVersion: "1.36.3"
+
+# Upstream RBAC gap (chart 0.8.1): kopiur-mover has get+patch on the `*/status`
+# subresources but not the parents, which RBAC treats as distinct. Movers 403 and
+# stop reporting progress, so a Restore sits in "Restoring" with no status — that
+# masked a hung gitea restore for 24h on 2026-07-29. Drop once upstream fixes it.
+patches:
+  - target:
+      kind: ClusterRole
+      name: kopiur-mover
+    patch: |-
+      - op: add
+        path: /rules/-
+        value:
+          apiGroups: ["kopiur.home-operations.com"]
+          resources:
+            - snapshots
+            - restores
+            - repositories
+            - clusterrepositories
+            - maintenances
+            - snapshotpolicies
+            - repositoryreplications
+          verbs: ["get"]

--- a/infrastructure/networking/cilium/values.yaml
+++ b/infrastructure/networking/cilium/values.yaml
@@ -146,10 +146,12 @@ hubble:
 
 # Operator Configuration
 operator:
-  # SINGLE-NODE: the required hostname anti-affinity below makes a 2nd operator
-  # replica permanently unschedulable (no 2nd host) -> the Deployment never goes
-  # 2/2 healthy and the Cilium ArgoCD app hangs Progressing. 1 replica on one node.
-  replicas: 1
+  # One per worker, via the required hostname anti-affinity below. At 1 replica
+  # this kept landing on the solar-powered shed node, putting IPAM and identity
+  # management behind that node's uptime.
+  # Drop back to 1 if the cluster ever has a single schedulable worker — the
+  # required anti-affinity would leave the 2nd replica Pending and hang the app.
+  replicas: 2
   resources:
     requests:
       cpu: 200m

--- a/infrastructure/storage/longhorn/node-failure-settings.yaml
+++ b/infrastructure/storage/longhorn/node-failure-settings.yaml
@@ -137,19 +137,12 @@ metadata:
 value: '{"v2":"0xf"}'
 
 ---
-# Over-provisioning ceiling for replica scheduling.
-# values.yaml's defaultSettings only seeds on FIRST install — Longhorn
-# manages settings via this CRD post-install, so the chart value at 300
-# was being silently reverted to 200 by longhorn-manager's reconciliation.
-# Pinning it here means ArgoCD owns the value and it stays at 300.
-#
-# Per-node ceiling math: (disk_size - reserved) * over_provisioning%
-# V2 layout (2026-06-11): reserved=0 on the dedicated 704G (672G GPU) block
-# disks, so at 300% the ceiling is ~2100 Gi/node. Physical usage stays the
-# real constraint; 300% is scheduling headroom, not a promise of capacity.
+# Scheduling ceiling per disk: (disk_size - reserved) * this %.
+# Keep in step with defaultSettings in values.yaml — longhorn-manager reconciles
+# this from that ConfigMap and wins, so a mismatch here is silently ignored.
 apiVersion: longhorn.io/v1beta2
 kind: Setting
 metadata:
   name: storage-over-provisioning-percentage
   namespace: longhorn-system
-value: "300"
+value: "200"

--- a/infrastructure/storage/longhorn/storageclass-flash.yaml
+++ b/infrastructure/storage/longhorn/storageclass-flash.yaml
@@ -36,8 +36,13 @@
 # consumer NVMe. Pre-allocating the volume did not help. If anyone recreates
 # `ssd-ent` as an lvmthin pool, this tier silently becomes a downgrade.
 #
-# dataLocality strict-local: the replica must live on the node that runs the pod —
-# no cross-node hop on the write path. Fine here: single worker node.
+# NEVER set dataLocality back to strict-local while more than one worker is
+# schedulable. The `flash` disk exists on one node and the scheduler cannot see
+# diskSelector, so the two pick nodes independently; every mismatch is a permanent
+# deadlock (the Longhorn webhook rejects the attach and the pod waits forever).
+# That took out grafana, alertmanager, posthog and radar-ng on 2026-07-29.
+# best-effort keeps the replica on the flash disk and lets a remote pod attach
+# over the network instead of wedging.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -55,4 +60,4 @@ parameters:
   # Pins volumes to Longhorn disks tagged `flash` — see the
   # node.longhorn.io/default-disks-config annotation in the Omni cluster template.
   diskSelector: "flash"
-  dataLocality: "strict-local"
+  dataLocality: "best-effort"

--- a/infrastructure/storage/longhorn/values.yaml
+++ b/infrastructure/storage/longhorn/values.yaml
@@ -29,12 +29,13 @@ defaultSettings:
   # the Dell system disk reserves 30 GiB. Keep the global percentage at 0 so it
   # does not add a second, implicit reservation on top of those declarations.
   storageReservedPercentageForDefaultDisk: "0"
-  # Declared Longhorn capacity exceeds the Threadripper's two 450 GiB thin-
-  # backed filesystems. 600% permits those declarations; actual free space
-  # remains protected by storageMinimalAvailablePercentage: 10 and the Dell's
-  # explicit 30 GiB reservation. This is a scheduling band-aid, not extra
-  # physical capacity; offload bulk data to NFS.
-  storageOverProvisioningPercentage: "600"
+  # Budget per disk = storageMaximum * this %, against DECLARED PVC size. At 600%
+  # the Dell reached 206 GiB scheduled on a 97 GiB disk; at 200% its budget falls
+  # below what it already holds, so Longhorn stops placing new replicas on the
+  # shed node on its own. Over-committed disks refuse new replicas, never evict.
+  # Do NOT drop to 100% — a DR restore doubles declared demand via `prime-*` PVCs
+  # and would deadlock the rebuild. Mirrored in node-failure-settings.yaml.
+  storageOverProvisioningPercentage: "200"
   allowRecurringJobWhileVolumeDetached: "true"
   replicaAutoBalance: "best-effort"
   # Ensure new consolidated settings that can be per-engine stay simple scalars for V1-only clusters


### PR DESCRIPTION
## Why

Four settings in this repo were written when the cluster had exactly **one worker**. The Dell worker joined **2026-07-19** and silently invalidated all of them. The **2026-07-29 rebuild** is where that surfaced — ~12 pods stuck for 24h across gitea, posthog, prometheus-stack, radar-ng and home-assistant.

None of these are new bugs. They're stale invariants that nothing re-checked.

## Changes

### `longhorn-flash`: `dataLocality: strict-local` → `best-effort`

The actual cause of the recurring breakage. `strict-local` requires the replica to sit on the node running the pod — but the `flash` disk exists on **one** node and the kube-scheduler cannot see `diskSelector`. The two picked nodes independently, and every mismatch was an unrecoverable deadlock:

```
admission webhook "validator.longhorn.io" denied the request:
data locality strict-local requires the volume and replica to stay on the same node,
but ticket is on node …dell-gpu-workers… and replica is on node …gpu-workers…
```

Took out grafana, alertmanager, posthog redis and radar-ng. `best-effort` keeps the replica on the flash disk and lets a remote pod attach over the network instead of wedging.

The old comment claimed this was `Fine here: single worker node.` — that stopped being true five days after it was written.

### `storageOverProvisioningPercentage`: `600` → `200`

600% let the Dell reach **206 GiB scheduled on a 97 GiB disk (210%)**. At 200% its budget lands *below* what it already holds, so Longhorn stops placing new replicas on the solar-powered shed node **on its own** — no taint, no nodeSelector, no allowlist.

| disk | scheduled | budget @200% |
|---|---|---|
| TR nvme1 | 370 GiB | 898 GiB |
| TR talos-ephemeral | 351 GiB | 894 GiB |
| TR ssd-flash | 210 GiB | 598 GiB |
| **Dell talos-ephemeral** | **206 GiB** | **194 GiB → capped** |

Not lower than 200: a DR restore creates a `prime-*` PVC alongside each real PVC, so a full rebuild roughly doubles declared demand for ~22 volumes at once and 100% would deadlock the restore.

**Also fixes a split-brain:** `values.yaml` said 600 and `node-failure-settings.yaml` said 300, while the live cluster ran 600. The `Setting` CR is at `generation: 2` — ArgoCD wrote 300, longhorn-manager reconciled it back to the ConfigMap value. The file's `this Setting CR is authoritative` comment was wrong. Both now say 200 so they can't disagree.

### Foundation off the solar node

`cilium-operator` and `onepassword-connect` were both **single-replica and kept landing on the shed PC**, putting IPAM, identity management and every `ExternalSecret` behind that node's uptime. Both → 2 replicas.

The cilium comment said a 2nd replica was `permanently unschedulable (no 2nd host)` — also no longer true.

The 1Password **operator** deliberately stays at 1: chart 2.4.1 gives it no leader election and no `leases` RBAC, so a 2nd replica would be an uncoordinated reconciler racing the first.

### `kopiur-mover` ClusterRole: add `get` on parent resources

Upstream gap in chart 0.8.1 — the role covers `*/status` but not the parents, which RBAC treats as distinct resources. Every mover 403s and stops reporting progress, so a Restore sits in `Restoring` with no status. That masked a genuinely hung gitea restore for 24h.

## Verification

All four components rendered with `kustomize build --enable-helm`:

- `longhorn-flash` → `dataLocality: best-effort`
- ConfigMap + `Setting` CR → `200`
- `cilium-operator` → `replicas: 2`
- `onepassword-connect` → `2`, `onepassword-connect-operator` → `1`
- patched `kopiur-mover` ClusterRole carries the new parent-resource rule
- 1Password anti-affinity selector verified against real pod labels (`app: onepassword-connect`) — my first attempt used `app.kubernetes.io/name` and would have silently no-opped

## Not in this PR

Config only. The live cluster still needs, as follow-ups:

- patching the 14 existing flash volumes (the SC change only affects **newly provisioned** volumes)
- recreating the 4 flash volumes that have **zero replicas** (grafana, radar-ng tiles/pmtiles/grids)
- restarting the hung gitea restore
- a decision on kafka `dev-kafka-dual-role-0` (`cluster.id` mismatch against restored data)
- right-sizing PVCs — 193 GiB actual vs 1137 GiB declared, ~6x
- `numberOfReplicas: 2` once a third, non-intermittent storage node exists (blocked today: a second copy of 927 GiB of volumes cannot fit on the Dell's 97 GiB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)