### PR TITLE
deal-scout: v0.8.5

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.8.4@sha256:dc6ee6d37b548195565f9b3476ef08c0421e00861bd27974f31abdb18595a998
+          image: ghcr.io/mitchross/deal-scout:v0.8.5@sha256:f61bdee455750451a55d22282ebbb40b1327779a9e4b7706eda3bd8c6e96875a
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.8.4@sha256:ef57375b9228bb3c7e6fbcee4bfa3a10a03d1bc3b02f2276a274f0cdf4dea8ce
+          image: ghcr.io/mitchross/deal-scout-worker:v0.8.5@sha256:88a4839690244f44b23f23f2863a11ebc3edf5c2c41dda856a3ed150b758b9d7
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.8.5.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.8.5`.