### PR TITLE
fix(posthog): stop the metrics sidecar black-holing its own database

### DIFF
--- a/infrastructure/controllers/vpa-system-policies/posthog-policies.yaml
+++ b/infrastructure/controllers/vpa-system-policies/posthog-policies.yaml
@@ -39,7 +39,12 @@ spec:
     minReplicas: 1
   resourcePolicy:
     containerPolicies:
-      - containerName: "*"
+      # Fixed-size sidecar: leave it alone. VPA scaled it to 35m CPU, which
+      # stretched the /metrics scrape past its probe timeout and restart-looped
+      # the exporter, taking the whole pod out of the `db` Service endpoints.
+      - containerName: postgres-exporter
+        mode: "Off"
+      - containerName: db
         controlledResources: ["cpu", "memory"]
         controlledValues: RequestsOnly
         maxAllowed:

--- a/my-apps/development/gitea-actions/deployment.yaml
+++ b/my-apps/development/gitea-actions/deployment.yaml
@@ -94,10 +94,13 @@ spec:
               command: [docker, info]
             periodSeconds: 2
             failureThreshold: 30
+          # `docker info` runs well past the 1s probe default on a dind busy
+          # with a build, and a liveness timeout kills the daemon mid-job.
           livenessProbe:
             exec:
               command: [docker, info]
             periodSeconds: 30
+            timeoutSeconds: 10
 
         # Prune sidecar — keeps the dind PVC from filling up. Runs every
         # 6h; bounds buildkit cache to 20Gi and removes stopped

--- a/my-apps/development/posthog/data-layer/postgres.yaml
+++ b/my-apps/development/posthog/data-layer/postgres.yaml
@@ -95,18 +95,20 @@ spec:
         ports:
         - containerPort: 9187
           name: metrics
+        # NEVER give this sidecar a readinessProbe. A not-ready container makes
+        # the whole pod not-ready, which drops this pod from the `db` Service
+        # endpoints and black-holes Postgres for every PostHog consumer — the
+        # database stays up and nothing can reach it. The DSN comment above
+        # avoids the same deadlock from the other direction.
+        # timeoutSeconds must exceed a real scrape: /metrics queries Postgres
+        # and measured ~1.65s here, against the 1s default.
         livenessProbe:
           httpGet:
             path: /metrics
             port: metrics
           initialDelaySeconds: 10
           periodSeconds: 30
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: metrics
-          initialDelaySeconds: 5
-          periodSeconds: 10
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
## What broke

PostHog was the last thing still down after the cluster recovered from the Talos extension-drift outage. `ingestion-general`, `property-defs-rs` and `worker` looped on `ECONNREFUSED` / `PoolTimedOut` against `db:5432` — while the `db` container itself was `ready=true` with **zero restarts**. Postgres was up the whole time.

## The chain

1. `postgres-exporter` (sidecar in the `db` pod) probed `/metrics` with no `timeoutSeconds`, so both liveness and readiness used the **1s default**.
2. The scrape genuinely takes **~1.65s** — measured in-pod:
   ```
   kubectl -n posthog exec <db-pod> -c db -- \
     sh -c 'time wget -q -O /dev/null http://127.0.0.1:9187/metrics'
   SCRAPE_OK   real 0m1.65s
   ```
3. So every probe failed. Liveness restart-looped the sidecar (6+ restarts, `Killing … failed liveness probe`); readiness held it `ready=false`.
4. One not-ready container makes the **whole pod** not-ready, so the `db` EndpointSlice published its only address with `ready=false`.
5. Service had zero ready endpoints → every consumer got connection refused.

`postgres.yaml` already carried a comment about avoiding a readiness deadlock via the DSN choice. This is the same deadlock arriving through a different door.

## Changes

- **`my-apps/development/posthog/data-layer/postgres.yaml`** — remove the exporter's `readinessProbe` and set liveness `timeoutSeconds: 10`. A monitoring sidecar can never make a pod *more* available, but it can remove the pod from its Service and take down the thing it observes. The `db` container keeps its own probes, so the database still gates its own readiness properly.
- **`infrastructure/controllers/vpa-system-policies/posthog-policies.yaml`** — the `posthog-db` VPA used `containerName: "*"` and had squeezed the sidecar to **35m CPU**, which is why the scrape was slow enough to trip a 1s timeout. Split into `postgres-exporter: mode "Off"` + an explicit `db` policy, per the CLAUDE.md rule on fixed-size sidecars.
- **`my-apps/development/gitea-actions/deployment.yaml`** — same bug class: `docker info` as an exec liveness probe on the 1s default, which a dind busy with a build will exceed. Added `timeoutSeconds: 10`.

## VPA audit

Run against the live cluster rather than grep, since chart-owned VPAs are inert. Only **5** VPAs recommend on more than one container:

| VPA | Verdict |
|---|---|
| `posthog/posthog-db` | **The bug.** Fixed here. |
| `gitea-actions/gitea-act-runner` | Already names containers explicitly with `prune: Off`. Probe timeout hardened. |
| `radar-ng/radar-ng-basemap` | Stale recommendation for `extract`; pod now uses init container `wait-for-pmtiles`. Harmless. |
| `versatiles/versatiles` | Stale recommendation for `download`; pod now uses init container `wait-for-map`. Harmless. |
| `radar-ng/radar-ng-open-meteo` | Already names both containers explicitly. |

Query that finds these: `kubectl get vpa -A -o json`, flag any whose `status.recommendation.containerRecommendations` has length > 1.

## Verification

`kustomize build` clean on all three directories. Rendered output confirms `postgres-exporter` has liveness `timeoutSeconds: 10` and no readinessProbe, and the VPA renders `postgres-exporter → mode: "Off"` alongside the explicit `db` policy.

The 4 remaining CrashLoopBackOff pods in the cluster are all PostHog and should clear once this syncs.

Not included: the unrelated pre-existing working-tree changes (`docs/nas-performance.md`, `mkdocs.yml` nav, OpenWebUI `DEFAULT_USER_ROLE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)