### PR TITLE
deal-scout: v0.6.1 — unbreak scraping + specs ingest

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.6.0@sha256:5be55263b06a0ee4f4525fa35fa1e21264508d2a681397f9499b3548b16d870f
+          image: ghcr.io/mitchross/deal-scout:v0.6.1@sha256:a00ecf8549776ba8097b5b00a73a9be828b5c668760e5cceda2493a91bed63f6
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.6.0@sha256:4e5f5098160a15fc9ddf5e3a6238734de16d1102f54b5d01d9d7d5a61ace37af
+          image: ghcr.io/mitchross/deal-scout-worker:v0.6.1@sha256:349179ab6ffd34da6ebee28aaf73262134476088fe76fe9ebf1944e9866ed347
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Fixes two regressions that had the whole pipeline down for ~22h.

1. `scrape.mjs` threw on import (temporal dead zone on `LOWCOST_EXTRACT`), so every source failed — all four Facebook jobs today failed on this.
2. Ingest 500'd with `table listings has no column named specs`; the column was added to SCHEMA with no ALTER migration.

Verified locally: real Facebook scrape now returns 240 listings, dashboard tests pass.