### PR TITLE
deal-scout: v0.2.0 — mini-PC BUY/MAYBE/REJECT classifier

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,9 +29,9 @@ spec:
       containers:
         - name: deal-scout
           # Source: ~/programming/hermes-agent/dashboard — build & push:
-          #   docker build -t registry.vanillax.me/deal-scout:v0.1.0 dashboard/
-          #   docker push registry.vanillax.me/deal-scout:v0.1.0
-          image: registry.vanillax.me/deal-scout:v0.1.0
+          #   docker build -t registry.vanillax.me/deal-scout:v0.2.0 dashboard/
+          #   docker push registry.vanillax.me/deal-scout:v0.2.0
+          image: registry.vanillax.me/deal-scout:v0.2.0
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR


### PR DESCRIPTION
One-line image bump to `registry.vanillax.me/deal-scout:v0.2.0` (already pushed to the registry).

New in the image: deterministic mini-PC procurement classifier — buy-now model allowlist (M75q Gen2 GE, OptiPlex x080/x090 Micro T-series, EliteDesk G6/G8 Mini, UM773/790/890, SER6-8), auto-reject rules (8th/9th gen, M720q/M920q, Gen1, for-parts/BIOS-lock/MDM, $1 bait), per-node lot pricing, price-threshold gates, and 40/25/20/10/5 scoring. UI gets BUY/MAYBE/REJECT badges + rating filter.

Scraper source lives in ~/programming/hermes-agent (being git-initialized separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)