### PR TITLE
deal-scout: v0.6.0

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.5.0@sha256:4adeadac22eedf457f58dc71ca616807337447421b8b0c1bd35c4f56e1d074c3
+          image: ghcr.io/mitchross/deal-scout:v0.6.0@sha256:5be55263b06a0ee4f4525fa35fa1e21264508d2a681397f9499b3548b16d870f
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.2.0@sha256:f4aa8c9b597bcd9ff4adc766b080e76080a773c9d96b0a4455cdc1c33b541a3b
+          image: ghcr.io/mitchross/deal-scout-worker:v0.6.0@sha256:4e5f5098160a15fc9ddf5e3a6238734de16d1102f54b5d01d9d7d5a61ace37af
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Unified versioning: dashboard v0.5.0 → v0.6.0 and worker v0.2.0 → v0.6.0 now share one version. Both pinned by tag + digest.

Built and pushed from `deal-scout` tag v0.6.0 via `./scripts/release.sh`. Merge to let ArgoCD sync.