### PR TITLE
deal-scout: v0.2.1 — MSU surplus, deal-card feed, images

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,9 +29,9 @@ spec:
       containers:
         - name: deal-scout
           # Source: ~/programming/hermes-agent/dashboard — build & push:
-          #   docker build -t registry.vanillax.me/deal-scout:v0.2.0 dashboard/
-          #   docker push registry.vanillax.me/deal-scout:v0.2.0
-          image: registry.vanillax.me/deal-scout:v0.2.0
+          #   docker build -t registry.vanillax.me/deal-scout:v0.2.1 dashboard/
+          #   docker push registry.vanillax.me/deal-scout:v0.2.1
+          image: registry.vanillax.me/deal-scout:v0.2.1
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR


### PR DESCRIPTION
Image bump to `deal-scout:v0.2.1` (pushed to registry). New in the image:

- **MSU Surplus Store** as a third source (Shopify JSON API, no browser needed, 429-backoff) — 46 live listings on first test
- **Slickdeals-style deal-card feed**: product images, BUY/MAYBE badges with scores, per-node lot pricing, reasons per card
- Listing image capture on all sources (eBay/FB/Shopify) with additive SQLite migration
- Classifier understands surplus-style titles ("i5 10th Gen") and rejects Xeon towers / 9th-gen-and-older
- Chart/legend gain a Surplus series

🤖 Generated with [Claude Code](https://claude.com/claude-code)