### PR TITLE
Add Intercept dual RTL-SDR application

### DIFF
--- a/my-apps/home/intercept/deployment.yaml
+++ b/my-apps/home/intercept/deployment.yaml
@@ -1,0 +1,137 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: intercept
+  namespace: intercept
+  labels:
+    app.kubernetes.io/name: intercept
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: intercept
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: intercept
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: 30
+      # Both Proxmox RTL-SDR mappings terminate on this Talos VM. The hostPath
+      # below is node-local, so the pod must never move to another worker.
+      nodeSelector:
+        node.vanillax.dev/class: dell-gpu
+      initContainers:
+        - name: initialize-data
+          image: docker.io/library/alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command:
+            - /bin/sh
+            - -c
+            - >-
+              mkdir -p /persist/instance
+              /persist/weather_sat
+              /persist/radiosonde
+              /persist/subghz
+              /persist/adsb
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 5m
+              memory: 8Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
+          volumeMounts:
+            - name: data
+              mountPath: /persist
+      containers:
+        - name: intercept
+          image: ghcr.io/smittix/intercept:main@sha256:72bb71edf69a6e26b356edcc83911f523029fc3eb6249d5b9a08857740afb3bf
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            # Upstream requires privileged access for libusb-based SDR tools.
+            privileged: true
+            allowPrivilegeEscalation: true
+            runAsUser: 0
+            runAsNonRoot: false
+          env:
+            - name: TZ
+              value: America/Detroit
+            - name: INTERCEPT_HOST
+              value: 0.0.0.0
+            - name: INTERCEPT_PORT
+              value: "5050"
+            - name: INTERCEPT_LOG_LEVEL
+              value: INFO
+            - name: INTERCEPT_ADSB_AUTO_START
+              value: "false"
+            - name: INTERCEPT_SHARED_OBSERVER_LOCATION
+              value: "true"
+            - name: INTERCEPT_REGION
+              value: US
+            # Intentional for LAN-only use. Do not bind the HTTPRoute to the
+            # external Gateway without restoring application authentication.
+            - name: INTERCEPT_DISABLE_AUTH
+              value: "true"
+          ports:
+            - name: http
+              containerPort: 5050
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 8Gi
+          volumeMounts:
+            # Persist the application database, credentials, settings, and
+            # generated output without masking the Python modules in /app/data.
+            - name: data
+              mountPath: /app/instance
+              subPath: instance
+            - name: data
+              mountPath: /app/data/weather_sat
+              subPath: weather_sat
+            - name: data
+              mountPath: /app/data/radiosonde
+              subPath: radiosonde
+            - name: data
+              mountPath: /app/data/subghz
+              subPath: subghz
+            - name: data
+              mountPath: /app/data/adsb
+              subPath: adsb
+            # Mount the bus, not 001/003 and 001/004: USB device numbers can
+            # change after a VM or hub restart, while both RTL2838s remain here.
+            - name: usb-bus
+              mountPath: /dev/bus/usb
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: intercept-data
+        - name: usb-bus
+          hostPath:
+            path: /dev/bus/usb
+            type: Directory

--- a/my-apps/home/intercept/httproute.yaml
+++ b/my-apps/home/intercept/httproute.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: intercept
+  namespace: intercept
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-internal-technitium
+      namespace: gateway
+  hostnames:
+    - intercept.vanillax.me
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: intercept
+          port: 5050
+          weight: 1

--- a/my-apps/home/intercept/kopiur/intercept-data.yaml
+++ b/my-apps/home/intercept/kopiur/intercept-data.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: intercept-data
+  namespace: intercept
+spec:
+  sources:
+    - pvc:
+        name: intercept-data
+  identity:
+    username: intercept-data
+    hostname: intercept
+  retention:
+    keepDaily: 14
+    keepWeekly: 6
+    keepMonthly: 3
+  mover:
+    securityContext:
+      runAsUser: 0
+      runAsNonRoot: false
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: intercept-data-daily
+  namespace: intercept
+spec:
+  policyRef:
+    name: intercept-data
+  schedule:
+    cron: "53 3 * * *"
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: intercept-data-restore
+  namespace: intercept
+spec:
+  source:
+    fromPolicy:
+      name: intercept-data
+      offset: 0
+  mover:
+    securityContext:
+      runAsUser: 0
+      runAsNonRoot: false

--- a/my-apps/home/intercept/kustomization.yaml
+++ b/my-apps/home/intercept/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: intercept
+
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - kopiur/intercept-data.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - vpa.yaml
+
+components:
+  - ../../common/kopiur-backup

--- a/my-apps/home/intercept/namespace.yaml
+++ b/my-apps/home/intercept/namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: intercept
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+    kopiur.home-operations.com/repo: cluster-kopia
+  annotations:
+    # Intercept and the kopiur mover both run as root: the upstream image owns
+    # its SQLite database and capture output as uid 0.
+    kopiur.home-operations.com/privileged-movers: "true"

--- a/my-apps/home/intercept/pvc.yaml
+++ b/my-apps/home/intercept/pvc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: intercept-data
+  namespace: intercept
+  annotations:
+    # Immutable dataSourceRef on a Bound PVC — mask the SSA dry-run diff;
+    # the AppSet ignoreDifferences handles the live comparison.
+    argocd.argoproj.io/compare-options: ServerSideDiff=false
+    argocd.argoproj.io/sync-options: ServerSideApply=false
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: longhorn
+  dataSourceRef:
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: intercept-data-restore

--- a/my-apps/home/intercept/service.yaml
+++ b/my-apps/home/intercept/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: intercept
+  namespace: intercept
+spec:
+  selector:
+    app.kubernetes.io/name: intercept
+  ports:
+    - name: http
+      port: 5050
+      targetPort: http
+      protocol: TCP

--- a/my-apps/home/intercept/vpa.yaml
+++ b/my-apps/home/intercept/vpa.yaml
@@ -1,0 +1,24 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: intercept
+  namespace: intercept
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: intercept
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: intercept
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        minAllowed:
+          cpu: 100m
+          memory: 256Mi
+        maxAllowed:
+          cpu: "4"
+          memory: 8Gi


### PR DESCRIPTION
## Summary

- add Intercept as an ArgoCD-discovered application under `my-apps/home/intercept`
- pin the workload to the Dell worker and expose `/dev/bus/usb` so both Proxmox-passed RTL2838 SDRs are available
- publish the UI only through the internal Gateway at `intercept.vanillax.me`
- disable application authentication intentionally for LAN-only access
- persist Intercept state and capture output on a 20Gi Longhorn PVC with kopiur restore-before-bind backups
- add an app-owned VPA policy

## Security boundary

`INTERCEPT_DISABLE_AUTH=true` is intentional. The HTTPRoute targets `gateway-internal-technitium`; the app must not be moved to the external Gateway without restoring authentication.

## Validation

- `kustomize build --enable-helm my-apps/home/intercept`
- `kubectl apply --dry-run=client -f <rendered-manifests>`
- `python3 scripts/validate-kopiur-coverage.py <rendered-manifests>`
- `bash scripts/validate-argocd-apps.sh`
- targeted assertion of the Dell node selector, internal Gateway, and no-auth environment contract
