### PR TITLE
deal-scout: v0.4.3 — 16GB RAM minimum, fix SSD-size-parsed-as-RAM

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,9 +29,9 @@ spec:
       containers:
         - name: deal-scout
           # Source: ~/programming/hermes-agent/dashboard — build & push:
-          #   docker build -t registry.vanillax.me/deal-scout:v0.4.1 dashboard/
-          #   docker push registry.vanillax.me/deal-scout:v0.4.1
-          image: registry.vanillax.me/deal-scout:v0.4.1
+          #   docker build -t registry.vanillax.me/deal-scout:v0.4.3 dashboard/
+          #   docker push registry.vanillax.me/deal-scout:v0.4.3
+          image: registry.vanillax.me/deal-scout:v0.4.3
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR


### PR DESCRIPTION
Per new hardware policy: **8GB machines are never straight BUYs** (16GB min, 32GB target) — they cap at WATCH with a "needs RAM — factor ~$50-80 for 32GB" note. Also fixes the extraction bug that enabled it: `8GB RAM, 128GB SSD` titles were reading the SSD size as RAM. Verified against the two 8GB listings at BUY 94 on the live shortlist — both demote. Boot-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)