### PR TITLE
deal-scout: v0.8.0

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.7.0@sha256:7b3749d4f619dd5912d8b85b0ed0221e04ed2fe75033297a24543c78288d9153
+          image: ghcr.io/mitchross/deal-scout:v0.8.0@sha256:3a9e249796a9f35d1329ef631bcf3f8e78ad0f684a5d8870dead73ca1bb4ec47
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.6.3@sha256:fb765f9a4b3a8b2e09f2012907005dfd66e3a630d0879326249f294a2a64c320
+          image: ghcr.io/mitchross/deal-scout-worker:v0.8.0@sha256:5af49db927e90d4c0f135766ad71ef128133523beabc0009505cef4fe88369e6
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.8.0.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.8.0`.