### PR TITLE
Use split xDS for Cilium Envoy

### DIFF
--- a/infrastructure/networking/cilium/values.yaml
+++ b/infrastructure/networking/cilium/values.yaml
@@ -123,6 +123,12 @@ gatewayAPI:
   sessionAffinity: true
   sessionAffinityTimeoutSeconds: 10800 # 3 hours
 
+# Cilium 1.20.0 ADS can livelock after its last L7 listener drains, publishing
+# an empty policy snapshot that makes every Gateway return 403 "Access denied".
+# Split xDS is unaffected; keep it until cilium/cilium#47624 ships in a release.
+envoy:
+  xdsMode: split
+
 # Cilium agent resources (VPA-optimized 2026-02-28; mem limit raised 2026-05-04)
 # Capacity baseline 2026-05-04 showed cilium-* daemonset pods observed
 # 0.8-1.2 GiB at the 2 GiB limit boundary. Endpoint maps grow with churn.


### PR DESCRIPTION
## What changed

- Configure Cilium Envoy to use `split` xDS mode instead of the Cilium 1.20 default, ADS.

## Why

Cilium 1.20.0 has an upstream ADS regression where draining the final L7 listener leaves NetworkPolicy subscription state inconsistent. The agent and Envoy then livelock while policy snapshots disappear and rebuild, causing shared Gateway API listeners to intermittently return `403 Access denied`.

This cluster reproduced the failure on the L2 Gateway owner: Cilium logged repeated endpoint proxy policy timeouts and briefly published zero `cilium.NetworkPolicy` resources. Every host on the internal Gateway failed while direct Service access remained healthy.

Upstream issue: https://github.com/cilium/cilium/issues/47624
Merged proxy fix awaiting a Cilium release: https://github.com/cilium/proxy/pull/1982

`split` is the unaffected legacy xDS mode and avoids running an unreleased proxy image. The override can be removed after a Cilium release includes the merged fix.

## Impact

Argo CD will roll the Cilium agent and Envoy DaemonSets using the repository's one-node-at-a-time strategy. Gateway and network-policy behavior remain enabled; only the xDS transport mode changes.

## Validation

- `git diff --check`
- `kustomize build --enable-helm infrastructure/networking/cilium` renders `envoy-xds-mode: split`
- `bash ./scripts/validate-argocd-apps.sh`
