### PR TITLE
longhorn: make settings actually GitOps-managed

### DIFF
--- a/infrastructure/controllers/argocd/apps/core-dependencies/longhorn-app.yaml
+++ b/infrastructure/controllers/argocd/apps/core-dependencies/longhorn-app.yaml
@@ -40,17 +40,16 @@ spec:
         maxDuration: 5m
   # Longhorn health checks ensure storage is ready before
   # other applications that need PVCs can be deployed
+  # Do NOT re-add a blanket `ConfigMap /data` or `Setting /value` ignore here.
+  # With RespectIgnoreDifferences=true those don't just hide a diff, they stop
+  # ArgoCD APPLYING the field — and settings reach Longhorn only via
+  #   values.yaml defaultSettings -> longhorn-default-setting ConfigMap
+  #     -> Longhorn's ConfigMap controller -> Setting CRs
+  # so ignoring either end made every Longhorn setting in git decorative. The
+  # cluster ran storage-over-provisioning at 600 while git said 200/300 and
+  # ArgoCD still reported Synced.
   ignoreDifferences:
-  - group: ""
-    kind: ConfigMap
-    jsonPointers:
-    - /data
   - group: ""
     kind: Secret
     jsonPointers:
     - /data
-  # Longhorn controller mutates Setting values into versioned format
-  - group: longhorn.io
-    kind: Setting
-    jsonPointers:
-    - /value

--- a/infrastructure/storage/longhorn/node-failure-settings.yaml
+++ b/infrastructure/storage/longhorn/node-failure-settings.yaml
@@ -1,6 +1,11 @@
 # Longhorn Node Failure and Recovery Settings
 # These settings prevent the issues you experienced with faulted volumes
 # when nodes were removed from the cluster.
+#
+# ONLY settings absent from values.yaml defaultSettings belong here. Longhorn's
+# ConfigMap controller reconciles Setting CRs from longhorn-default-setting, so
+# anything declared in both places has its CR silently overwritten — declare a
+# setting in exactly one file.
 
 ---
 # CRITICAL: Automatically delete pods when a node goes down
@@ -36,34 +41,6 @@ metadata:
   name: node-drain-policy
   namespace: longhorn-system
 value: "block-if-contains-last-replica"
-
----
-# Reserve NOTHING on default-created disks (V2 rebuild, 2026-06-11).
-# The old value (25%) was a V1-era fix for "insufficient storage" when the
-# default disk lived on the shared OS partition. On V2 every Longhorn disk is
-# a DEDICATED raw block device (/dev/sdb via the cluster template's
-# default-disks-config annotation) with nothing else on it — reserving 25%
-# would silently waste ~176Gi per 704G disk, because longhorn-manager
-# computes storageReserved from this percentage at disk-creation time when
-# the annotation says storageReserved: 0.
-# NOTE: this Setting CR is authoritative — values.yaml defaultSettings only
-# seeds on first install (see storage-over-provisioning-percentage below).
-apiVersion: longhorn.io/v1beta2
-kind: Setting
-metadata:
-  name: storage-reserved-percentage-for-default-disk
-  namespace: longhorn-system
-value: "0"
-
----
-# Enable fast replica rebuild for quicker recovery
-# NOTE: Must be a plain boolean string, not JSON format
-apiVersion: longhorn.io/v1beta2
-kind: Setting
-metadata:
-  name: fast-replica-rebuild-enabled
-  namespace: longhorn-system
-value: "true"
 
 ---
 # Concurrent replica rebuilds per node — INTENTIONALLY 1 (2026-06-12 incident).
@@ -135,14 +112,3 @@ metadata:
   name: data-engine-cpu-mask
   namespace: longhorn-system
 value: '{"v2":"0xf"}'
-
----
-# Scheduling ceiling per disk: (disk_size - reserved) * this %.
-# Keep in step with defaultSettings in values.yaml — longhorn-manager reconciles
-# this from that ConfigMap and wins, so a mismatch here is silently ignored.
-apiVersion: longhorn.io/v1beta2
-kind: Setting
-metadata:
-  name: storage-over-provisioning-percentage
-  namespace: longhorn-system
-value: "200"


### PR DESCRIPTION
## The problem

#1820 set `storageOverProvisioningPercentage: 200`. After merge and sync, the cluster still ran **600** — and ArgoCD reported **Synced**.

Settings reach Longhorn by exactly one path:

```
values.yaml defaultSettings
  → longhorn-default-setting ConfigMap  (key: default-setting.yaml)
      → Longhorn's ConfigMap controller
          → Setting CRs
```

`longhorn-app.yaml` ignored **both ends of that pipe** — `ConfigMap /data` *and* `Setting /value` — and the app runs `RespectIgnoreDifferences=true`, which doesn't merely hide a diff, it **stops ArgoCD applying the field**.

So every Longhorn setting in this repo has been decorative. The smoking gun: the `Setting` CR sat at `generation: 2` holding the ConfigMap's `600`, while `node-failure-settings.yaml` said `300` and ArgoCD called it Synced.

## Changes

### Drop the `ConfigMap /data` and `Setting /value` ignores

Verified safe *before* removing, not after:

- the ConfigMap diffs at **exactly one key out of 17** — the `200` we want
- all **8 remaining `Setting` CRs match live byte-for-byte**

So there is no drift for ArgoCD to start churning on. `Secret /data` is kept.

### Remove three `Setting` CRs that duplicate `values.yaml`

`fast-replica-rebuild-enabled`, `storage-over-provisioning-percentage`, `storage-reserved-percentage-for-default-disk`.

The ConfigMap controller reconciles `Setting` CRs **from** the ConfigMap, so a setting declared in both places can never take effect from the CR — it only *looks* managed. That's why `node-failure-settings.yaml` carried a comment claiming the CR was "authoritative" while the cluster ignored it.

`fast-replica-rebuild-enabled` was also the **sole justification** for the blanket `Setting` ignore — Longhorn rewrites `true` into `{"v1":"true","v2":"true"}`. It was 1 of 11 settings, and the ignore it motivated was blocking the other 10. With the duplicate gone, that mutation is no longer a tracked diff and the blanket ignore isn't needed.

A header note in `node-failure-settings.yaml` now states the rule: **declare a setting in exactly one file.**

## Why this matters beyond one value

This is the same failure mode as #1820 — a control that *looks* declarative but isn't, so drift accumulates invisibly until a rebuild exposes it. Upstream's documented alternative for changing settings on a live cluster is **the Longhorn UI**, which does not survive a nuke. This makes the git path work instead.

## Verification

```
render longhorn        : ok
render argocd apps     : ok
Setting CRs in git     : 8, zero overlap with ConfigMap keys
ignoreDifferences      : Secret /data only
git vs live (8 CRs)    : all match
```

Sources: [longhorn/longhorn discussion #9642](https://github.com/longhorn/longhorn/discussions/9642), [Longhorn: Customizing Default Settings](https://longhorn.io/docs/1.12.0/advanced-resources/deploy/customizing-default-settings/), [Argo CD diffing docs](https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)