### PR TITLE
deal-scout: v0.8.2

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.8.1@sha256:6d27f3681c380307359e3d9f436dbdcdc28abd659d543c3f6daed7327e255100
+          image: ghcr.io/mitchross/deal-scout:v0.8.2@sha256:f1db6548a0f449dd6f1e300ff1fc95d8aac841a4d519acc7ecf0d566f188e228
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.8.1@sha256:0aafb2a21b764d69bf8fa3ae40ee7f69120b7f51a531d392ee86923f244278e6
+          image: ghcr.io/mitchross/deal-scout-worker:v0.8.2@sha256:2aa996834da0788fc6760cc06c3ed87b27e40c4eae1ae7ab59ba25689243c09c
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.8.2.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.8.2`.