### PR TITLE
cnpg: assert paperless recovery on auth_user, not documents_document

### DIFF
--- a/scripts/bootstrap-cnpg-recovery.sh
+++ b/scripts/bootstrap-cnpg-recovery.sh
@@ -313,11 +313,17 @@ wait_for_application_healthy() {
 
 cd "$ROOT_DIR"
 
+# The per-database proof table must be one that actually holds rows in the
+# pinned backup, otherwise the assertion fails on a restore that genuinely
+# worked. Paperless asserts auth_user (2 accounts), not documents_document:
+# every paperless lineage has zero documents, so documents_document could
+# never pass. Verify a candidate table against the restored cluster before
+# changing one — a table chosen for looking important is not evidence.
 log "Validating the pinned recovery contract"
 while IFS='|' read -r db_name read_lineage backup_id write_lineage system_id database_name table_name consumer_app consumer_path; do
   assert_recovery_render "$db_name" "$read_lineage" "$backup_id" "$write_lineage"
 done <<'EOF'
-paperless|paperless-database-v6|20260728T050000|paperless-database-v9|7654249455955726366|paperless|documents_document|my-apps-paperless-ngx|my-apps/home/paperless-ngx
+paperless|paperless-database-v6|20260728T050000|paperless-database-v9|7654249455955726366|paperless|auth_user|my-apps-paperless-ngx|my-apps/home/paperless-ngx
 temporal|temporal-database-v8|20260728T030000|temporal-database-v11|7654249455983591452|temporal|executions|my-apps-temporal|my-apps/development/temporal
 EOF
 
@@ -378,7 +384,7 @@ while IFS='|' read -r db_name read_lineage backup_id write_lineage system_id dat
   sync_application "$consumer_app"
   wait_for_application_healthy "$consumer_app"
 done <<'EOF'
-paperless|paperless-database-v6|20260728T050000|paperless-database-v9|7654249455955726366|paperless|documents_document|my-apps-paperless-ngx|my-apps/home/paperless-ngx
+paperless|paperless-database-v6|20260728T050000|paperless-database-v9|7654249455955726366|paperless|auth_user|my-apps-paperless-ngx|my-apps/home/paperless-ngx
 temporal|temporal-database-v8|20260728T030000|temporal-database-v11|7654249455983591452|temporal|executions|my-apps-temporal|my-apps/development/temporal
 EOF
 


### PR DESCRIPTION
## Why

The paperless restore is **genuine** — but it was failing the row assertion, blocking temporal behind it.

```
system_identifier       = 7654249455955726366   ← matches the pinned source lineage
auth_user               = 2                     ← real accounts, permissions, workflow config
documents_document      = 0
documents_tag           = 0
documents_correspondent = 0
```

Every paperless lineage is **3.9–4.5 MB flat** (v1 through v8), so `documents_document` has never held rows — the assertion could never pass, no matter how correct the restore.

Asserting `auth_user` still proves the restore carried real application data rather than an empty `initdb`, which is exactly what the check exists for. This does **not** weaken the safety net: it's the same check that correctly caught immich coming back with `user = 0` and `asset = 0`.

Added a comment on the contract loop explaining how to choose a proof table, so the next person doesn't pick one that merely looks important.

## Verification

`./scripts/bootstrap-cnpg-recovery.sh` preflight passes with paperless + temporal.

## After merge

Temporal finally runs — its v8 backup is **160 MB** against the empty lineages' 5.3 MB, so it's the one database in this whole exercise with unambiguously real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6rHcCfadxjJxmAuVuAAhs