### PR TITLE
Enable Intercept ADS-B history

### DIFF
--- a/my-apps/home/intercept/deployment.yaml
+++ b/my-apps/home/intercept/deployment.yaml
@@ -71,6 +71,21 @@ spec:
               value: INFO
             - name: INTERCEPT_ADSB_AUTO_START
               value: "false"
+            - name: INTERCEPT_ADSB_HISTORY_ENABLED
+              value: "true"
+            - name: INTERCEPT_ADSB_DB_HOST
+              value: intercept-postgres
+            - name: INTERCEPT_ADSB_DB_PORT
+              value: "5432"
+            - name: INTERCEPT_ADSB_DB_NAME
+              value: intercept_adsb
+            - name: INTERCEPT_ADSB_DB_USER
+              value: intercept
+            - name: INTERCEPT_ADSB_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: intercept-postgres-secret
+                  key: password
             - name: INTERCEPT_SHARED_OBSERVER_LOCATION
               value: "true"
             - name: INTERCEPT_REGION

--- a/my-apps/home/intercept/kopiur/postgres-data.yaml
+++ b/my-apps/home/intercept/kopiur/postgres-data.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: intercept-postgres-data
+  namespace: intercept
+spec:
+  sources:
+    - pvc:
+        name: intercept-postgres-data
+  identity:
+    username: intercept-postgres-data
+    hostname: intercept
+  retention:
+    keepHourly: 24
+    keepDaily: 7
+    keepWeekly: 4
+  mover:
+    securityContext:
+      runAsUser: 999
+      runAsGroup: 999
+      runAsNonRoot: true
+    podSecurityContext:
+      fsGroup: 999
+      supplementalGroups:
+        - 999
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: intercept-postgres-data-hourly
+  namespace: intercept
+spec:
+  policyRef:
+    name: intercept-postgres-data
+  schedule:
+    cron: "1 * * * *"
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: intercept-postgres-data-restore
+  namespace: intercept
+spec:
+  source:
+    fromPolicy:
+      name: intercept-postgres-data
+      offset: 0
+  mover:
+    securityContext:
+      runAsUser: 999
+      runAsGroup: 999
+      runAsNonRoot: true
+    podSecurityContext:
+      fsGroup: 999
+      supplementalGroups:
+        - 999

--- a/my-apps/home/intercept/kustomization.yaml
+++ b/my-apps/home/intercept/kustomization.yaml
@@ -4,8 +4,13 @@ namespace: intercept
 
 resources:
   - namespace.yaml
+  - postgres-secret.yaml
   - pvc.yaml
   - kopiur/intercept-data.yaml
+  - postgres/deployment.yaml
+  - postgres/service.yaml
+  - postgres/pvc.yaml
+  - kopiur/postgres-data.yaml
   - deployment.yaml
   - service.yaml
   - httproute.yaml

--- a/my-apps/home/intercept/namespace.yaml
+++ b/my-apps/home/intercept/namespace.yaml
@@ -8,6 +8,7 @@ metadata:
     pod-security.kubernetes.io/warn: privileged
     kopiur.home-operations.com/repo: cluster-kopia
   annotations:
-    # Intercept and the kopiur mover both run as root: the upstream image owns
-    # its SQLite database and capture output as uid 0.
+    # Intercept and its data-PVC mover run as root: the upstream image owns its
+    # SQLite database and capture output as uid 0. The Postgres mover remains
+    # non-root with its own uid:gid in kopiur/postgres-data.yaml.
     kopiur.home-operations.com/privileged-movers: "true"

--- a/my-apps/home/intercept/postgres-secret.yaml
+++ b/my-apps/home/intercept/postgres-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: intercept-postgres-secret
+  namespace: intercept
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: intercept-postgres-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: password
+      remoteRef:
+        key: postgres-secrets
+        property: intercept_db_password

--- a/my-apps/home/intercept/postgres/deployment.yaml
+++ b/my-apps/home/intercept/postgres/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: intercept-postgres
+  namespace: intercept
+  labels:
+    app.kubernetes.io/name: intercept-postgres
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: intercept-postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: intercept-postgres
+    spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 60
+      securityContext:
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: postgres
+          # Major upgrades require a dump/restore; the data directory is not
+          # compatible across PostgreSQL major versions.
+          image: docker.io/library/postgres:18.4
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: POSTGRES_DB
+              value: intercept_adsb
+            - name: POSTGRES_USER
+              value: intercept
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: intercept-postgres-secret
+                  key: password
+            - name: POSTGRES_INITDB_ARGS
+              value: --data-checksums
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          startupProbe:
+            exec:
+              command: ["pg_isready", "-U", "intercept", "-d", "intercept_adsb"]
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "intercept", "-d", "intercept_adsb"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "intercept", "-d", "intercept_adsb"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              memory: 2Gi
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: intercept-postgres-data

--- a/my-apps/home/intercept/postgres/pvc.yaml
+++ b/my-apps/home/intercept/postgres/pvc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: intercept-postgres-data
+  namespace: intercept
+  annotations:
+    # Immutable dataSourceRef on a Bound PVC — mask the SSA dry-run diff;
+    # the AppSet ignoreDifferences handles the live comparison.
+    argocd.argoproj.io/compare-options: ServerSideDiff=false
+    argocd.argoproj.io/sync-options: ServerSideApply=false
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: longhorn
+  dataSourceRef:
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: intercept-postgres-data-restore

--- a/my-apps/home/intercept/postgres/service.yaml
+++ b/my-apps/home/intercept/postgres/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: intercept-postgres
+  namespace: intercept
+spec:
+  selector:
+    app.kubernetes.io/name: intercept-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+      protocol: TCP

--- a/my-apps/home/intercept/vpa.yaml
+++ b/my-apps/home/intercept/vpa.yaml
@@ -22,3 +22,28 @@ spec:
         maxAllowed:
           cpu: "4"
           memory: 8Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: intercept-postgres
+  namespace: intercept
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: intercept-postgres
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: postgres
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        minAllowed:
+          cpu: 25m
+          memory: 128Mi
+        maxAllowed:
+          cpu: "2"
+          memory: 4Gi


### PR DESCRIPTION
## Summary

- enable Intercept's PostgreSQL-backed ADS-B history mode
- add a plain PostgreSQL 18.4 Deployment and internal Service
- persist the database on a dedicated 20Gi Longhorn RWO PVC
- protect the database with hourly kopiur restore-before-bind backups
- add a Postgres VPA policy
- keep Intercept application authentication disabled and its route internal-only

This enables long-term ADS-B messages, aircraft snapshots, sessions, reporting, export, and historical playback. Intercept retains its existing SQLite/settings/capture PVC separately.

## Required before merge

Add the concealed field `intercept_db_password` to the existing `postgres-secrets` item in the `homelab-prod` 1Password vault. The ExternalSecret creates `intercept-postgres-secret`; both Intercept and Postgres consume the same password.

Do not merge until that field exists, or both pods will wait on the missing Secret.

## Validation

- app Kustomize render: 17 resources
- Kubernetes client dry-run accepted the rendered resources
- kubeconform: 0 invalid resources
- kopiur coverage: both PVCs covered, 0 app warnings/failures
- repository-wide VPA validation: 0 errors
- ArgoCD topology validation passed
- targeted assertions verified history environment wiring, secret reference, Postgres security context, RWO/Recreate strategy, restore-before-bind, and hourly backup schedule
