### PR TITLE
deal-scout: v0.6.2 — all-in pricing, STEAL tier, salvage track

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.6.1@sha256:a00ecf8549776ba8097b5b00a73a9be828b5c668760e5cceda2493a91bed63f6
+          image: ghcr.io/mitchross/deal-scout:v0.6.2@sha256:b6062628cc99dd96d45c31401d83c9be42a44fc341aef85294e293a9c2890122
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.6.1@sha256:349179ab6ffd34da6ebee28aaf73262134476088fe76fe9ebf1944e9866ed347
+          image: ghcr.io/mitchross/deal-scout-worker:v0.6.2@sha256:ddcac221e1da6ed76787700a380f156af198c398ab4fab88799b6bfdf03ea2f7
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Adds the salvage-board classifier track, all-in pricing (sticker + the RAM/NVMe/PSU a listing still needs), and a STEAL tier for all-in prices well under the query median.

RAM cost dominates right now, so barebones units are no longer ranked on sticker price.