### PR TITLE
cnpg: fix backup resource ambiguity; talos: complete VXLAN inner checksums

### DIFF
--- a/omni/cluster-template/cluster-template-singlenode-gpu.yaml
+++ b/omni/cluster-template/cluster-template-singlenode-gpu.yaml
@@ -31,6 +31,23 @@ patches:
     machine:
       install:
         disk: /dev/sda
+# Cross-node pod TCP silently dies without this. virtio hands VXLAN packets
+# up with the INNER TCP checksum still deferred (CHECKSUM_PARTIAL); nothing
+# downstream can finish it, because pve's mlx4_en uplink reports
+# tx-udp_tnl-csum-segmentation off [fixed] and the host only ever sees the
+# outer UDP header. The receiver then discards every segment as corrupt
+# (Tcp: InCsumErrors in /proc/net/snmp) with no interface or BPF drop
+# recorded, so it looks like a black hole. Same-host pod traffic is immune —
+# the partial-checksum metadata rides along and is never materialised — which
+# is why only the node across the wire loses TCP while UDP and ICMP work.
+# Verify with: talosctl get ethernetstatus
+- name: vxlan-inner-checksum
+  inline:
+    apiVersion: v1alpha1
+    kind: EthernetConfig
+    name: eth0
+    features:
+      tx-checksum-ip-generic: false
 - file: patches/docker-hub-auth.yaml
 - name: node-performance
   inline:

--- a/scripts/bootstrap-cnpg-recovery.sh
+++ b/scripts/bootstrap-cnpg-recovery.sh
@@ -186,7 +186,9 @@ wait_for_backup() {
   backup_name="$1"
   deadline="$(deadline_after "$BACKUP_TIMEOUT_SECONDS")"
   while true; do
-    backup_json="$(kubectl -n "$CNPG_NAMESPACE" get backup "$backup_name" -o json 2>/dev/null || true)"
+    # Fully qualified: bare `backup` resolves to backups.longhorn.io, which
+    # wins the short-name race and makes this wait time out forever.
+    backup_json="$(kubectl -n "$CNPG_NAMESPACE" get backups.postgresql.cnpg.io "$backup_name" -o json 2>/dev/null || true)"
     phase="$(printf '%s' "$backup_json" | jq -r '.status.phase // ""' 2>/dev/null || true)"
     case "$phase" in
       completed)


### PR DESCRIPTION
Two unrelated blockers found while recovering the databases.

## 1. `wait_for_backup` could never succeed

`kubectl get backup` resolves to **`backups.longhorn.io`** — Longhorn's CRD wins the short-name race:

```
backups   lhb   longhorn.io/v1beta2          Backup   ← wins
backups         postgresql.cnpg.io/v1        Backup
```

So the CNPG Backup was never found and the wait burned its full 40-minute timeout, even though `paperless-post-recovery-v9` had completed. Every earlier run died on an assertion before reaching this, so it never surfaced.

Checked the others: `cluster` → `postgresql.cnpg.io/v1` ✅ and `application` → `argoproj.io/v1alpha1` ✅ resolve correctly. Only `backup` is affected.

## 2. Cross-node pod TCP was black-holing to the Dell worker

virtio hands VXLAN packets up with the **inner** TCP checksum still deferred (`CHECKSUM_PARTIAL`), and nothing downstream can finish it: pve's `mlx4_en` uplink reports `tx-udp_tnl-csum-segmentation: off [fixed]`, and the host only ever sees the outer UDP header.

Packet capture on the *receiving* hypervisor showed the same wrong checksum repeating within each flow — the pseudo-header sum, never materialised:

```
cksum 0x1822 (incorrect -> 0x9a0d)
cksum 0x1822 (incorrect -> 0x9e09)   ← constant wrong value = uncompleted CHECKSUM_PARTIAL
cksum 0x1822 (incorrect -> 0xa20d)
```

The receiver discarded every segment — `Tcp: InCsumErrors` 1374/1374 on the affected node vs **0** on both others across 100× more traffic — with **no interface drop and no BPF drop recorded**, so it presented as a black hole rather than an error.

Same-host pod traffic is immune: the partial-checksum metadata rides with the skb and is never materialised. That's why only the node across the wire lost TCP while UDP and ICMP kept working, and why `cilium-health` read `Node 1/1 reachable, Endpoints 0/1`.

### Why EthernetConfig and not a privileged DaemonSet

A DaemonSet running `ethtool -K eth0 tx off` would work but needs privileged + `hostNetwork`. Talos ships a declarative equivalent, so this survives reboots, upgrades and Omni reconciliation with no privileged workload.

### Ruled out first, each with direct evidence

| Suspect | How it was cleared |
|---|---|
| AX86U media bridge | UDP, ICMP and 1500-byte DF all pass |
| AX86U Flow Cache / Runner | Disabled at runtime — checksums still wrong |
| Dell NIC RX offload | Disabled `rx`/`gro` — no change |
| Proxmox firewall | Disabled, all-ACCEPT, no DROP rules |
| MTU | 1500 DF passes; eth0 1500 / cilium_vxlan 1280 identical on all nodes |
| Cilium | ipcache, tunnel endpoints, BPF LB, XDP identical across nodes |
| Receiver | Packets arrive already-corrupt on the wire |

## Verification

- Preflight passes; template parses (4 docs, patch renders as expected)
- Post-merge: `talosctl get ethernetstatus` should show `tx-checksum-ip-generic: false`, and `Tcp: InCsumErrors` should stop climbing **under active TCP load** (an idle window gives a false flatline — I got caught by exactly that)

## Applying

The EthernetConfig needs an Omni template sync to reach the nodes:

```
omnictl cluster template sync -f omni/cluster-template/cluster-template-singlenode-gpu.yaml
```

My omnictl/talosctl credentials are expired, so that one is yours to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6rHcCfadxjJxmAuVuAAhs