### PR TITLE
Add hindsight memory service and deal-scout dashboard

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,5 +28,8 @@
   },
   "enabledMcpjsonServers": [
     "claude-tempo"
+  ],
+  "disabledMcpjsonServers": [
+    "claude-tempo"
   ]
 }

--- a/.github/workflows/basemap-bootstrap-image.yml
+++ b/.github/workflows/basemap-bootstrap-image.yml
@@ -7,6 +7,11 @@
 #
 # Tags are immutable by policy: if VERSION already exists on GHCR the push is
 # skipped with a notice — bump VERSION to publish new script/image content.
+# PRs enforce that build-input changes bump VERSION relative to the base branch
+# and that VERSION matches the radar-ng Job tag. The registry check is separate:
+# a planned tag may not exist yet, so remote existence alone cannot detect an
+# unbumped version (we got burned when Renovate changed go-pmtiles under the
+# already-planned, not-yet-published v1.0.1 tag).
 #
 # NOTE: the basemap-bootstrap package was originally pushed manually with a
 # PAT. If the first Actions push 403s, grant this repo write access on the
@@ -17,7 +22,9 @@ name: basemap-bootstrap image
 on:
   pull_request:
     paths:
+      - '.github/workflows/basemap-bootstrap-image.yml'
       - 'my-apps/development/radar-ng/basemap-bootstrap-image/**'
+      - 'my-apps/development/radar-ng/job-basemap-bootstrap.yaml'
   push:
     branches: [main]
     paths:
@@ -31,38 +38,104 @@ permissions:
 env:
   IMAGE: ghcr.io/${{ github.repository_owner }}/basemap-bootstrap
   CONTEXT: my-apps/development/radar-ng/basemap-bootstrap-image
+  JOB_MANIFEST: my-apps/development/radar-ng/job-basemap-bootstrap.yaml
 
 jobs:
   build-push:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Read version
+      - name: Read and validate version
         id: v
-        run: echo "tag=$(cat "$CONTEXT/VERSION")" >> "$GITHUB_OUTPUT"
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t version_lines < "$CONTEXT/VERSION"
+          if (( ${#version_lines[@]} != 1 )) || [[ ! "${version_lines[0]}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::$CONTEXT/VERSION must contain exactly one vX.Y.Z tag"
+            exit 1
+          fi
+          printf 'tag=%s\n' "${version_lines[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release invariants
+        id: changes
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TAG: ${{ steps.v.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mapfile -t job_tags < <(
+            sed -n 's|^[[:space:]]*image:[[:space:]]*ghcr.io/mitchross/basemap-bootstrap:\([^[:space:]#]*\).*|\1|p' "$JOB_MANIFEST"
+          )
+          if (( ${#job_tags[@]} != 1 )); then
+            echo "::error::$JOB_MANIFEST must contain exactly one basemap-bootstrap image"
+            exit 1
+          fi
+          if [[ "${job_tags[0]}" != "$TAG" ]]; then
+            echo "::error::$JOB_MANIFEST uses ${job_tags[0]}, but $CONTEXT/VERSION is $TAG"
+            exit 1
+          fi
+
+          context_changed=true
+          content_changed=true
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            context_changed=false
+            content_changed=false
+            while IFS= read -r path; do
+              [[ -z "$path" ]] && continue
+              context_changed=true
+              [[ "$path" == "$CONTEXT/VERSION" ]] || content_changed=true
+            done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- "$CONTEXT")
+
+            if [[ "$content_changed" == "true" ]]; then
+              base_tag="$(git show "$BASE_SHA:$CONTEXT/VERSION")"
+              if [[ "$base_tag" == "$TAG" ]]; then
+                echo "::error::basemap-bootstrap build inputs changed without a VERSION bump; update VERSION and the tag in $JOB_MANIFEST"
+                exit 1
+              fi
+            fi
+          fi
+
+          printf 'context=%s\n' "$context_changed" >> "$GITHUB_OUTPUT"
+          printf 'content=%s\n' "$content_changed" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether tag is already published
+        if: steps.changes.outputs.context == 'true'
+        id: exists
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG: ${{ steps.v.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Check anonymously before login: this public package remains readable
+          # even when GITHUB_TOKEN has not yet been granted package write access.
+          if docker manifest inspect "$IMAGE:$TAG" >/dev/null 2>&1; then
+            if [ "$EVENT_NAME" = "pull_request" ]; then
+              echo "::error::$IMAGE:$TAG is already published; choose a new VERSION and update the tag in $JOB_MANIFEST"
+              exit 1
+            fi
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$IMAGE:$TAG already published — bump VERSION to release new content"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && steps.exists.outputs.exists != 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Skip if tag already published
-        if: github.event_name != 'pull_request'
-        id: exists
-        run: |
-          if docker manifest inspect "$IMAGE:${{ steps.v.outputs.tag }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::$IMAGE:${{ steps.v.outputs.tag }} already published — bump VERSION to release new content"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Build (push on main)
-        if: steps.exists.outputs.exists != 'true'
+        if: steps.changes.outputs.context == 'true' && steps.exists.outputs.exists != 'true'
         uses: docker/build-push-action@v6
         with:
           context: ${{ env.CONTEXT }}

--- a/my-apps/ai/hindsight/db-deployment.yaml
+++ b/my-apps/ai/hindsight/db-deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hindsight-db
+  namespace: hindsight
+  labels:
+    app: hindsight-db
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  strategy:
+    type: Recreate # RWO PVC — old pod must release the volume first
+  selector:
+    matchLabels:
+      app: hindsight-db
+  template:
+    metadata:
+      labels:
+        app: hindsight-db
+    spec:
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: postgres
+          image: pgvector/pgvector:pg16
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              value: hindsight
+            - name: POSTGRES_USER
+              value: hindsight
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hindsight-secrets
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+              name: postgres
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "hindsight"]
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "hindsight"]
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hindsight-db-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hindsight-db
+  namespace: hindsight
+  labels:
+    app: hindsight-db
+spec:
+  selector:
+    app: hindsight-db
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432

--- a/my-apps/ai/hindsight/deployment.yaml
+++ b/my-apps/ai/hindsight/deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hindsight
+  namespace: hindsight
+  labels:
+    app: hindsight
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: hindsight
+  template:
+    metadata:
+      labels:
+        app: hindsight
+    spec:
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: hindsight
+          # Full (non-slim) image: bundled local embedding + reranker models,
+          # so only the LLM is external (in-cluster vLLM).
+          image: ghcr.io/vectorize-io/hindsight:0.8.6
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hindsight-secrets
+                  key: POSTGRES_PASSWORD
+            - name: HINDSIGHT_API_DATABASE_URL
+              value: "postgresql://hindsight:$(POSTGRES_PASSWORD)@hindsight-db:5432/hindsight"
+            - name: HINDSIGHT_API_VECTOR_EXTENSION
+              value: "pgvector"
+            # Memory-processing LLM: in-cluster vLLM (OpenAI-compatible, free tokens)
+            - name: HINDSIGHT_API_LLM_PROVIDER
+              value: "openai"
+            - name: HINDSIGHT_API_LLM_BASE_URL
+              value: "http://vllm-service.vllm.svc.cluster.local:8080/v1"
+            - name: HINDSIGHT_API_LLM_MODEL
+              value: "qwen3.6-27b"
+            - name: HINDSIGHT_API_LLM_API_KEY
+              value: "vllm" # vLLM ignores auth; SDK requires a non-empty key
+            - name: HINDSIGHT_API_TENANT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hindsight-secrets
+                  key: HINDSIGHT_API_TENANT_API_KEY
+          ports:
+            - containerPort: 8888
+              name: http
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 60 # first boot loads embedding models
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+            limits:
+              memory: 3Gi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 512Mi

--- a/my-apps/ai/hindsight/externalsecret.yaml
+++ b/my-apps/ai/hindsight/externalsecret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hindsight-secrets
+  namespace: hindsight
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: hindsight-secrets
+    creationPolicy: Owner
+  data:
+    # 1Password item "hindsight" — create with these two fields.
+    # tenant_api_key: MUST match HINDSIGHT_API_KEY in ~/.hermes/.env on the desktop.
+    # db_password: any generated string.
+    - secretKey: HINDSIGHT_API_TENANT_API_KEY
+      remoteRef:
+        key: hindsight
+        property: tenant_api_key
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: hindsight
+        property: db_password

--- a/my-apps/ai/hindsight/httproute.yaml
+++ b/my-apps/ai/hindsight/httproute.yaml
@@ -1,0 +1,30 @@
+# INTERNAL route (local network only, via gateway-internal) — mirrors vllm.
+# Hermes on the desktop hits https://hindsight.vanillax.me with the tenant
+# API key (Authorization: Bearer). Memory data stays off the Cloudflare tunnel.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hindsight-route
+  namespace: hindsight
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-internal-technitium
+      namespace: gateway
+  hostnames:
+    - "hindsight.vanillax.me"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 5m # recall/reflect calls can chain several LLM round-trips
+        backendRequest: 5m
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: hindsight-service
+          port: 8888
+          weight: 1

--- a/my-apps/ai/hindsight/kustomization.yaml
+++ b/my-apps/ai/hindsight/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: hindsight
+
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - pvc.yaml
+  - db-deployment.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - vpa.yaml

--- a/my-apps/ai/hindsight/namespace.yaml
+++ b/my-apps/ai/hindsight/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hindsight

--- a/my-apps/ai/hindsight/pvc.yaml
+++ b/my-apps/ai/hindsight/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hindsight-db-pvc
+  namespace: hindsight
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi

--- a/my-apps/ai/hindsight/service.yaml
+++ b/my-apps/ai/hindsight/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hindsight-service
+  namespace: hindsight
+  labels:
+    app: hindsight
+spec:
+  selector:
+    app: hindsight
+  ports:
+    - name: http # CRITICAL — HTTPRoute matches by port name; fails silently without it
+      port: 8888
+      targetPort: 8888

--- a/my-apps/ai/hindsight/vpa.yaml
+++ b/my-apps/ai/hindsight/vpa.yaml
@@ -1,0 +1,37 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: hindsight
+  namespace: hindsight
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: hindsight
+  updatePolicy:
+    updateMode: "InPlaceOrRecreate"
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: hindsight-db
+  namespace: hindsight
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: hindsight-db
+  updatePolicy:
+    updateMode: "InPlaceOrRecreate"
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly

--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deal-scout
+  namespace: deal-scout
+  labels:
+    app: deal-scout
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  strategy:
+    type: Recreate # RWO PVC (SQLite) — old pod must release the volume first
+  selector:
+    matchLabels:
+      app: deal-scout
+  template:
+    metadata:
+      labels:
+        app: deal-scout
+    spec:
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: deal-scout
+          # Source: ~/programming/hermes-agent/dashboard — build & push:
+          #   docker build -t registry.vanillax.me/deal-scout:v0.1.0 dashboard/
+          #   docker push registry.vanillax.me/deal-scout:v0.1.0
+          image: registry.vanillax.me/deal-scout:v0.1.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DATA_DIR
+              value: /data
+            - name: INGEST_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: deal-scout-secrets
+                  key: INGEST_TOKEN
+          ports:
+            - containerPort: 8000
+              name: http
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 25m
+              memory: 96Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: deal-scout-data
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi

--- a/my-apps/utility/deal-scout/externalsecret.yaml
+++ b/my-apps/utility/deal-scout/externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: deal-scout-secrets
+  namespace: deal-scout
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: deal-scout-secrets
+    creationPolicy: Owner
+  data:
+    # 1Password item "deal-scout" — one field.
+    # ingest_token: MUST match DEAL_SCOUT_TOKEN in ~/.hermes/.env on the desktop.
+    - secretKey: INGEST_TOKEN
+      remoteRef:
+        key: deal-scout
+        property: ingest_token

--- a/my-apps/utility/deal-scout/httproute.yaml
+++ b/my-apps/utility/deal-scout/httproute.yaml
@@ -1,0 +1,28 @@
+# INTERNAL route (local network only, via gateway-internal).
+# Dashboard read endpoints are unauthenticated, so keep this off the
+# Cloudflare tunnel. Flip to the gateway-external + external-dns pattern
+# later if remote access is wanted (add auth first).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: deal-scout-route
+  namespace: deal-scout
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-internal-technitium
+      namespace: gateway
+  hostnames:
+    - "deals.vanillax.me"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: deal-scout
+          port: 8000
+          weight: 1

--- a/my-apps/utility/deal-scout/kustomization.yaml
+++ b/my-apps/utility/deal-scout/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: deal-scout
+
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - vpa.yaml

--- a/my-apps/utility/deal-scout/namespace.yaml
+++ b/my-apps/utility/deal-scout/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: deal-scout

--- a/my-apps/utility/deal-scout/pvc.yaml
+++ b/my-apps/utility/deal-scout/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: deal-scout-data
+  namespace: deal-scout
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 1Gi

--- a/my-apps/utility/deal-scout/service.yaml
+++ b/my-apps/utility/deal-scout/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deal-scout
+  namespace: deal-scout
+  labels:
+    app: deal-scout
+spec:
+  selector:
+    app: deal-scout
+  ports:
+    - name: http # CRITICAL — HTTPRoute matches by port name; fails silently without it
+      port: 8000
+      targetPort: 8000

--- a/my-apps/utility/deal-scout/vpa.yaml
+++ b/my-apps/utility/deal-scout/vpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: deal-scout
+  namespace: deal-scout
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: deal-scout
+  updatePolicy:
+    updateMode: "InPlaceOrRecreate"
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly


### PR DESCRIPTION
## What

Two new ArgoCD-discovered apps powering the Hermes deal-scout pipeline (desktop Hermes agent scrapes eBay + FB Marketplace via logged-in Chrome, posts here):

**`my-apps/ai/hindsight`** — self-hosted [Hindsight](https://hindsight.vectorize.io) 0.8.6, persistent memory for the Hermes agent
- pgvector Postgres (`pgvector/pgvector:pg16`, longhorn PVC, Recreate strategy)
- memory-processing LLM = in-cluster vLLM (`vllm-service.vllm:8080`, qwen3.6-27b) — free tokens, embeddings bundled in the image
- internal-only HTTPRoute `hindsight.vanillax.me`, tenant API key via ExternalSecret (1Password item `hindsight` — **already created**)

**`my-apps/utility/deal-scout`** — FastAPI + SQLite dashboard for scraped hardware listings
- `registry.vanillax.me/deal-scout:v0.1.0` (**already pushed**; source `~/programming/hermes-agent/dashboard`)
- listings-by-day chart, median-based deal flagging, token-authed `/api/ingest`
- internal-only HTTPRoute `deals.vanillax.me` (read endpoints unauthenticated → kept off the Cloudflare tunnel)
- ExternalSecret from 1Password item `deal-scout` (**already created**)

## Also riding along

- `basemap-bootstrap-image.yml`: enforce VERSION bumps on build-input PRs — finished stray work from an earlier session
- `.claude/settings.local.json`: MCP toggle churn

## Verification

- `kubectl kustomize` passes on both app dirs
- Dashboard image tested end-to-end locally (ingest → dedup → deals API → UI screenshot-verified)
- Both 1Password items exist and match the desktop `~/.hermes/.env` tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)