### PR TITLE
deal-scout: v0.2.3 — reject laptops/AIOs, cap eBay variant listings

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,9 +29,9 @@ spec:
       containers:
         - name: deal-scout
           # Source: ~/programming/hermes-agent/dashboard — build & push:
-          #   docker build -t registry.vanillax.me/deal-scout:v0.2.2 dashboard/
-          #   docker push registry.vanillax.me/deal-scout:v0.2.2
-          image: registry.vanillax.me/deal-scout:v0.2.2
+          #   docker build -t registry.vanillax.me/deal-scout:v0.2.3 dashboard/
+          #   docker push registry.vanillax.me/deal-scout:v0.2.3
+          image: registry.vanillax.me/deal-scout:v0.2.3
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR


### PR DESCRIPTION
Classifier tuning from live data review:

- **Laptops/AIOs auto-REJECT** (Ideapad/EliteBook/ThinkPad/Latitude/all-in-one/etc.) — they matched CPU+price rules but aren't cluster nodes
- **eBay variant listings** ("$249 to $334" dropdown listings) can never auto-BUY — the search price is the cheapest config, so they cap at MAYBE with a verify-dropdowns reason; the cron agent now prices the actual qualifying config from the item page
- Skill: dashboard-API-down now gets reported loudly instead of [SILENT]

Image boot-tested before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)