### PR TITLE
docs: align cilium, Gateway API, and Argo CD/Helm version pins

### DIFF
--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -30,10 +30,11 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Match the binaries bundled in Argo CD v3.4.5. A render that only passes
+  # Match the binaries bundled in Argo CD v3.5.0. A render that only passes
   # with newer or older tools is not proof that repo-server can deploy it.
+  # v3.5.0 dropped Helm 3 entirely — repo-server renders with Helm 4.
   KUSTOMIZE_VERSION: 5.8.1
-  HELM_VERSION: 3.19.4
+  HELM_VERSION: 4.2.1
   KUBECONFORM_VERSION: v0.7.0
   KUBERNETES_VERSION: 1.36.3
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ ArgoCD deploys in strict order so dependencies land before the things that need 
 | Omni server + `omnictl` | `v1.9.0` | `omni/omni/omni.env.example` |
 | Talos Linux | `v1.13.7` | `omni/cluster-template/cluster-template-singlenode-gpu.yaml` |
 | Kubernetes | `v1.36.3` | `omni/cluster-template/cluster-template-singlenode-gpu.yaml` |
-| Cilium | `1.19.6` | `infrastructure/networking/cilium/kustomization.yaml` |
-| Gateway API CRDs | `v1.4.1` | bootstrap commands below |
-| ArgoCD Helm chart | `10.2.1` (Argo CD `v3.4.5`) | `scripts/bootstrap-argocd.sh` |
+| Cilium | `1.20.0` | `infrastructure/networking/cilium/kustomization.yaml` |
+| Gateway API CRDs | `v1.6.1` | bootstrap commands below |
+| ArgoCD Helm chart | `10.3.0` (Argo CD `v3.5.0`) | `scripts/bootstrap-argocd.sh` |
 | Proxmox provider | `latest@sha256:96433a…` | `omni/proxmox-provider/docker-compose.yml` |
 
 Keep the Omni server and local `omnictl` on the **same** release — mismatched versions fail with obscure gRPC errors.
 
-> **Gateway API `v1.4.1` is an intentional pin.** `v1.5.x` moved `TLSRoute` to `v1`, but Cilium 1.19 still expects `v1alpha2`. Cilium 1.20 is the first minor with Gateway API 1.5.1 support — don't bump the CRDs ahead of Cilium.
+> **Keep the Gateway API CRDs on the version Cilium declares support for.** Cilium 1.20 supports Gateway API `v1.6.1`. Bumping the CRDs ahead of Cilium breaks route reconciliation — check the Cilium release's Gateway API docs before moving either one.
 
 ---
 
@@ -173,11 +173,11 @@ Omni? Create the service account first — see
 
 ### 4. Install Gateway API CRDs
 
-Install both channels before enabling Cilium Gateway API support — Cilium 1.19 still watches the experimental `TLSRoute` API.
+Install both channels before enabling Cilium Gateway API support, **experimental last**. Both channels ship `TLSRoute`, but standard serves only `v1` while experimental serves `v1alpha2`/`v1alpha3` too — Cilium reads the alpha versions, so a standard-channel `TLSRoute` CRD makes every TLSRoute unreadable. Applying experimental second leaves the right one in place.
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
 ```
 
 ### 5. Install Cilium (CNI)
@@ -194,7 +194,7 @@ else
 fi
 
 "$CILIUM_CMD" install \
-    --version 1.19.6 \
+    --version 1.20.0 \
     --set cluster.name=talos-singlenode-gpu-prod \
     --set ipam.mode=kubernetes \
     --set kubeProxyReplacement=true \
@@ -219,7 +219,7 @@ what ArgoCD renders at Wave 0 (`infrastructure/networking/cilium/`), or Wave 0
 will immediately reconfigure the seed install:
 
 > - **Routing mode matches by default**: the CLI's default (`tunnel`/vxlan) equals `values.yaml`'s `routingMode: tunnel`. If the managed values ever change routing mode, add the matching `--set routingMode=...` here or Wave 0 restarts every agent mid-bootstrap.
-> - **`--version 1.19.6`** must match `infrastructure/networking/cilium/kustomization.yaml`. A mismatch makes ArgoCD upgrade Cilium at Wave 0, regenerating some Hubble certs but not others → `x509: certificate signed by unknown authority` blocks every later wave.
+> - **`--version 1.20.0`** must match `infrastructure/networking/cilium/kustomization.yaml`. A mismatch makes ArgoCD upgrade Cilium at Wave 0, regenerating some Hubble certs but not others → `x509: certificate signed by unknown authority` blocks every later wave.
 > - **`cluster.name`** must match `values.yaml` (Hubble cert SANs). Run without it and certs are issued for `default`/`kind-kind` → TLS failures.
 > - **Hubble stays disabled at bootstrap on purpose** — ArgoCD enables it at Wave 0 so it's the sole owner of the Hubble TLS certs (no CLI-vs-ArgoCD cert mismatch).
 

--- a/infrastructure/controllers/argocd/kustomization.yaml
+++ b/infrastructure/controllers/argocd/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 helmCharts:
   - name: argo-cd
     repo: https://argoproj.github.io/argo-helm
-    version: "10.3.0" # Pinned chart; appVersion v3.4.5
+    version: "10.3.0" # Pinned chart; appVersion v3.5.0
     releaseName: argocd
     namespace: argocd
     valuesFile: values.yaml

--- a/omni/README.md
+++ b/omni/README.md
@@ -140,11 +140,11 @@ See the complete guide: [docs/CILIUM_CNI.md](docs/CILIUM_CNI.md)
 **Quick Install**:
 ```bash
 # Disable kube-proxy in cluster config, then:
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
 
 cilium-cli install \
-    --version 1.19.6 \
+    --version 1.20.0 \
     --set cluster.name=talos-prod-cluster \
     --set ipam.mode=kubernetes \
     --set kubeProxyReplacement=true \

--- a/omni/docs/CILIUM_CNI.md
+++ b/omni/docs/CILIUM_CNI.md
@@ -113,7 +113,7 @@ Simple installation without Gateway API support:
 
 ```bash
 cilium install \
-    --version 1.19.6 \
+    --version 1.20.0 \
     --set cluster.name=talos-prod-cluster \
     --set ipam.mode=kubernetes \
     --set kubeProxyReplacement=true \
@@ -131,12 +131,12 @@ Full installation with Gateway API support:
 
 ```bash
 # First, install Gateway API CRDs
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
 
 # Then install Cilium
 cilium install \
-    --version 1.19.6 \
+    --version 1.20.0 \
     --set cluster.name=talos-prod-cluster \
     --set ipam.mode=kubernetes \
     --set kubeProxyReplacement=true \
@@ -157,12 +157,12 @@ Installation with Hubble for network observability:
 
 ```bash
 # Install Gateway API CRDs
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
 
 # Install Cilium with Hubble
 cilium install \
-    --version 1.19.6 \
+    --version 1.20.0 \
     --set cluster.name=talos-prod-cluster \
     --set ipam.mode=kubernetes \
     --set kubeProxyReplacement=true \
@@ -680,7 +680,7 @@ cilium version
 
 ```bash
 # Upgrade to specific version (must match chart version in infrastructure/networking/cilium/kustomization.yaml)
-cilium upgrade --version 1.19.6
+cilium upgrade --version 1.20.0
 
 # Or latest
 cilium upgrade
@@ -789,7 +789,7 @@ Enable service mesh features:
 
 ```bash
 cilium install \
-  --version 1.19.6 \
+  --version 1.20.0 \
   --set cluster.name=talos-prod-cluster \
   --set kubeProxyReplacement=true \
   --set ingressController.enabled=true \


### PR DESCRIPTION
Doc-side references drifted when Cilium `1.20.0` and Argo CD chart `10.3.0` merged. The Argo CD bump also changed the repo-server toolchain, which CI was not tracking.

## Changes

**Cilium `1.19.6` → `1.20.0`** — 7 stale refs in `README.md`, `omni/README.md`, `omni/docs/CILIUM_CNI.md`. `README.md` warns that a mismatch between its bootstrap command and `kustomization.yaml` makes ArgoCD upgrade Cilium at Wave 0, regenerating some Hubble certs but not others (`x509: certificate signed by unknown authority`) — that mismatch was live.

**Gateway API CRDs `v1.4.1` → `v1.6.1`** — Cilium 1.20 docs declare support for v1.6.1 ("all the Core conformance tests are passed"), and the Gateway API v1.6 conformance page lists Cilium v1.20.0 for HTTPRoute/GRPCRoute/TLSRoute.

The old "intentional pin" note is retired. Its rationale was that v1.5.x moved `TLSRoute` to `v1` while Cilium expected `v1alpha2`; in v1.6.1 the experimental `TLSRoute` CRD serves `v1`, `v1alpha2`, and `v1alpha3` together. This cluster also has zero TLSRoute/TCPRoute/UDPRoute/GRPCRoute objects — 65 HTTPRoutes on `gateway.networking.k8s.io/v1`, which v1.6.1 still serves.

Added a note that **experimental must be applied second**: both channels ship `TLSRoute`, but standard serves only `v1` while Cilium reads the alpha versions, so a standard-channel CRD makes every TLSRoute unreadable. The existing command order was already correct; now it says why.

**Argo CD appVersion `v3.4.5` → `v3.5.0`** — chart 10.3.0 ships v3.5.0. Renovate carried the hand-written comment across the 10.2.1 → 10.3.0 bump unchanged.

**CI `HELM_VERSION` `3.19.4` → `4.2.1`** — the significant one. Argo CD v3.5.0 dropped Helm 3 entirely (`helm3_version=3.19.4` → `helm4_version=4.2.1` in `hack/tool-versions.sh`; zero `helm3` entries remain). CI was validating every chart render with Helm 3 while repo-server renders with Helm 4 — the exact mismatch the pin comment exists to prevent. Kustomize is unchanged at `5.8.1`.

## Verification

- Server-side dry-run of both v1.6.1 channels against the live cluster (k8s `v1.36.3`): clean, no schema rejections, no field-manager conflicts.
- All **32** chart directories render clean under Helm 4 (`kustomize build --enable-helm`, helm `v4.2.2`).
- Confirmed appVersions directly from the chart repo: `10.2.1` → `v3.4.5`, `10.3.0` → `v3.5.0`.

## Not included

The live cluster still has Gateway API `v1.4.1` CRDs installed. This PR only updates the documented version — applying the CRD upgrade to the running cluster is a separate, deliberate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)