### PR TITLE
fix: correct copyparty Secret volume field

### DIFF
--- a/my-apps/media/copyparty/deployment.yaml
+++ b/my-apps/media/copyparty/deployment.yaml
@@ -64,4 +64,4 @@ spec:
           claimName:  copyparty-data
       - name: config
         secret:
-          name: copyparty-config
+          secretName: copyparty-config


### PR DESCRIPTION
## Summary

Fixes the Kubernetes schema error reported by the merged security-remediation PR's `Kustomize Render and Schema Validation` job.

## Root cause

The copyparty Deployment used `name` inside a Secret volume source. Kubernetes' `SecretVolumeSource` schema requires `secretName`, so kubeconform rejected the Deployment and ArgoCD/Kubernetes would reject the manifest.

## Change

```yaml
secret:
  secretName: copyparty-config
```

## Validation

- `kustomize build my-apps/media/copyparty`
- `git diff --check`
- Confirmed the rendered Deployment contains `volumes[].secret.secretName`

A local `kubectl --dry-run=client` could not download the OpenAPI schema through the Omni endpoint; the GitHub kubeconform job is the authoritative schema verification for this PR.