### PR TITLE
otel: break the sync-wave deadlock blocking collector deployment

### DIFF
--- a/infrastructure/controllers/opentelemetry-operator/collector-gateway-httproute.yaml
+++ b/infrastructure/controllers/opentelemetry-operator/collector-gateway-httproute.yaml
@@ -28,6 +28,14 @@ metadata:
     # silently ignores the route and no CNAME is created in Cloudflare.
     external-dns: "true"
   annotations:
+    # MUST sync after the collectors (wave 1). Its backendRef Service
+    # otel-gateway-collector is created by the operator only once
+    # OpenTelemetryCollector/otel-gateway exists, so at the default wave 0 this
+    # route can never go Healthy — and ArgoCD will not advance to wave 1 until
+    # it does. That deadlocked the app from 2026-07-29 until 07-30: the
+    # collectors were never created, otel sat Degraded, and the failing child
+    # burned root's sync retries.
+    argocd.argoproj.io/sync-wave: "2"
     # Inherited from gateway-external's own target annotation when unset
     # (verified live), but the repo rule requires it per-route: keeps the
     # CNAME pinned to the tunnel if the Gateway annotation ever moves.


### PR DESCRIPTION
## The deadlock

`HTTPRoute/otel-gateway` carried no sync-wave annotation, so it defaulted to **wave 0** — ahead of the resources it depends on:

```
wave 0   HTTPRoute/otel-gateway
wave 1   OpenTelemetryCollector/otel-gateway
         OpenTelemetryCollector/otel-agent
         Instrumentation/default
```

Its `backendRef` Service `otel-gateway-collector` is created by the operator **only after** `OpenTelemetryCollector/otel-gateway` exists. So the route can never go Healthy:

```
[Synced|Failed] HTTPRoute/otel-gateway
  Parent gateway-external: Service "otel-gateway-collector" not found
```

ArgoCD won't advance past a wave until it's Healthy — so **wave 0 waits forever on something only wave 1 can produce.**

## Blast radius

The collectors were never applied at all. They don't appear in the app's `syncResult`, and `kubectl get opentelemetrycollector -A` returns nothing — so OTEL collection has been entirely non-functional, not merely degraded.

Worse, because root deploys this as a **child Application**, its failing health gate burned root's sync retries (`Retrying attempt #10`). While that operation was pinned to an older revision, newly merged commits sat unapplied — which is how #1822 initially appeared to "sync" without taking effect.

## Not a webhook problem

Worth recording, since that was my first guess. A server-side dry run of the rendered collector succeeds:

```
$ kubectl apply --dry-run=server -f otel-agent.yaml
opentelemetrycollector.opentelemetry.io/otel-agent created (server dry run)
```

The resource was always valid and admissible. ArgoCD simply never reached it.

## Fix

Move the route to wave 2 so collectors create first, the operator publishes the Service, and the route resolves.

```
HTTPRoute/otel-gateway  wave=2
Instrumentation/default wave=1
OpenTelemetryCollector/otel-agent    wave=1
OpenTelemetryCollector/otel-gateway  wave=1
```

## General lesson

A route whose backend Service is produced by an operator from a CR must sync **after** that CR. The default wave 0 is a trap for any Gateway API route pointing at an operator-managed Service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)