### PR TITLE
vllm: scale to 0 to isolate basement light flicker

### DIFF
--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -9,7 +9,11 @@ spec:
   # vLLM is the active in-cluster LLM backend (TP=2 across both 3090s).
   # llama-cpp and comfyui are scaled to 0 — vLLM's TP=2 takes BOTH cards.
   # To revert: set this to 0 and llama-cpp-server back to 1 (one commit).
-  replicas: 1
+  #
+  # Temporarily 0: idling the GPUs (~25W/card instead of ~195W) to test
+  # whether basement light flicker tracks this box or the AC compressor.
+  # Set back to 1 when that test is done.
+  replicas: 0
   strategy:
     type: Recreate            # whole-card GPU workload; never two pods on the cards at once
   revisionHistoryLimit: 1


### PR DESCRIPTION
## Why

Temporary diagnostic. Idling both 3090s takes them from ~195 W each (under the new 200 W cap) to ~25 W each — the whole box goes from roughly **790 W to about 300 W** at the wall.

**The test:** if lights still flicker with the GPUs idle, the server isn't the cause.

| Signature | AC compressor | GPU transients |
|---|---|---|
| Timing | Every ~10–20 min, independent of server load | Only under compute load |
| Duration | ~0.5–2 s dip | Millisecond flicker |
| Scope | Whole house | Same circuit / nearby |
| Worse when | Hot outside | Running inference |

A failing start capacitor is the classic cause — locked-rotor inrush is 5–8× running current, and a weak cap makes the compressor struggle, so the sag lasts longer and worsens over weeks.

## Why this needs a commit

`my-apps-vllm` has `selfHeal: true`. A live `kubectl scale` was reverted within seconds — ArgoCD restored `spec=1` and started a new pod. The value only holds from git.

## Revert

Set `replicas: 1` when the test concludes. This is the same lever the documented GPU scale-swap uses, so it's a normal operation rather than a hack.

Note `llama.vanillax.me` will read "no healthy upstream" while this is 0, since llama-cpp is also at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6rHcCfadxjJxmAuVuAAhs