### PR TITLE
feat: add cobalt media downloader

### DIFF
--- a/my-apps/media/cobalt/deployment.yaml
+++ b/my-apps/media/cobalt/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cobalt
+  namespace: cobalt
+  labels:
+    app.kubernetes.io/name: cobalt
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cobalt
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cobalt
+    spec:
+      containers:
+      - name: cobalt
+        image: ghcr.io/imputnet/cobalt:11
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: API_URL
+          value: "https://cobalt.vanillax.me/"
+        ports:
+        - name: http
+          containerPort: 9000
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ "ALL" ]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            memory: 1Gi
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 10

--- a/my-apps/media/cobalt/deployment.yaml
+++ b/my-apps/media/cobalt/deployment.yaml
@@ -17,9 +17,17 @@ spec:
       labels:
         app.kubernetes.io/name: cobalt
     spec:
+      securityContext:
+        # Image declares `USER node` by name; kubelet cannot verify a non-numeric
+        # user, so runAsNonRoot needs the matching numeric uid or the pod won't start.
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: cobalt
-        image: ghcr.io/imputnet/cobalt:11
+        image: ghcr.io/imputnet/cobalt:11@sha256:63186dd68afd57ce3bb1f62cc4c139f5fa95b9c3e87a3cf5c6e4c7a570523f62
         imagePullPolicy: IfNotPresent
         env:
         - name: API_URL
@@ -32,6 +40,10 @@ spec:
           readOnlyRootFilesystem: true
           capabilities:
             drop: [ "ALL" ]
+        volumeMounts:
+        # readOnlyRootFilesystem leaves node/ffmpeg with nowhere to spill scratch data.
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             cpu: 100m
@@ -50,3 +62,6 @@ spec:
             port: http
           initialDelaySeconds: 5
           periodSeconds: 10
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/my-apps/media/cobalt/http-route.yaml
+++ b/my-apps/media/cobalt/http-route.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cobalt
+  namespace: cobalt
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway-internal-technitium
+    namespace: gateway
+  hostnames:
+  - cobalt.vanillax.me
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: cobalt
+      port: 9000
+      weight: 1

--- a/my-apps/media/cobalt/kustomization.yaml
+++ b/my-apps/media/cobalt/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- deployment.yaml
+- service.yaml
+- http-route.yaml
+- vpa.yaml
+
+namespace: cobalt

--- a/my-apps/media/cobalt/namespace.yaml
+++ b/my-apps/media/cobalt/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cobalt

--- a/my-apps/media/cobalt/service.yaml
+++ b/my-apps/media/cobalt/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cobalt
+  namespace: cobalt
+spec:
+  sessionAffinity: ClientIP
+  ports:
+    - name: http
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: cobalt

--- a/my-apps/media/cobalt/vpa.yaml
+++ b/my-apps/media/cobalt/vpa.yaml
@@ -1,0 +1,11 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: cobalt-vpa
+  namespace: cobalt
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cobalt
+  updateMode: "Off"

--- a/my-apps/media/cobalt/vpa.yaml
+++ b/my-apps/media/cobalt/vpa.yaml
@@ -1,11 +1,22 @@
+# VPA policy is owned with this application so Argo prunes it with the target.
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: cobalt-vpa
+  name: cobalt
   namespace: cobalt
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: cobalt
-  updateMode: "Off"
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "1"
+          memory: 1Gi


### PR DESCRIPTION
Self-hosted [cobalt.tools](https://cobalt.tools) instance for on-demand video downloads.

**Services:** YouTube, TikTok, Twitter/X, Instagram, Reddit, Twitch, Vimeo, SoundCloud, and more.

**Details:**
- Image: `ghcr.io/imputnet/cobalt:11`
- URL: `cobalt.vanillax.me` (internal gateway)
- Port: 9000
- Read-only filesystem, no persistent storage
- Auto-discovered by `my-apps` ApplicationSet