### PR TITLE
deal-scout: v0.8.4

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.8.3@sha256:cfc7963174e60d98906a6d1f0c9b2d446e2037377c1b34ebecb6b87577754726
+          image: ghcr.io/mitchross/deal-scout:v0.8.4@sha256:dc6ee6d37b548195565f9b3476ef08c0421e00861bd27974f31abdb18595a998
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.8.3@sha256:5b4125a606bbde4bf10bf6500102843e0bd14119ef94af87acafe6d14dcf72cd
+          image: ghcr.io/mitchross/deal-scout-worker:v0.8.4@sha256:ef57375b9228bb3c7e6fbcee4bfa3a10a03d1bc3b02f2276a274f0cdf4dea8ce
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.8.4.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.8.4`.