### PR TITLE
deal-scout: v0.2.2 — fix crash-loop, classify.py missing from image

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,9 +29,9 @@ spec:
       containers:
         - name: deal-scout
           # Source: ~/programming/hermes-agent/dashboard — build & push:
-          #   docker build -t registry.vanillax.me/deal-scout:v0.2.1 dashboard/
-          #   docker push registry.vanillax.me/deal-scout:v0.2.1
-          image: registry.vanillax.me/deal-scout:v0.2.1
+          #   docker build -t registry.vanillax.me/deal-scout:v0.2.2 dashboard/
+          #   docker push registry.vanillax.me/deal-scout:v0.2.2
+          image: registry.vanillax.me/deal-scout:v0.2.2
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR


### PR DESCRIPTION
Fixes the CrashLoopBackOff you found in ArgoCD: `ModuleNotFoundError: No module named 'classify'` — the Dockerfile copied `app.py` but not `classify.py`. Image `v0.2.2` (pushed) includes it; container boot-tested with /healthz + /api/deals before pushing this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)