### PR TITLE
Use portable Intercept ACARS image

### DIFF
--- a/my-apps/home/intercept/deployment.yaml
+++ b/my-apps/home/intercept/deployment.yaml
@@ -52,7 +52,9 @@ spec:
               mountPath: /persist
       containers:
         - name: intercept
-          image: ghcr.io/smittix/intercept:main@sha256:72bb71edf69a6e26b356edcc83911f523029fc3eb6249d5b9a08857740afb3bf
+          # Upstream's amd64 acarsdec is built with -march=native and crashes
+          # on this worker; the derivative only replaces that binary (#246).
+          image: ghcr.io/mitchross/intercept:acarsdec-portable-0f59c326-339f63eb@sha256:fdbe22567f5c5e016952ff0609847f9ce3e3a1dd71ed4ebf2bad51bb6b08f9af
           imagePullPolicy: IfNotPresent
           securityContext:
             # Upstream requires privileged access for libusb-based SDR tools.


### PR DESCRIPTION
## What changed

- Switch Intercept to the public `ghcr.io/mitchross/intercept` derivative image.
- Pin the OCI index by digest.
- Keep the exact upstream Intercept AMD64 base and replace only `/usr/bin/acarsdec`.

## Why

The upstream AMD64 Docker artifact compiles `acarsdec` with `-march=native`. On the Dell i5-8500 worker, ACARS opens either RTL-SDR and then crashes with `SIGILL` in `initRtl()` on an AVX-512 `vbroadcastss` instruction.

The issue is reported upstream as smittix/intercept#246.

The replacement binary:

- pins `TLeconte/acarsdec` source commit `339f63eb91a890cfe5b199ad70814cfe86702d1e`, matching the source available when the upstream Intercept image was built;
- retains upstream `-Ofast` optimization;
- removes only `-march=native`;
- is layered over upstream Intercept AMD64 manifest `sha256:6c400201c653fe7aae1ec669a7cd29cd79b1bae967245b8cec33a8ee21a1b4a5`.

## Validation

- Published OCI index: `sha256:fdbe22567f5c5e016952ff0609847f9ce3e3a1dd71ed4ebf2bad51bb6b08f9af`
- Published AMD64 manifest: `sha256:8b1b20d4ad364d83eae56ec319bd902e867bd9e2f82b4101dc9cb889bc94014e`
- SBOM and provenance attestations published with the image.
- Disassembled published replacement: zero ZMM instructions and zero matching AVX-512 candidates.
- Intercept Kustomize render succeeds.
- Kubernetes client dry-run succeeds.
- `scripts/validate-argocd-apps.sh` passes.
- `scripts/validate-truenas-csi.sh` passes.

## After merge

ArgoCD will recreate the Intercept pod because it uses a single RWO PVC. Verify both SDRs with `rtl_test`, then start ACARS on 131.550 MHz and confirm `acarsdec` remains running and emits no `SIGILL`.

Once upstream publishes a portable image for smittix/intercept#246, replace this temporary derivative with the upstream digest.
