### PR TITLE
posthog: raise clickhouse background_pool_size to 16

### DIFF
--- a/my-apps/development/posthog/config/clickhouse/config.xml
+++ b/my-apps/development/posthog/config/clickhouse/config.xml
@@ -86,11 +86,13 @@
     <background_message_broker_schedule_pool_size>10</background_message_broker_schedule_pool_size>
     <max_thread_pool_size>10000</max_thread_pool_size>
 
-    <!-- how many threads merge files, default is 16. Must stay >=10: upstream
-         migrations create tables with per-table
-         number_of_free_entries_in_pool_to_execute_mutation=20, and CH rejects
-         the CREATE unless pool*concurrency_ratio(2) >= 20. -->
-    <background_pool_size>12</background_pool_size>
+    <!-- how many threads merge files. Upstream migrations create tables whose
+         per-table pool thresholds CH sanity-checks against
+         pool*concurrency_ratio(2); the CREATE is rejected if the product is
+         lower. Highest threshold seen so far is
+         number_of_free_entries_in_pool_to_execute_optimize_entire_partition=25,
+         so this must stay >=13. Left at upstream's default 16 (=32) for headroom. -->
+    <background_pool_size>16</background_pool_size>
 
     <!-- Number of workers to recycle connections in background (see also drain_timeout).
          If the pool is full, connection will be drained synchronously. -->


### PR DESCRIPTION
`posthog-migrate` is failing with `BackoffLimitExceeded`; ArgoCD has been retrying the sync hook (retry #10 at time of diagnosis). ClickHouse rejects the migration's `CREATE TABLE` with `Code: 36`:

> The value of `number_of_free_entries_in_pool_to_execute_optimize_entire_partition` setting (**25**) is greater than the value of `background_pool_size`*`background_merges_mutations_concurrency_ratio` (**24**)

## Cause

`config.xml` pinned `background_pool_size` to 12, sized against the older per-table threshold: `number_of_free_entries_in_pool_to_execute_mutation=20`, satisfied by `12*2 = 24`. The current upstream migration raises a *different* per-table setting — `optimize_entire_partition` — to 25. 24 is one short, and CH's MergeTree sanity check rejects the CREATE.

This is the same class as the two prior incidents in this directory: upstream ClickHouse config drift surfaced by a monolith image bump, not a code regression. `my-apps/development/posthog/CLAUDE.md` invariant #2 covers it.

## Fix

Restore upstream's default `background_pool_size` of 16, giving `16*2 = 32` — clears both thresholds with headroom rather than sitting one above the current one. Comment rewritten to name the binding constraint and the `>=13` floor so the next bump has the reasoning.

## Verification

- `config.xml` parses clean.
- `16*2 = 32` >= 25 (`optimize_entire_partition`) and >= 20 (`execute_mutation`).
- Rendered `kustomize build`: generated ConfigMap hash moves `clickhouse-config-m574h49488` -> `clickhouse-config-mbd8fhc68h`, so the Deployment volume ref changes and the ClickHouse pod rolls with the new config rather than silently keeping the old one.

## Blast radius

ClickHouse is single-node with `strategy: Recreate` on an RWO PVC, so it restarts on merge — brief ClickHouse downtime. PostHog web/worker stay up; the sync is currently blocked at the migrate hook, so app pods are still on the previous images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)