### PR TITLE
park wyze-bridge and holmesgpt at 0 replicas

### DIFF
--- a/monitoring/holmesgpt/kustomization.yaml
+++ b/monitoring/holmesgpt/kustomization.yaml
@@ -15,3 +15,17 @@ helmCharts:
     releaseName: holmes
     valuesFile: values.yaml
     includeCRDs: true
+
+# Parked at 0. Holmes is an agentic investigator: each unhealthy object drives
+# dozens of chained qwen3.6-27b calls, and it opened 8 concurrent connections
+# against vLLM's max-num-seqs=2 — saturating both GPUs at ~193W each for
+# 0.1 tok/s. Nothing consumes the output (robusta sink disabled, no inbound
+# callers), so the analysis was discarded. Wire it to a sink before scaling up.
+patches:
+  - target:
+      kind: Deployment
+      name: holmes-holmes
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 0

--- a/my-apps/home/wyze-bridge/deployment.yaml
+++ b/my-apps/home/wyze-bridge/deployment.yaml
@@ -4,7 +4,11 @@ metadata:
   name: wyze-bridge
   namespace: wyze-bridge
 spec:
-  replicas: 1
+  # Parked at 0: crashlooping (263 restarts). Every restart is an unhealthy
+  # object for HolmesGPT to investigate, and each investigation is dozens of
+  # LLM calls against vLLM — so this was indirectly pinning both GPUs.
+  # Diagnose the crashloop before setting this back to 1.
+  replicas: 0
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
## Why

**`wyze-bridge`** is crashlooping at **263 restarts**.

**`holmesgpt`** is an agentic investigator — every unhealthy object drives dozens of chained `qwen3.6-27b` calls. It had **8 concurrent connections** open against vLLM's `max-num-seqs=2`, pinning both 3090s at ~193 W each to produce **0.1 tok/s**.

Those two compound: wyze-bridge's restart churn is exactly the kind of unhealthy object Holmes investigates, so the crashloop was indirectly holding both GPUs hostage.

And **nothing consumes Holmes' output** — the robusta sink is disabled and there are zero inbound callers on its API — so all that inference was discarded.

## Before restoring

- **wyze-bridge**: diagnose the crashloop first
- **holmesgpt**: wire it to a sink (Keep is already deployed) so the analysis lands somewhere

## Note

Holmes is a remote Helm chart with no replica value in `values.yaml`, hence the Kustomize patch rather than a values change. Verified both render at `replicas: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6rHcCfadxjJxmAuVuAAhs