### PR TITLE
cnpg: fix WAL-archive deadlock on all three DBs (temporal down)

### DIFF
--- a/infrastructure/database/cloudnative-pg/immich/base/cluster.yaml
+++ b/infrastructure/database/cloudnative-pg/immich/base/cluster.yaml
@@ -75,4 +75,5 @@ spec:
         #        reused v4 (whose prefix still held old WAL) → Barman "Expected
         #        empty archive", ContinuousArchiving stuck False. Clean v5 prefix.
         # DO NOT change this value without bumping lineage in lockstep.
-        serverName: immich-database-v6
+        #   v6 — 2026-07-29 rebuild reused non-empty prefix → archiving stuck False.
+        serverName: immich-database-v7

--- a/infrastructure/database/cloudnative-pg/immich/overlays/recovery/bootstrap-patch.yaml
+++ b/infrastructure/database/cloudnative-pg/immich/overlays/recovery/bootstrap-patch.yaml
@@ -31,4 +31,4 @@ spec:
           # bumping recovery target lineage. See cnpg-plugin-migration.md
           # §9.1. N-1 of base (base now writes v6). RustFS multipart bug was
           # FIXED 2026-06-19 (1.0.0-beta.8) — these base backups ARE restorable.
-          serverName: immich-database-v5
+          serverName: immich-database-v6

--- a/infrastructure/database/cloudnative-pg/paperless/base/cluster.yaml
+++ b/infrastructure/database/cloudnative-pg/paperless/base/cluster.yaml
@@ -84,4 +84,5 @@ spec:
         #        "Expected empty archive", ContinuousArchiving stuck False.
         #        Bumped to a clean v5 prefix.
         # DO NOT change this value without bumping lineage in lockstep.
-        serverName: paperless-database-v6
+        #   v6 — 2026-07-29 rebuild reused non-empty prefix → archiving stuck False.
+        serverName: paperless-database-v7

--- a/infrastructure/database/cloudnative-pg/paperless/overlays/recovery/bootstrap-patch.yaml
+++ b/infrastructure/database/cloudnative-pg/paperless/overlays/recovery/bootstrap-patch.yaml
@@ -35,4 +35,4 @@ spec:
           # bumping recovery target lineage. See cnpg-plugin-migration.md
           # §9.1. N-1 of base (base now writes v6). RustFS multipart bug was
           # FIXED 2026-06-19 (1.0.0-beta.8) — these base backups ARE restorable.
-          serverName: paperless-database-v5
+          serverName: paperless-database-v6

--- a/infrastructure/database/cloudnative-pg/temporal/base/cluster.yaml
+++ b/infrastructure/database/cloudnative-pg/temporal/base/cluster.yaml
@@ -36,7 +36,7 @@ spec:
     # 50Gi -> 10Gi for single-node 2950X rebuild (2026-06-19). WAL is transient
     # spool (max_wal_size < 1GB); 50Gi was never approached. Reclaims Longhorn
     # scheduling budget on the worker's Longhorn filesystems.
-    size: 10Gi
+    size: 20Gi  # 2026-07-31: was 10Gi; filled during the v8 archive deadlock — headroom for boot + backlog drain
     storageClass: longhorn
   enableSuperuserAccess: true
   monitoring:
@@ -68,4 +68,8 @@ spec:
         # DO NOT change this value without bumping lineage in lockstep.
         # The companion overlays/recovery/bootstrap-patch.yaml MUST be
         # updated in the SAME commit (read FROM v(N-1) → write TO vN).
-        serverName: temporal-database-v8
+        #   v8 — 2026-07-29 full-cluster rebuild; fresh initdb reused the v8 name
+        #        whose prefix already held WAL → Barman "Expected empty archive",
+        #        ContinuousArchiving=False since; WAL PVC filled 2026-07-31 and
+        #        took Temporal down. Clean v9 prefix.
+        serverName: temporal-database-v9

--- a/infrastructure/database/cloudnative-pg/temporal/overlays/recovery/bootstrap-patch.yaml
+++ b/infrastructure/database/cloudnative-pg/temporal/overlays/recovery/bootstrap-patch.yaml
@@ -41,4 +41,4 @@ spec:
           #   v5 — lineage superseded by the 2026-06-12 rebuild.
           #   v6 — abandoned 2026-06-23 (dirty prefix → "Expected empty
           #        archive"); kept at N-1 relative to the active v7 write target.
-          serverName: temporal-database-v7
+          serverName: temporal-database-v8


### PR DESCRIPTION
**Incident**: temporal.vanillax.me 500s since ~05:00 EDT 2026-07-31. Root cause chain:

1. The 2026-07-29 full-cluster rebuild initdb'd fresh CNPG clusters but **reused old barman serverNames** (`temporal-database-v8`, `immich-database-v6`, `paperless-database-v6`)
2. Their S3 prefixes still held the previous incarnation's WAL → barman's empty-archive check refused to start → **ContinuousArchiving=False on all three, zero successful backups since rebuild**
3. Temporal (write-heaviest) filled its 10Gi WAL PVC in 2.5 days → postgres CrashLoopBackOff (107 restarts) → `no usable database connection` → Temporal UI/workflows down. **Immich and paperless are on the same trajectory**, just slower.

**Fix** (the repo's own documented §9.1 procedure, this is lineage bump #9):
- serverName → `temporal-database-v9`, `immich-database-v7`, `paperless-database-v7` (clean prefixes; archiving starts immediately)
- recovery overlays flipped to read from v(N-1) in the same commit, per the lockstep rule
- temporal `walStorage` 10→20Gi (longhorn online expansion) so postgres can boot with a full volume and drain the backlog
- lineage comments updated with the incident

All six overlay kustomizations build clean. After merge I'll watch: archiving → True, WAL drains, temporal pods reconnect, UI recovers.

**Follow-up worth doing** (separate PR): a PrometheusRule alerting on ContinuousArchiving=False / no-successful-backup-in-24h — this failure mode has now happened on 8 of 9 lineage generations and is silent until a volume fills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)