### PR TITLE
deal-scout: v0.8.1

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.8.0@sha256:3a9e249796a9f35d1329ef631bcf3f8e78ad0f684a5d8870dead73ca1bb4ec47
+          image: ghcr.io/mitchross/deal-scout:v0.8.1@sha256:6d27f3681c380307359e3d9f436dbdcdc28abd659d543c3f6daed7327e255100
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.8.0@sha256:5af49db927e90d4c0f135766ad71ef128133523beabc0009505cef4fe88369e6
+          image: ghcr.io/mitchross/deal-scout-worker:v0.8.1@sha256:0aafb2a21b764d69bf8fa3ae40ee7f69120b7f51a531d392ee86923f244278e6
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.8.1.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.8.1`.