### PR TITLE
gpu: cap 3090s at 200W for house-circuit headroom

### DIFF
--- a/infrastructure/controllers/nvidia-gpu-operator/powerlimit-daemonset.yaml
+++ b/infrastructure/controllers/nvidia-gpu-operator/powerlimit-daemonset.yaml
@@ -6,11 +6,12 @@
 #
 # This DaemonSet runs only on the dual-RTX-3090 worker and reapplies
 # `nvidia-smi -pl <watts>` every five minutes. The Dell GTX 1050 Ti does not
-# carry the `gpu-worker=true` label and must not receive the 3090's 290W cap.
+# carry the `gpu-worker=true` label and must not receive the 3090's cap.
 #
 # Valid range on RTX 3090: ~100W (min) .. 450W (max). Default is 420W.
-# We cap at 290W — the measured air-cooled decode-efficiency knee:
-# ~22% less board power for ~7% less decode throughput versus 370W.
+# We cap at 200W to keep the whole box inside its house circuit — see the
+# POWER_LIMIT_WATTS comment below. Expect roughly 15-20% less throughput than
+# the 290W efficiency knee; that is a deliberate trade for electrical headroom.
 #
 # Requires:
 #   - privileged container (nvidia-smi -pl needs root + driver write)
@@ -96,10 +97,12 @@ spec:
               value: "all"
             - name: NVIDIA_DRIVER_CAPABILITIES
               value: "utility"
-            # 290W is the measured decode-efficiency knee for air-cooled 3090s.
-            # Use 250W instead when optimizing for prefill-heavy workloads.
+            # 200W is a HOUSE-CIRCUIT constraint, not an efficiency choice: two
+            # 3090s at the old 290W cap put the Threadripper box near 900W at
+            # the wall and made basement lights flicker. Do not raise this back
+            # toward the 290W efficiency knee without confirming the circuit.
             - name: POWER_LIMIT_WATTS
-              value: "290"
+              value: "200"
             - name: REAPPLY_SECONDS
               value: "300"
           resources:


### PR DESCRIPTION
## Why

Measured **896 W at the wall** for the whole Threadripper box while vLLM was serving, with basement lights flickering.

The power limiter was working correctly — both cards enforced at 290 W and drawing ~245 W each. The 896 W is the *whole machine*:

| Component | Draw |
|---|---|
| 2× RTX 3090 @ ~245 W | ~490 W |
| Threadripper 2950X under load | ~180–200 W |
| Board, 128 GB RAM, NVMe/SATA, fans | ~100 W |
| PSU inefficiency (~88%) | ~110 W |
| **Total** | **~890 W** |

## Change

`POWER_LIMIT_WATTS` 290 → **200**.

Costs roughly 15–20% throughput versus the 290 W efficiency knee. The comment records this as a **circuit constraint, not a tuning choice**, so it doesn't get "optimized" back up later.

## Caveat worth keeping visible

896 W is only ~50% of a 15 A/120 V circuit. **Flickering at half load is not normal** and this cap does not diagnose it — it reduces load. Likely physical: shared circuit, a loose/backstabbed outlet, a long undersized run, or 3090 transient spikes (millisecond-scale, well above average draw — the classic cause of visible blinking). Worth an electrician or a dedicated 20 A circuit regardless.

## Verify after sync

```
kubectl -n gpu-operator logs -l app.kubernetes.io/name=nvidia-powerlimit --tail=4
```
Enforced column should read `200.00 W`. The DaemonSet reapplies every 300 s, so it survives driver reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6rHcCfadxjJxmAuVuAAhs