### PR TITLE
deal-scout: v0.8.3

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.8.1@sha256:6d27f3681c380307359e3d9f436dbdcdc28abd659d543c3f6daed7327e255100
+          image: ghcr.io/mitchross/deal-scout:v0.8.3@sha256:cfc7963174e60d98906a6d1f0c9b2d446e2037377c1b34ebecb6b87577754726
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.8.1@sha256:0aafb2a21b764d69bf8fa3ae40ee7f69120b7f51a531d392ee86923f244278e6
+          image: ghcr.io/mitchross/deal-scout-worker:v0.8.3@sha256:5b4125a606bbde4bf10bf6500102843e0bd14119ef94af87acafe6d14dcf72cd
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.8.3.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.8.3`.