### PR TITLE
vllm: persist torch.compile + Triton caches across restarts

### DIFF
--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -158,6 +158,14 @@ spec:
               readOnly: true
             - name: dshm
               mountPath: /dev/shm        # TP workers IPC over shared memory — size it generously
+            # Persist the compiled graphs. Both paths must survive a restart or
+            # the engine recompiles from scratch every boot.
+            - name: compile-cache
+              mountPath: /root/.cache/vllm/torch_compile_cache
+              subPath: torch_compile
+            - name: compile-cache
+              mountPath: /root/.triton/cache
+              subPath: triton
       volumes:
         - name: models
           persistentVolumeClaim:
@@ -166,3 +174,6 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 16Gi
+        - name: compile-cache
+          persistentVolumeClaim:
+            claimName: vllm-compile-cache

--- a/my-apps/ai/vllm/pvc.yaml
+++ b/my-apps/ai/vllm/pvc.yaml
@@ -49,3 +49,28 @@ spec:
       storage: 1Ti
   storageClassName: ""
   volumeName: vllm-nfs-pv
+---
+# torch.compile + Triton kernel caches. Without this the engine recompiles on
+# every start: measured 166s of torch.compile plus a 131s warmup inside an
+# 11-minute cold start, all of it thrown away when the pod restarts. Local
+# block (not the read-only NFS models share) because the caches are written at
+# runtime. Pattern from the club-3090 dual-3090 compose, which mounts the same
+# two paths.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vllm-compile-cache
+  namespace: vllm
+  labels:
+    backup-exempt: "true"
+  annotations:
+    # MUST be the fully-qualified key — bare `backup-exempt-reason` is silently
+    # ignored and the PVC is denied on CREATE (CI guard `backup-exempt-contract`).
+    storage.vanillax.dev/backup-exempt-reason: "Regenerable torch.compile/Triton kernel cache; rebuilt automatically on first boot after loss"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: longhorn


### PR DESCRIPTION
## Why

Cold start is **11 minutes**. Measured breakdown from a real boot:

| Phase | Time |
|---|---|
| Container + CUDA init | ~2.5 min |
| NCCL / TP=2 setup | ~30 s |
| Weight load (13.17 GiB) | 63 s |
| **`torch.compile`** | **166 s** ← discarded every restart |
| **Profiling / warmup** | **131 s** |
| CUDA graph capture → serving | ~90 s |

`torch.compile` writes to `/root/.cache/vllm/torch_compile_cache` on the **container filesystem**, so it's thrown away on every restart and the engine recompiles identical graphs.

Mounting both cache paths on a small local PVC fixes it. The [club-3090](https://github.com/noonghunna/club-3090) dual-3090 reference compose mounts exactly these two paths and reports *"first boot warms (~60-90 sec); subsequent boots reuse cached graphs."*

Local block rather than the read-only NFS models share, since these are written at runtime. Backup-exempt — regenerable, rebuilt automatically if lost.

## Deliberately NOT changed

Reviewed our config against the club-3090 dual-3090 reference. `max-model-len 262144`, `gpu-memory-utilization 0.92`, `max-num-seqs 2`, `max-num-batched-tokens 8192`, TP=2, the NCCL vars and `PYTORCH_CUDA_ALLOC_CONF` all already match. Three divergences are **intentional**:

**MTP speculative decoding stays OFF.** The reference carries `--speculative-config {"method":"mtp","num_speculative_tokens":3}`, but **vllm#50021 is open and live in our v0.26.0 pin**:

> The GDN spec-decode path builds a state-block index from an UNBOUNDED accepted-token count; a zero/stale count dereferences a wild address → `CUDA error: unspecified launch failure` + Xid 13/31 and a dead worker, **typically after minutes of agent-shaped traffic**. Not quant-, topology- or depth-specific. MITIGATION: run the drafter off.

Agent-shaped traffic is precisely this cluster's workload. Lower `n` cuts frequency, not exposure.

**`VLLM_USE_FLASHINFER_SAMPLER` stays 1.** The measurement favouring `0` (−3.0% narrative / −1.7% code) was taken **with MTP active**, routing through the rejection sampler. It doesn't transfer to a non-MTP config.

**`kv-cache-dtype` stays `fp8_e4m3`.** The reference AWQ profile lists `int8_per_token_head`, but its own later finding reversed that — int8-PTH routes to TRITON_ATTN and *"CRATERS decode at depth"* vs fp8/e4m3 → FlashInfer.

## On the deprecated quant

Our AWQ-BF16-INT4 tier is marked deprecated upstream in favour of `autoround-int4` (~89 vs ~67 TPS). **Not acting on it**: that TPS gap assumes MTP on, which we can't safely run, and measured quality is a tie (109 vs 105, within noise).

## Verify after sync

First boot still warms the cache; the **second** restart should drop ~166 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6rHcCfadxjJxmAuVuAAhs