### PR TITLE
deal-scout: v0.7.0

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.6.2@sha256:b6062628cc99dd96d45c31401d83c9be42a44fc341aef85294e293a9c2890122
+          image: ghcr.io/mitchross/deal-scout:v0.7.0@sha256:7b3749d4f619dd5912d8b85b0ed0221e04ed2fe75033297a24543c78288d9153
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.6.2@sha256:ddcac221e1da6ed76787700a380f156af198c398ab4fab88799b6bfdf03ea2f7
+          image: ghcr.io/mitchross/deal-scout-worker:v0.7.0@sha256:c771d8b2a4936fe487ff006caed91b2235cd2d660443f3480b7d6a63e3a99307
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.7.0.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.7.0`.