### PR TITLE
cnpg: bump recovery write lineages to v9/v9/v11

### DIFF
--- a/infrastructure/database/CLAUDE.md
+++ b/infrastructure/database/CLAUDE.md
@@ -64,9 +64,9 @@ The `serverName` values below live in each DB's `base/cluster.yaml` and
 
 | Database  | Next write target (base) | Recovery source | Pinned backup ID |
 |-----------|--------------------------|-----------------|------------------|
-| immich    | `immich-database-v8`     | `immich-database-v6` | `20260728T020000` |
-| paperless | `paperless-database-v8`  | `paperless-database-v6` | `20260728T050000` |
-| temporal  | `temporal-database-v10`  | `temporal-database-v8` | `20260728T030000` |
+| immich    | `immich-database-v9`     | `immich-database-v6` | `20260728T020000` |
+| paperless | `paperless-database-v9`  | `paperless-database-v6` | `20260728T050000` |
+| temporal  | `temporal-database-v11`  | `temporal-database-v8` | `20260728T030000` |
 
 The roots are intentionally on `overlays/recovery` for the planned 2026-07-31
 full-cluster rebuild. Their Argo Applications and consumer Applications have
@@ -74,7 +74,15 @@ auto-sync/self-heal explicitly disabled. After bootstrap, run
 `scripts/bootstrap-cnpg-recovery.sh --execute`; it advances each pair only
 after exact lineage, application rows, WAL archiving, and the recovery-only
 `Backup` object are proven. Flip the roots back to `overlays/initdb` only after that
-acceptance succeeds on v8/v8/v10.
+acceptance succeeds on v9/v9/v11.
+
+2026-08-03: the 2026-08-01 recovery run silently bootstrapped `initdb` instead
+of recovering. Its v8/v8/v10 lineages carry a different `systemid`, sit on WAL
+timeline 1, and hold empty databases (temporal 5 MB vs v8's 160 MB), so they
+are abandoned and the write targets moved to v9/v9/v11. The reads stay pinned
+to the 2026-07-28 backups — those remain the only data-bearing ones. Verify a
+recovery by comparing `systemid` in the new lineage's `backup.info` against the
+source lineage: a real restore preserves it.
 
 2026-07-31 pre-nuke audit: the July 29 rebuild used `initdb`, so live Immich
 had zero assets/users, Paperless had zero documents, and Temporal had zero

--- a/infrastructure/database/cloudnative-pg/immich/base/cluster.yaml
+++ b/infrastructure/database/cloudnative-pg/immich/base/cluster.yaml
@@ -78,6 +78,8 @@ spec:
         #   v6 — last data-bearing lineage before the 2026-07-29 rebuild.
         #   v7 — clean archiving target opened 2026-07-31, but the live initdb
         #        contained zero assets/users. Abandoned after the audit.
-        #   v8 — clean forward target for the 2026-07-31 recovery from the
-        #        pinned v6 backup.
-        serverName: immich-database-v8
+        #   v8 — opened 2026-08-01, but that run bootstrapped initdb instead of
+        #        recovering: its backups carry a different systemid and sit on
+        #        timeline 1, so they hold an empty database. Abandoned.
+        #   v9 — clean forward target for the recovery from the pinned v6 backup.
+        serverName: immich-database-v9

--- a/infrastructure/database/cloudnative-pg/immich/overlays/recovery/bootstrap-patch.yaml
+++ b/infrastructure/database/cloudnative-pg/immich/overlays/recovery/bootstrap-patch.yaml
@@ -32,7 +32,7 @@ spec:
           # endpoint). Only serverName changes between live writes and
           # recovery reads.
           barmanObjectName: immich-objectstore
-          # Data-bearing recovery lineage. Base writes to fresh v8; v7 is an
-          # empty post-rebuild lineage and must never be selected as a restore
-          # source. backupID above pins the verified 2026-07-28 base backup.
+          # Data-bearing recovery lineage. Base writes to fresh v9; v7 and v8
+          # are empty post-rebuild lineages and must never be selected as a
+          # restore source. backupID above pins the verified 2026-07-28 backup.
           serverName: immich-database-v6

--- a/infrastructure/database/cloudnative-pg/immich/overlays/recovery/post-recovery-backup.yaml
+++ b/infrastructure/database/cloudnative-pg/immich/overlays/recovery/post-recovery-backup.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Backup
 metadata:
-  name: immich-post-recovery-v8
+  name: immich-post-recovery-v9
   annotations:
     # Create after the recovery Cluster. The recovery script independently
     # waits for this exact Backup to complete before releasing the consumer.

--- a/infrastructure/database/cloudnative-pg/paperless/base/cluster.yaml
+++ b/infrastructure/database/cloudnative-pg/paperless/base/cluster.yaml
@@ -88,6 +88,8 @@ spec:
         #        also contains a newer empty backup, so recovery pins backupID.
         #   v7 — clean archiving target opened 2026-07-31, but the live initdb
         #        contained zero documents. Abandoned after the audit.
-        #   v8 — clean forward target for the 2026-07-31 recovery from the
-        #        pinned v6 backup.
-        serverName: paperless-database-v8
+        #   v8 — opened 2026-08-01, but that run bootstrapped initdb instead of
+        #        recovering: its backups carry a different systemid and sit on
+        #        timeline 1, so they hold an empty database. Abandoned.
+        #   v9 — clean forward target for the recovery from the pinned v6 backup.
+        serverName: paperless-database-v9

--- a/infrastructure/database/cloudnative-pg/paperless/overlays/recovery/bootstrap-patch.yaml
+++ b/infrastructure/database/cloudnative-pg/paperless/overlays/recovery/bootstrap-patch.yaml
@@ -31,7 +31,7 @@ spec:
           # endpoint). Only serverName changes between live writes and
           # recovery reads.
           barmanObjectName: paperless-objectstore
-          # Data-bearing recovery lineage. Base writes to fresh v8; v7 is an
-          # empty post-rebuild lineage. backupID above avoids the newer empty
-          # base backup that polluted this otherwise valid v6 catalog.
+          # Data-bearing recovery lineage. Base writes to fresh v9; v7 and v8
+          # are empty post-rebuild lineages. backupID above avoids the newer
+          # empty base backup that polluted this otherwise valid v6 catalog.
           serverName: paperless-database-v6

--- a/infrastructure/database/cloudnative-pg/paperless/overlays/recovery/post-recovery-backup.yaml
+++ b/infrastructure/database/cloudnative-pg/paperless/overlays/recovery/post-recovery-backup.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Backup
 metadata:
-  name: paperless-post-recovery-v8
+  name: paperless-post-recovery-v9
   annotations:
     argocd.argoproj.io/sync-wave: "10"
 spec:

--- a/infrastructure/database/cloudnative-pg/temporal/base/cluster.yaml
+++ b/infrastructure/database/cloudnative-pg/temporal/base/cluster.yaml
@@ -75,6 +75,8 @@ spec:
         #   v9 — clean archiving target opened 2026-07-31, but its first base
         #        backup preceded schema initialization and contains no workflow
         #        executions. Abandoned after the audit.
-        #   v10 — clean forward target for the 2026-07-31 recovery from the
-        #         pinned data-bearing v8 backup.
-        serverName: temporal-database-v10
+        #   v10 — opened 2026-08-01, but that run bootstrapped initdb instead of
+        #         recovering: its backups carry a different systemid, sit on
+        #         timeline 1, and are 5 MB against v8's 160 MB. Abandoned.
+        #   v11 — clean forward target for the recovery from the pinned v8 backup.
+        serverName: temporal-database-v11

--- a/infrastructure/database/cloudnative-pg/temporal/overlays/recovery/bootstrap-patch.yaml
+++ b/infrastructure/database/cloudnative-pg/temporal/overlays/recovery/bootstrap-patch.yaml
@@ -45,4 +45,6 @@ spec:
           #   v6 — abandoned 2026-06-23 (dirty prefix → "Expected empty archive").
           #   v8 — last data-bearing lineage before the 2026-07-29 rebuild;
           #        backupID above selects its verified 2026-07-28 base backup.
+          #   v10 — empty initdb lineage from the 2026-08-01 run. Base writes
+          #         forward to v11; never select v9 or v10 as a restore source.
           serverName: temporal-database-v8

--- a/infrastructure/database/cloudnative-pg/temporal/overlays/recovery/post-recovery-backup.yaml
+++ b/infrastructure/database/cloudnative-pg/temporal/overlays/recovery/post-recovery-backup.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Backup
 metadata:
-  name: temporal-post-recovery-v10
+  name: temporal-post-recovery-v11
   annotations:
     argocd.argoproj.io/sync-wave: "10"
 spec:

--- a/scripts/bootstrap-cnpg-recovery.sh
+++ b/scripts/bootstrap-cnpg-recovery.sh
@@ -314,9 +314,9 @@ log "Validating the pinned recovery contract"
 while IFS='|' read -r db_name read_lineage backup_id write_lineage system_id database_name table_name consumer_app consumer_path; do
   assert_recovery_render "$db_name" "$read_lineage" "$backup_id" "$write_lineage"
 done <<'EOF'
-immich|immich-database-v6|20260728T020000|immich-database-v8|7654249409354104861|immich|asset|my-apps-immich|my-apps/media/immich
-paperless|paperless-database-v6|20260728T050000|paperless-database-v8|7654249455955726366|paperless|documents_document|my-apps-paperless-ngx|my-apps/home/paperless-ngx
-temporal|temporal-database-v8|20260728T030000|temporal-database-v10|7654249455983591452|temporal|executions|my-apps-temporal|my-apps/development/temporal
+immich|immich-database-v6|20260728T020000|immich-database-v9|7654249409354104861|immich|asset|my-apps-immich|my-apps/media/immich
+paperless|paperless-database-v6|20260728T050000|paperless-database-v9|7654249455955726366|paperless|documents_document|my-apps-paperless-ngx|my-apps/home/paperless-ngx
+temporal|temporal-database-v8|20260728T030000|temporal-database-v11|7654249455983591452|temporal|executions|my-apps-temporal|my-apps/development/temporal
 EOF
 
 if [ "$EXECUTE" != true ]; then
@@ -376,9 +376,9 @@ while IFS='|' read -r db_name read_lineage backup_id write_lineage system_id dat
   sync_application "$consumer_app"
   wait_for_application_healthy "$consumer_app"
 done <<'EOF'
-immich|immich-database-v6|20260728T020000|immich-database-v8|7654249409354104861|immich|asset|my-apps-immich|my-apps/media/immich
-paperless|paperless-database-v6|20260728T050000|paperless-database-v8|7654249455955726366|paperless|documents_document|my-apps-paperless-ngx|my-apps/home/paperless-ngx
-temporal|temporal-database-v8|20260728T030000|temporal-database-v10|7654249455983591452|temporal|executions|my-apps-temporal|my-apps/development/temporal
+immich|immich-database-v6|20260728T020000|immich-database-v9|7654249409354104861|immich|asset|my-apps-immich|my-apps/media/immich
+paperless|paperless-database-v6|20260728T050000|paperless-database-v9|7654249455955726366|paperless|documents_document|my-apps-paperless-ngx|my-apps/home/paperless-ngx
+temporal|temporal-database-v8|20260728T030000|temporal-database-v11|7654249455983591452|temporal|executions|my-apps-temporal|my-apps/development/temporal
 EOF
 
 log "CNPG recovery accepted"


### PR DESCRIPTION
## Why

The 2026-08-01 recovery run **bootstrapped `initdb` instead of recovering**. Three independent proofs that `v8`/`v8`/`v10` hold empty databases:

| Check | Source (v6/v6/v8) | Target (v8/v8/v10) |
|---|---|---|
| `systemid` (immich) | `7654249409354104861` | `7667787411410997275` |
| `systemid` (paperless) | `7654249455955726366` | `7667787440422031389` |
| `systemid` (temporal) | `7654249455983591452` | `7668749719565185052` |
| WAL timeline | `00000002` | `00000001` (= fresh initdb) |
| temporal backup size | 160.0 MB | 5.3 MB |

A physical restore preserves `system_identifier`, so a differing ID means these are different databases. Timeline 1 is where `initdb` starts; a restored-and-promoted cluster would be on timeline 3.

Those lineages then archived empty backups until the 2026-08-03 rebuild. The dirty prefixes made `barman-cloud-check-wal-archive` fail with `Expected empty archive` — **the only reason the stale contract never ran and overwrote the real data**.

## What changed

Write targets move to clean prefixes; **reads, pinned `backupID`s and `system_identifier` assertions are unchanged**.

| DB | Read (unchanged) | backupID (unchanged) | Write |
|---|---|---|---|
| immich | `immich-database-v6` | `20260728T020000` | `v8` → **`v9`** |
| paperless | `paperless-database-v6` | `20260728T050000` | `v8` → **`v9`** |
| temporal | `temporal-database-v8` | `20260728T030000` | `v10` → **`v11`** |

The 2026-07-28 backups remain the only data-bearing ones. The `system_identifier` assertions in `bootstrap-cnpg-recovery.sh` are deliberately untouched — they are what detects an `initdb` masquerading as a recovery, and would have caught this.

## Verification

- `./scripts/bootstrap-cnpg-recovery.sh` preflight passes with the new contract
- `kustomize build` renders confirm read/backupID/write and the renamed post-recovery `Backup` objects
- `immich-database-v9`, `paperless-database-v9`, `temporal-database-v11` confirmed **empty** in RustFS, so the empty-archive check will pass

## After merge

The stuck cluster must be torn down before rerunning (stale PVCs otherwise hang "Setting up primary" forever):

```
kubectl -n cloudnative-pg delete cluster immich-database
kubectl -n cloudnative-pg delete pvc -l cnpg.io/cluster=immich-database
./scripts/bootstrap-cnpg-recovery.sh --execute
```

Those PVCs only ever held failed restore attempts.

## Unrelated, still open

Node `kf5x8m` is **cordoned** — TCP-over-VXLAN is broken bidirectionally (UDP fine, underlay fine, MTU fine, Cilium config correct). Longhorn's stateless CSI Deployments were moved off it; ~47 pods remain stranded there including `external-secrets`, both `cloudflared` replicas and `1password-connect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6rHcCfadxjJxmAuVuAAhs