### PR TITLE
docs: GPU power cap is 200W, and it is a circuit limit

### DIFF
--- a/docs/domains/ai-gpu/3090-llm-optimization.md
+++ b/docs/domains/ai-gpu/3090-llm-optimization.md
@@ -402,11 +402,20 @@ tuning can only trim the small slice; retiring the platform is the real saving.
 
 **Live mitigation:**
 `infrastructure/controllers/nvidia-gpu-operator/powerlimit-daemonset.yaml` —
-a DaemonSet on the GPU node that caps both 3090s at **290W** (club-3090
-`docs/HARDWARE.md` measured knee: −22% board power for −7% decode TPS vs 370W
-stock; the "230W sweet spot" lore costs ~16% efficiency vs 290W). Set
-`POWER_LIMIT_WATTS=250` to favor prefill-heavy workloads (−5% chat TPS,
-prefill at its own knee).
+a DaemonSet on the GPU node that caps both 3090s at **200W**.
+
+200W is a **house-circuit limit, not the efficiency knee**. At the previous
+290W cap the whole Threadripper box measured ~896W at the wall (2x ~245W GPU +
+~190W CPU + ~100W platform + PSU loss) and basement lights flickered. The cap
+buys electrical headroom at a real throughput cost.
+
+For reference, the performance-optimal values from club-3090 `docs/HARDWARE.md`
+are **290W** air-cooled (measured knee: −22% board power for −7% decode TPS vs
+370W stock) and **250W** for prefill-heavy work; that doc also notes the "230W
+sweet spot" lore costs ~16% efficiency vs 290W, so 200W is below every measured
+recommendation. Raising `POWER_LIMIT_WATTS` back toward 290W is an electrical
+decision first — confirm the circuit, and note that GPU transient spikes exceed
+any `nvidia-smi` average cap, so the cap alone does not eliminate flicker.
 
 **Rejected: KEDA cron scale-to-zero for vLLM overnight.** The my-apps AppSet
 runs `selfHeal: true` and the GPU apps use git replica-flips as the

--- a/docs/domains/ai-gpu/gpu-scale-swap.md
+++ b/docs/domains/ai-gpu/gpu-scale-swap.md
@@ -91,10 +91,11 @@ curl -s http://vllm-service.vllm.svc.cluster.local:8080/v1/models
   `nvidia-powerlimit` admin DaemonSet).
 - Don't switch a GPU Deployment to `RollingUpdate` — Recreate is what
   guarantees the old pod releases the card (and avoids RWO Multi-Attach).
-- Don't delete the 290 W power cap to "fix" slowness — tune
+- Don't delete the 200 W power cap to "fix" slowness — tune
   `POWER_LIMIT_WATTS` in
   `infrastructure/controllers/nvidia-gpu-operator/powerlimit-daemonset.yaml`
-  instead.
+  instead. The cap is set by the house circuit, not by the efficiency knee;
+  raising it needs an electrical decision, not just a performance one.
 
 Related: [model catalog](model-catalog.md) (who points at what) ·
 [3090 LLM optimization](3090-llm-optimization.md) (why vLLM TP=2 is the

--- a/docs/domains/ai-gpu/pi-agent-local-dev.md
+++ b/docs/domains/ai-gpu/pi-agent-local-dev.md
@@ -54,12 +54,12 @@
       <div class="dgm-node dgm-node--gpu dgm-node--pulse">
         <span class="dgm-node__badge">gpu 0</span>
         <span class="dgm-node__title">RTX 3090</span>
-        <span class="dgm-node__meta">290W cap</span>
+        <span class="dgm-node__meta">200W cap</span>
       </div>
       <div class="dgm-node dgm-node--gpu dgm-node--pulse">
         <span class="dgm-node__badge">gpu 1</span>
         <span class="dgm-node__title">RTX 3090</span>
-        <span class="dgm-node__meta">290W cap</span>
+        <span class="dgm-node__meta">200W cap</span>
       </div>
     </div>
   </div>

--- a/my-apps/ai/CLAUDE.md
+++ b/my-apps/ai/CLAUDE.md
@@ -70,11 +70,15 @@ intended for that card must opt in with the Dell GPU class explicitly.
   injection. (Sole exception: the infrastructure `nvidia-powerlimit` admin
   DaemonSet, which must see all cards without consuming a `nvidia.com/gpu`
   allocation.)
-- **Both 3090s are power-capped at 290W** by
-  `infrastructure/controllers/nvidia-gpu-operator/powerlimit-daemonset.yaml`
-  (measured efficiency knee: −22% power for −7% decode TPS — see the power
-  section of `docs/domains/ai-gpu/3090-llm-optimization.md`). Don't "fix" a
-  perceived slowdown by deleting the cap; tune `POWER_LIMIT_WATTS` instead.
+- **Both 3090s are power-capped at 200W** by
+  `infrastructure/controllers/nvidia-gpu-operator/powerlimit-daemonset.yaml`.
+  This is a **house-circuit constraint, not an efficiency choice**: at the
+  previous 290W cap the Threadripper box drew ~900W at the wall and basement
+  lights flickered. 290W is the measured efficiency knee and 200W is below it
+  (club-3090 measures ~16% worse efficiency at 230W than 290W), so this
+  deliberately trades throughput for electrical headroom. Don't raise it back
+  toward 290W without confirming the circuit; don't "fix" a perceived slowdown
+  by deleting the cap.
 
 ## GPU Workload Pattern
 


### PR DESCRIPTION
## Why

The cap moved **290W → 200W** (#1845) but four docs still said 290W — including two that explicitly instruct the reader *not* to change it:

- `my-apps/ai/CLAUDE.md` — *"Both 3090s are power-capped at 290W... Don't 'fix' a perceived slowdown by deleting the cap"*
- `docs/domains/ai-gpu/gpu-scale-swap.md` — *"Don't delete the 290 W power cap"*
- `docs/domains/ai-gpu/3090-llm-optimization.md`
- `docs/domains/ai-gpu/pi-agent-local-dev.md` (diagram labels ×2)

A future session following those would have "restored" 290W and put the box back near 900W at the wall.

## What changed

Records **why**, not just what. 200W is **below every measured recommendation** — club-3090 `docs/HARDWARE.md` puts the knee at 290W air-cooled, 250W for prefill-heavy, and notes the "230W sweet spot" lore already costs ~16% efficiency vs 290W.

It's bought for **electrical headroom**: at 290W the Threadripper box measured **896W** at the wall (2× ~245W GPU + ~190W CPU + ~100W platform + PSU loss) and basement lights flickered. Raising it back is an electrical decision, not a performance one.

Also noted: the cap **does not eliminate flicker by itself** — GPU transient spikes are millisecond-scale and exceed any `nvidia-smi` average cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6rHcCfadxjJxmAuVuAAhs