### PR TITLE
deal-scout: v0.3.0 — Deal Scout v2 design (3 tabs, feedback learning, admin config)

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,9 +29,9 @@ spec:
       containers:
         - name: deal-scout
           # Source: ~/programming/hermes-agent/dashboard — build & push:
-          #   docker build -t registry.vanillax.me/deal-scout:v0.2.3 dashboard/
-          #   docker push registry.vanillax.me/deal-scout:v0.2.3
-          image: registry.vanillax.me/deal-scout:v0.2.3
+          #   docker build -t registry.vanillax.me/deal-scout:v0.3.0 dashboard/
+          #   docker push registry.vanillax.me/deal-scout:v0.3.0
+          image: registry.vanillax.me/deal-scout:v0.3.0
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR


### PR DESCRIPTION
Implements the Claude-designed "Deal Scout v2" UI (designs/ in mitchross/deal-scout) plus the backend it needs:

- **Dashboard tab**: stat strip, shortlist (strong buys + top watches) with ▲/▼ voting, walk-away price bars, query health, per-source status
- **Listings tab**: BUY/WATCH/SKIP/Hidden tier chips, source+query+search filters, table & card views, star/hide per row
- **Admin tab**: tracked queries (toggle/add, served to the scraper via /api/config), editable $/node thresholds (live re-rating), reject-rule chips, learned-signal management, source toggles
- **Learning loop**: downvotes/hides derive reject terms server-side; terms seen 3+ times auto-REJECT matching listings
- Scraper now pulls queries/sources from /api/config (Admin is source of truth after first-run seeding)

Boot-tested container incl. new endpoints; all three tabs screenshot-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)