### PR TITLE
deal-scout: v0.3.1 — Comprenew + Slickdeals sources, MSU as price baseline

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,9 +29,9 @@ spec:
       containers:
         - name: deal-scout
           # Source: ~/programming/hermes-agent/dashboard — build & push:
-          #   docker build -t registry.vanillax.me/deal-scout:v0.2.3 dashboard/
-          #   docker push registry.vanillax.me/deal-scout:v0.2.3
-          image: registry.vanillax.me/deal-scout:v0.2.3
+          #   docker build -t registry.vanillax.me/deal-scout:v0.3.1 dashboard/
+          #   docker push registry.vanillax.me/deal-scout:v0.3.1
+          image: registry.vanillax.me/deal-scout:v0.3.1
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR


### PR DESCRIPTION
New sources + policy tweak (stacks on v0.3.0 if #1831 unmerged — this supersedes its tag either way):

- **Comprenew** (shopcomprenew.org, Grand Rapids e-waste nonprofit) — Shopify JSON, drivable pickup, 35 listings on first probe
- **Slickdeals RSS** feeds (mini pc / optiplex micro / thinkcentre tiny / beelink / minisforum) — national price-drop radar, 122 deals on first pull; classifier filters the junk
- **MSU Surplus reclassified as price baseline** — never surfaces as BUY (nobody's driving to East Lansing); tagged BASELINE · EL in the UI
- UI: source chips/filters/toggles for all five sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)