### PR TITLE
Deploy Deal Scout split-source workers from GHCR

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -28,10 +28,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: deal-scout
-          # Source: ~/programming/deal-scout/dashboard — build & push:
-          #   docker build -t registry.vanillax.me/deal-scout:v0.4.3 dashboard/
-          #   docker push registry.vanillax.me/deal-scout:v0.4.3
-          image: registry.vanillax.me/deal-scout:v0.4.3
+          # Source: github.com/mitchross/deal-scout, dashboard/
+          image: ghcr.io/mitchross/deal-scout:v0.5.0@sha256:4adeadac22eedf457f58dc71ca616807337447421b8b0c1bd35c4f56e1d074c3
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: deal-scout
-          # Source: ~/programming/hermes-agent/dashboard — build & push:
+          # Source: ~/programming/deal-scout/dashboard — build & push:
           #   docker build -t registry.vanillax.me/deal-scout:v0.4.3 dashboard/
           #   docker push registry.vanillax.me/deal-scout:v0.4.3
           image: registry.vanillax.me/deal-scout:v0.4.3

--- a/my-apps/utility/deal-scout/externalsecret.yaml
+++ b/my-apps/utility/deal-scout/externalsecret.yaml
@@ -13,7 +13,8 @@ spec:
     creationPolicy: Owner
   data:
     # 1Password item "deal-scout" — one field.
-    # ingest_token: MUST match DEAL_SCOUT_TOKEN in ~/.hermes/.env on the desktop.
+    # ingest_token: MUST match DEAL_SCOUT_TOKEN in
+    # ~/.config/deal-scout/env on the CachyOS desktop.
     - secretKey: INGEST_TOKEN
       remoteRef:
         key: deal-scout

--- a/my-apps/utility/deal-scout/kustomization.yaml
+++ b/my-apps/utility/deal-scout/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
   - service.yaml
   - httproute.yaml
   - temporal-workers/temporal-connection.yaml
+  - temporal-workers/ebay-externalsecret.yaml
   - temporal-workers/temporal-worker-deployment.yaml
   - vpa.yaml

--- a/my-apps/utility/deal-scout/temporal-workers/ebay-externalsecret.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/ebay-externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: deal-scout-ebay
+  namespace: deal-scout
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: deal-scout-ebay
+    creationPolicy: Owner
+  data:
+    - secretKey: EBAY_CLIENT_ID
+      remoteRef:
+        key: ebay-developer
+        property: client_id
+    - secretKey: EBAY_CLIENT_SECRET
+      remoteRef:
+        key: ebay-developer
+        property: client_secret

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -1,19 +1,12 @@
-# WorkerDeployment — Temporal Worker Controller CRD (annotated walkthrough in
-# news-reader-temporal-worker/temporal-worker-deployment.yaml).
-#
-# Runs the deal-scout Temporal worker: task queue `deal-scout`, which owns the
-# `deal-scout-scan` Schedule (5x/day, browserless sources: Slickdeals + MSU +
-# Comprenew). No cron anywhere — Temporal Schedules + durable activities with
-# retries. Watch runs at temporal.vanillax.me → Schedules / Workflows.
-#
-# Browser-bound eBay/FB scans still run on the desktop via the
-# deal-scout-runner systemd timer polling the dashboard's /api/scan-request
-# (Temporal frontend is not exposed off-cluster; expose 7233 later and that
-# relay becomes a desktop Temporal worker on a `deal-scout-local` queue).
+# One cluster worker owns both schedules. Cluster-capable sources run as
+# isolated activities here; eBay uses its application-only Browse API token.
+# The Facebook schedule writes a durable job to the
+# Deal Scout API for the outbound-only CachyOS runner. Temporal's unauthenticated
+# frontend remains cluster-internal.
 apiVersion: temporal.io/v1alpha1
 kind: WorkerDeployment
 metadata:
-  name: deal-scout # → Temporal "deployment name"
+  name: deal-scout
   namespace: deal-scout
 spec:
   replicas: 1
@@ -26,7 +19,6 @@ spec:
     steps:
       - rampPercentage: 50
         pauseDuration: 2m
-      # workflows here are short (one scrape activity); a light ramp suffices
   sunset:
     scaledownDelay: 10m
     deleteDelay: 1h
@@ -45,25 +37,35 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          # Source: deal-scout repo, worker/ — build & push:
-          #   docker build -f worker/Dockerfile -t registry.vanillax.me/deal-scout-worker:vX.Y.Z .
-          # Controller injects TEMPORAL_ADDRESS / TEMPORAL_NAMESPACE /
-          # TEMPORAL_DEPLOYMENT_NAME / TEMPORAL_WORKER_BUILD_ID — do not set here.
+          # Source: deal-scout repo worker/. No personal browser profile is
+          # present; eBay authentication is application-only OAuth.
           image: registry.vanillax.me/deal-scout-worker:v0.1.0
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API
               value: "http://deal-scout:8000"
+            - name: CLUSTER_SOURCES
+              value: "ebay,slickdeals,msu,comprenew"
             - name: DEAL_SCOUT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: deal-scout-secrets
                   key: INGEST_TOKEN
+            - name: EBAY_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: deal-scout-ebay
+                  key: EBAY_CLIENT_ID
+            - name: EBAY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: deal-scout-ebay
+                  key: EBAY_CLIENT_SECRET
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-            readOnlyRootFilesystem: false # Temporal workflow bundling writes to tmp
+            readOnlyRootFilesystem: false
           resources:
             requests:
               cpu: 50m

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: registry.vanillax.me/deal-scout-worker:v0.1.0
+          image: ghcr.io/mitchross/deal-scout-worker:v0.2.0@sha256:f4aa8c9b597bcd9ff4adc766b080e76080a773c9d96b0a4455cdc1c33b541a3b
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
## What changed

- Move the Deal Scout dashboard and Temporal worker from the private registry to public, digest-pinned GHCR images.
- Add an ExternalSecret mapping `homelab-prod/ebay-developer` into `EBAY_CLIENT_ID` and `EBAY_CLIENT_SECRET`.
- Assign eBay, Slickdeals, MSU, and Comprenew to the cluster worker.
- Keep authenticated Facebook work on the outbound-only CachyOS runner through durable dashboard scan jobs.

## Why

The private registry outage took both Deal Scout components down after rescheduling. GHCR removes that dependency. The source split also keeps the Facebook login local while allowing eBay to use its production application-only Browse API inside the cluster.

## Validation

- `scripts/validate-argocd-apps.sh` passed all checks
- `kubectl kustomize my-apps/utility/deal-scout` rendered successfully
- Render contains only the expected pinned GHCR images
- Dashboard digest verified: `sha256:4adeadac22eedf457f58dc71ca616807337447421b8b0c1bd35c4f56e1d074c3`
- Worker digest verified: `sha256:f4aa8c9b597bcd9ff4adc766b080e76080a773c9d96b0a4455cdc1c33b541a3b`
- Production eBay OAuth and Browse API calls succeeded using the referenced 1Password item

## Current Temporal state

Temporal is currently absent from the live `temporal` namespace and is being repaired separately. This change does not alter Temporal infrastructure. The dashboard and ExternalSecret can reconcile immediately; the WorkerDeployment will create its worker when Temporal connectivity returns.