### PR TITLE
deal-scout: v0.8.8

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.8.7@sha256:c2f77e7635ba358a89981fc6459e72535eee9fb365ad2b8461d787bb13a19483
+          image: ghcr.io/mitchross/deal-scout:v0.8.8@sha256:ac313ecb428893772cfab587522d9ce8a2a17369f4ebc4af654c07beed21f8e5
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.8.7@sha256:4b158c4511fb2c2055a495a5c16eb5c08875e2df271f1c5bf90be159d83e3a4d
+          image: ghcr.io/mitchross/deal-scout-worker:v0.8.8@sha256:e533bc4159f110355ee210f5bdb6b027a6bcc80519eee1f2846313ee8217de2f
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.8.8.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.8.8`.