### PR TITLE
registry: stop weekly GC bricking the registry on registry:3

### DIFF
--- a/infrastructure/storage/container-registry/config.yml
+++ b/infrastructure/storage/container-registry/config.yml
@@ -7,6 +7,16 @@ storage:
     blobdescriptor: inmemory
   delete:
     enabled: true
+  # Must be declared here even though it's false. registry-gc flips it with
+  # REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED=true, and distribution v3's
+  # env override can only descend into a key that already exists as a map. On
+  # registry:3 without this block the override lands as a scalar and the
+  # process panics at boot ("readonly config key must contain additional
+  # keys"), which bricked the registry for 15h on 2026-08-02 — GC set the var,
+  # crashed the pod, and never reached the step that unsets it.
+  maintenance:
+    readonly:
+      enabled: false
   # Blobs on RustFS S3 (durable, survives a cluster/storage nuke — unlike the
   # old Longhorn-snapshot-on-PVC path). accesskey/secretkey injected via env
   # (REGISTRY_STORAGE_S3_ACCESSKEY/SECRETKEY) from Secret registry-s3-credentials.

--- a/infrastructure/storage/container-registry/config.yml
+++ b/infrastructure/storage/container-registry/config.yml
@@ -7,16 +7,6 @@ storage:
     blobdescriptor: inmemory
   delete:
     enabled: true
-  # Must be declared here even though it's false. registry-gc flips it with
-  # REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED=true, and distribution v3's
-  # env override can only descend into a key that already exists as a map. On
-  # registry:3 without this block the override lands as a scalar and the
-  # process panics at boot ("readonly config key must contain additional
-  # keys"), which bricked the registry for 15h on 2026-08-02 — GC set the var,
-  # crashed the pod, and never reached the step that unsets it.
-  maintenance:
-    readonly:
-      enabled: false
   # Blobs on RustFS S3 (durable, survives a cluster/storage nuke — unlike the
   # old Longhorn-snapshot-on-PVC path). accesskey/secretkey injected via env
   # (REGISTRY_STORAGE_S3_ACCESSKEY/SECRETKEY) from Secret registry-s3-credentials.

--- a/infrastructure/storage/container-registry/gc-cronjob.yaml
+++ b/infrastructure/storage/container-registry/gc-cronjob.yaml
@@ -3,14 +3,12 @@
 # fills silently — pushes start failing once it's full.
 #
 # Flow:
-#   1. Flip REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED=true on the
-#      registry deploy. Concurrent pushes during GC can corrupt the store
-#      (in-flight blob upload + GC sweep = lost data) so we go read-only
-#      first.
+#   1. Flip the registry deploy to read-only. Concurrent pushes during GC can
+#      corrupt the store (in-flight blob upload + GC sweep = lost data).
 #   2. Wait for the rolled pod to be Ready.
 #   3. Exec `registry garbage-collect -m` inside the pod. `-m` is
 #      mark-and-sweep (the safe variant introduced in distribution 2.x).
-#   4. Unset the env var, wait for rollout.
+#   4. Unset the env var, wait for rollout (EXIT trap — always runs).
 #
 # Schedule is Sunday 04:00 UTC — off-peak for this cluster's CI bursts.
 apiVersion: batch/v1
@@ -44,21 +42,23 @@ spec:
               command: [/bin/bash, -euo, pipefail, -c]
               args:
                 - |
-                  # Always restore writes, even if GC or the rollout fails.
-                  # Without this the registry stays read-only until someone
-                  # notices pulls 503ing (see config.yml — a failed run on
-                  # 2026-08-02 left it down for 15h).
+                  # Restore writes on every exit path. A failed run that left
+                  # the registry read-only 503'd every pull for 15h once.
                   restore_writes() {
                     echo "[gc] restoring writes (trap)"
                     kubectl -n kube-system set env deploy/registry \
-                      REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED- || true
+                      REGISTRY_STORAGE_MAINTENANCE- || true
                     kubectl -n kube-system rollout status deploy/registry --timeout=180s || true
                   }
                   trap restore_writes EXIT
 
+                  # Override the whole maintenance map, not the leaf. On
+                  # registry:3 REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED
+                  # either panics the process at boot or is dropped with
+                  # "map with non-string keys" — never applied.
                   echo "[gc] flipping registry to read-only"
                   kubectl -n kube-system set env deploy/registry \
-                    REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED=true
+                    'REGISTRY_STORAGE_MAINTENANCE={readonly: {enabled: true}}'
                   kubectl -n kube-system rollout status deploy/registry --timeout=180s
 
                   echo "[gc] running garbage-collect -m"
@@ -67,7 +67,6 @@ spec:
                   kubectl -n kube-system exec "$POD" -- \
                     registry garbage-collect -m /etc/distribution/config.yml
 
-                  # Writes are restored by the EXIT trap above.
                   echo "[gc] done"
 ---
 apiVersion: v1

--- a/infrastructure/storage/container-registry/gc-cronjob.yaml
+++ b/infrastructure/storage/container-registry/gc-cronjob.yaml
@@ -44,6 +44,18 @@ spec:
               command: [/bin/bash, -euo, pipefail, -c]
               args:
                 - |
+                  # Always restore writes, even if GC or the rollout fails.
+                  # Without this the registry stays read-only until someone
+                  # notices pulls 503ing (see config.yml — a failed run on
+                  # 2026-08-02 left it down for 15h).
+                  restore_writes() {
+                    echo "[gc] restoring writes (trap)"
+                    kubectl -n kube-system set env deploy/registry \
+                      REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED- || true
+                    kubectl -n kube-system rollout status deploy/registry --timeout=180s || true
+                  }
+                  trap restore_writes EXIT
+
                   echo "[gc] flipping registry to read-only"
                   kubectl -n kube-system set env deploy/registry \
                     REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED=true
@@ -55,10 +67,7 @@ spec:
                   kubectl -n kube-system exec "$POD" -- \
                     registry garbage-collect -m /etc/distribution/config.yml
 
-                  echo "[gc] restoring writes"
-                  kubectl -n kube-system set env deploy/registry \
-                    REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED-
-                  kubectl -n kube-system rollout status deploy/registry --timeout=180s
+                  # Writes are restored by the EXIT trap above.
                   echo "[gc] done"
 ---
 apiVersion: v1


### PR DESCRIPTION
## Problem

The weekly `registry-gc` job put the registry in read-only mode, ran garbage collection, then restored writes. On `registry:3` the env var it used to do that (`REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED`) **panics the process at boot**:

```
panic: readonly config key must contain additional keys
```

The registry crash-looped, `rollout status` failed, `set -e` killed the script, and the step that unsets the var never ran. Nothing was left to undo it — 15h down, 186 restarts, every image pull in the cluster 503ing.

## Fix

1. Override the whole `maintenance` map instead of the leaf key:
   `REGISTRY_STORAGE_MAINTENANCE={readonly: {enabled: true}}`.
   The leaf form is unusable on registry:3 — without a `maintenance` block in `config.yml` it panics, and with one it is silently dropped (`Ignoring environment variable ... map with non-string keys`), leaving the registry writable during GC. The whole-map form applies cleanly and needs no `config.yml` change.
2. Restore writes from an `EXIT` trap, so no failure anywhere in the job can leave the registry read-only.

## Validation

Run against the real `registry:3` image, not just rendered:

| step | result |
|---|---|
| push while flipped read-only | `405` (refused, as intended) |
| pull while flipped | `200` |
| `registry garbage-collect -m` while read-only | sweeps and deletes blobs normally |
| push after the trap unsets the var | `202` |
| old leaf env var, for comparison | container exits 2 (the outage) |

## Clearing the current outage

Already recovered — the registry deploy no longer carries the stuck env var. If it recurs before this merges:

```
kubectl -n kube-system set env deploy/registry REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED-
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)