### PR TITLE
chore: trim inline comments added during last night's debugging

### DIFF
--- a/monitoring/holmesgpt/kustomization.yaml
+++ b/monitoring/holmesgpt/kustomization.yaml
@@ -16,11 +16,8 @@ helmCharts:
     valuesFile: values.yaml
     includeCRDs: true
 
-# Parked at 0. Holmes is an agentic investigator: each unhealthy object drives
-# dozens of chained qwen3.6-27b calls, and it opened 8 concurrent connections
-# against vLLM's max-num-seqs=2 — saturating both GPUs at ~193W each for
-# 0.1 tok/s. Nothing consumes the output (robusta sink disabled, no inbound
-# callers), so the analysis was discarded. Wire it to a sink before scaling up.
+# Parked at 0 — saturated vLLM and nothing consumes its output (no sink, no
+# inbound callers). Wire it to a sink before scaling up.
 patches:
   - target:
       kind: Deployment

--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -158,8 +158,7 @@ spec:
               readOnly: true
             - name: dshm
               mountPath: /dev/shm        # TP workers IPC over shared memory — size it generously
-            # Persist the compiled graphs. Both paths must survive a restart or
-            # the engine recompiles from scratch every boot.
+            # Both paths must persist or the engine recompiles every boot.
             - name: compile-cache
               mountPath: /root/.cache/vllm/torch_compile_cache
               subPath: torch_compile

--- a/my-apps/ai/vllm/pvc.yaml
+++ b/my-apps/ai/vllm/pvc.yaml
@@ -50,12 +50,8 @@ spec:
   storageClassName: ""
   volumeName: vllm-nfs-pv
 ---
-# torch.compile + Triton kernel caches. Without this the engine recompiles on
-# every start: measured 166s of torch.compile plus a 131s warmup inside an
-# 11-minute cold start, all of it thrown away when the pod restarts. Local
-# block (not the read-only NFS models share) because the caches are written at
-# runtime. Pattern from the club-3090 dual-3090 compose, which mounts the same
-# two paths.
+# torch.compile + Triton caches — without this the engine recompiles every
+# boot (~166s). Local block: the caches are written at runtime.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/my-apps/home/wyze-bridge/deployment.yaml
+++ b/my-apps/home/wyze-bridge/deployment.yaml
@@ -4,10 +4,7 @@ metadata:
   name: wyze-bridge
   namespace: wyze-bridge
 spec:
-  # Parked at 0: crashlooping (263 restarts). Every restart is an unhealthy
-  # object for HolmesGPT to investigate, and each investigation is dozens of
-  # LLM calls against vLLM — so this was indirectly pinning both GPUs.
-  # Diagnose the crashloop before setting this back to 1.
+  # Parked at 0 — crashlooping (263 restarts). Diagnose before restoring to 1.
   replicas: 0
   strategy:
     type: Recreate

--- a/omni/cluster-template/cluster-template-singlenode-gpu.yaml
+++ b/omni/cluster-template/cluster-template-singlenode-gpu.yaml
@@ -31,16 +31,9 @@ patches:
     machine:
       install:
         disk: /dev/sda
-# Cross-node pod TCP silently dies without this. virtio hands VXLAN packets
-# up with the INNER TCP checksum still deferred (CHECKSUM_PARTIAL); nothing
-# downstream can finish it, because pve's mlx4_en uplink reports
-# tx-udp_tnl-csum-segmentation off [fixed] and the host only ever sees the
-# outer UDP header. The receiver then discards every segment as corrupt
-# (Tcp: InCsumErrors in /proc/net/snmp) with no interface or BPF drop
-# recorded, so it looks like a black hole. Same-host pod traffic is immune —
-# the partial-checksum metadata rides along and is never materialised — which
-# is why only the node across the wire loses TCP while UDP and ICMP work.
-# Verify with: talosctl get ethernetstatus
+# NEVER remove: without this the inner VXLAN TCP checksum is never completed
+# and cross-node pod TCP silently black-holes (Tcp: InCsumErrors, no drops
+# logged). Check with `talosctl get ethernetstatus`.
 - name: vxlan-inner-checksum
   inline:
     apiVersion: v1alpha1


### PR DESCRIPTION
Four files picked up multi-line forensic narration during last night's debugging. Cut each to the operative *why* — the reasoning already lives in the commit messages, `docs/domains/ai-gpu/`, and the Mink notes.

| File | Before | After |
|---|---|---|
| `cluster-template-singlenode-gpu.yaml` (EthernetConfig) | 10 lines | **3** |
| `my-apps/ai/vllm/pvc.yaml` | 6 | **2** |
| `monitoring/holmesgpt/kustomization.yaml` | 5 | **2** |
| `my-apps/home/wyze-bridge/deployment.yaml` | 4 | **1** |

The EthernetConfig one keeps the NEVER-remove warning and the verify command, since that's the class of comment worth having:

```yaml
# NEVER remove: without this the inner VXLAN TCP checksum is never completed
# and cross-node pod TCP silently black-holes (Tcp: InCsumErrors, no drops
# logged). Check with `talosctl get ethernetstatus`.
```

No behaviour change. All four verified to still render (`holmes replicas=0`, template parses as 4 docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6rHcCfadxjJxmAuVuAAhs