### PR TITLE
posthog: drop non-default postgres-exporter collectors

### DIFF
--- a/my-apps/development/posthog/data-layer/postgres.yaml
+++ b/my-apps/development/posthog/data-layer/postgres.yaml
@@ -77,14 +77,8 @@ spec:
       - name: postgres-exporter
         image: quay.io/prometheuscommunity/postgres-exporter:v0.20.1@sha256:ac5ec343104fae0e2d84a27bb8d69b38430a11910c5382cad85d478d2bab713e
         imagePullPolicy: IfNotPresent
-        # Non-default collectors disabled: the exporter crashlooped 91 times,
-        # exiting code 2 several minutes after a clean start with nothing
-        # logged. Ruled out: the DB connection (established fine), the server
-        # version (15.12.0 read OK), and pg_stat_statements itself (installed,
-        # preloaded, queries fine by hand). The silent exit points at one of
-        # these two non-default collectors, so run the default set instead.
-        # Re-add ONE at a time if their metrics are wanted, and watch the
-        # restart count before adding the second.
+        # Non-default collectors disabled — they crashlooped the exporter
+        # (exit 2, nothing logged). Re-add one at a time.
         # args:
         # - --collector.long_running_transactions
         # - --collector.stat_statements

--- a/my-apps/development/posthog/data-layer/postgres.yaml
+++ b/my-apps/development/posthog/data-layer/postgres.yaml
@@ -77,10 +77,18 @@ spec:
       - name: postgres-exporter
         image: quay.io/prometheuscommunity/postgres-exporter:v0.20.1@sha256:ac5ec343104fae0e2d84a27bb8d69b38430a11910c5382cad85d478d2bab713e
         imagePullPolicy: IfNotPresent
-        args:
-        - --collector.long_running_transactions
-        - --collector.stat_statements
-        - --collector.stat_statements.limit=25
+        # Non-default collectors disabled: the exporter crashlooped 91 times,
+        # exiting code 2 several minutes after a clean start with nothing
+        # logged. Ruled out: the DB connection (established fine), the server
+        # version (15.12.0 read OK), and pg_stat_statements itself (installed,
+        # preloaded, queries fine by hand). The silent exit points at one of
+        # these two non-default collectors, so run the default set instead.
+        # Re-add ONE at a time if their metrics are wanted, and watch the
+        # restart count before adding the second.
+        # args:
+        # - --collector.long_running_transactions
+        # - --collector.stat_statements
+        # - --collector.stat_statements.limit=25
         env:
         - name: DATA_SOURCE_NAME
           valueFrom:


### PR DESCRIPTION
## Why

The `postgres-exporter` sidecar crashlooped **91 times**, exiting code 2 several minutes after a clean start with **nothing logged** before the exit:

```
Established new database connection  fingerprint=127.0.0.1:5432
Semantic version changed  from=0.0.0 to=15.12.0
<silence, then exit 2>
```

Ruled out by hand:
- **DB connection** — established fine
- **Version detection** — read 15.12.0 OK
- **`pg_stat_statements`** — installed, in `shared_preload_libraries`, queries fine (59 rows)

That leaves the two non-default collectors. Running the default set instead.

**This is a bisect, not a proven root cause.** The process exits without logging, so it can't be pinned from logs alone. Re-add **one at a time** if those metrics are wanted, watching the restart count before adding the second.

## Severity

Sidecar only — the `db` container stayed `ready=true` with **0 restarts** throughout. PostHog itself was never down; this was monitoring noise, not an outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6rHcCfadxjJxmAuVuAAhs