### PR TITLE
docs: correct Gateway API v1.6.1 install

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,15 @@ Omni? Create the service account first — see
 
 ### 4. Install Gateway API CRDs
 
-Install both channels before enabling Cilium Gateway API support, **experimental last**. Both channels ship `TLSRoute`, but standard serves only `v1` while experimental serves `v1alpha2`/`v1alpha3` too — Cilium reads the alpha versions, so a standard-channel `TLSRoute` CRD makes every TLSRoute unreadable. Applying experimental second leaves the right one in place.
+Install the complete standard channel before enabling Cilium Gateway API support:
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
 ```
+
+Do not apply the full experimental bundle afterward: Gateway API v1.6.1's
+safe-upgrades policy rejects mixing the two channels. This cluster does not use
+experimental `TLSRoute` resources.
 
 ### 5. Install Cilium (CNI)
 

--- a/omni/README.md
+++ b/omni/README.md
@@ -140,8 +140,7 @@ See the complete guide: [docs/CILIUM_CNI.md](docs/CILIUM_CNI.md)
 **Quick Install**:
 ```bash
 # Disable kube-proxy in cluster config, then:
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
 
 cilium-cli install \
     --version 1.20.0 \

--- a/omni/docs/CILIUM_CNI.md
+++ b/omni/docs/CILIUM_CNI.md
@@ -131,8 +131,7 @@ Full installation with Gateway API support:
 
 ```bash
 # First, install Gateway API CRDs
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
 
 # Then install Cilium
 cilium install \
@@ -157,8 +156,7 @@ Installation with Hubble for network observability:
 
 ```bash
 # Install Gateway API CRDs
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
 
 # Install Cilium with Hubble
 cilium install \


### PR DESCRIPTION
## Summary

- replace the standard-then-experimental Gateway API install sequence with one server-side apply of the v1.6.1 standard bundle
- keep the root and Omni bootstrap documentation consistent
- document that v1.6.1 safe-upgrades rejects layering the full experimental bundle over standard

## Why

Cilium 1.20 expects Gateway API v1.6.1, but the documented two-command sequence is invalid with the v1.6.1 safe-upgrades admission policy. This cluster has no experimental `TLSRoute` resources, so only the standard channel is required.

## Validation

- `git diff --check`
- verified no `experimental-install.yaml`, installer-script, or Argo-owned CRD references remain
- live standard v1.6.1 CRDs serve `v1`
- Cilium Gateway secret sync recovered
- Pi-to-vLLM smoke test returned `PI_VLLM_OK`
