### PR TITLE
deal-scout: v0.6.3

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.6.2@sha256:b6062628cc99dd96d45c31401d83c9be42a44fc341aef85294e293a9c2890122
+          image: ghcr.io/mitchross/deal-scout:v0.6.3@sha256:2339661c75a6e015df6d742b8716a52b28175d7190e105d5e031daebce2f7040
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.6.2@sha256:ddcac221e1da6ed76787700a380f156af198c398ab4fab88799b6bfdf03ea2f7
+          image: ghcr.io/mitchross/deal-scout-worker:v0.6.3@sha256:fb765f9a4b3a8b2e09f2012907005dfd66e3a630d0879326249f294a2a64c320
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.6.3.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.6.3`.