### PR TITLE
Add kopiur backup coverage for deal-scout and hindsight

### DIFF
--- a/my-apps/ai/hindsight/kopiur/hindsight-db.yaml
+++ b/my-apps/ai/hindsight/kopiur/hindsight-db.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+# hindsight database backup STUB — uniform fields (repository, copyMethod,
+# populator) injected by ../../common/kopiur-backup. The mover securityContext
+# is per-PVC and stays in THIS stub (docs/domains/storage/kopiur-mover-permissions.md).
+#
+# pgvector/pgvector:pg16 running as a plain Deployment, NOT CloudNativePG --
+# so it gets no CNPG backup and needs this. Runs as uid/gid 999 (the postgres
+# user in that image), which is what the mover securityContext below matches.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: hindsight-db-pvc
+  namespace: hindsight
+spec:
+  sources:
+    - pvc:
+        name: hindsight-db-pvc
+  identity:
+    username: hindsight-db-pvc
+    hostname: hindsight
+  retention:
+    keepDaily: 14
+    keepWeekly: 6
+    keepMonthly: 3
+  mover:
+    securityContext:
+      runAsUser: 999
+      runAsGroup: 999
+      runAsNonRoot: true
+    podSecurityContext:
+      fsGroup: 999
+      supplementalGroups:
+        - 999
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: hindsight-db-pvc-daily
+  namespace: hindsight
+spec:
+  policyRef:
+    name: hindsight-db-pvc
+  schedule:
+    cron: "57 3 * * *"
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: hindsight-db-pvc-restore
+  namespace: hindsight
+spec:
+  source:
+    fromPolicy:
+      name: hindsight-db-pvc
+      offset: 0
+  mover:
+    securityContext:
+      runAsUser: 999
+      runAsGroup: 999
+      runAsNonRoot: true
+    podSecurityContext:
+      fsGroup: 999
+      supplementalGroups:
+        - 999

--- a/my-apps/ai/hindsight/kustomization.yaml
+++ b/my-apps/ai/hindsight/kustomization.yaml
@@ -11,3 +11,8 @@ resources:
   - service.yaml
   - httproute.yaml
   - vpa.yaml
+  - kopiur/hindsight-db.yaml
+
+# Uniform kopiur backup fields (repository, copyMethod, populator) for the per-PVC stub(s) in kopiur/.
+components:
+  - ../../common/kopiur-backup

--- a/my-apps/ai/hindsight/namespace.yaml
+++ b/my-apps/ai/hindsight/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: hindsight
+  labels:
+    # kopiur-managed: ClusterExternalSecret cred fanout + ClusterRepository
+    # tenancy (allowedNamespaces selector).
+    kopiur.home-operations.com/repo: cluster-kopia

--- a/my-apps/ai/hindsight/pvc.yaml
+++ b/my-apps/ai/hindsight/pvc.yaml
@@ -3,6 +3,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: hindsight-db-pvc
   namespace: hindsight
+  annotations:
+    # Immutable dataSourceRef on a Bound PVC — mask the SSA dry-run diff
+    # (the AppSet ignoreDifferences handles the live compare).
+    argocd.argoproj.io/compare-options: ServerSideDiff=false
+    argocd.argoproj.io/sync-options: ServerSideApply=false
 spec:
   accessModes:
     - ReadWriteOnce
@@ -10,3 +15,12 @@ spec:
   resources:
     requests:
       storage: 5Gi
+  # kopiur restore-before-bind: on recreate this binds Pending until the
+  # Restore populator hydrates it from the latest kopia snapshot. No-op while
+  # Bound. Backup/restore CRs in kopiur/hindsight-db.yaml; uniform fields come
+  # from the ../../common/kopiur-backup component; the mover uid:gid lives in
+  # the stub.
+  dataSourceRef:
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: hindsight-db-pvc-restore

--- a/my-apps/utility/deal-scout/kopiur/deal-scout-data.yaml
+++ b/my-apps/utility/deal-scout/kopiur/deal-scout-data.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+# deal-scout data backup STUB — uniform fields (repository, copyMethod,
+# populator) injected by ../../common/kopiur-backup. The mover securityContext
+# is per-PVC and stays in THIS stub (docs/domains/storage/kopiur-mover-permissions.md).
+#
+# Holds deals.db, a SQLite database: scraped listings plus the feedback and
+# learned reject signals that are NOT reproducible by re-scraping. Backed up
+# per the "non-CNPG databases" rule in docs/storage-architecture.md.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: deal-scout-data
+  namespace: deal-scout
+spec:
+  sources:
+    - pvc:
+        name: deal-scout-data
+  identity:
+    username: deal-scout-data
+    hostname: deal-scout
+  retention:
+    keepDaily: 14
+    keepWeekly: 6
+    keepMonthly: 3
+  mover:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+    podSecurityContext:
+      fsGroup: 1000
+      supplementalGroups:
+        - 1000
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: deal-scout-data-daily
+  namespace: deal-scout
+spec:
+  policyRef:
+    name: deal-scout-data
+  schedule:
+    cron: "55 3 * * *"
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: deal-scout-data-restore
+  namespace: deal-scout
+spec:
+  source:
+    fromPolicy:
+      name: deal-scout-data
+      offset: 0
+  mover:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+    podSecurityContext:
+      fsGroup: 1000
+      supplementalGroups:
+        - 1000

--- a/my-apps/utility/deal-scout/kustomization.yaml
+++ b/my-apps/utility/deal-scout/kustomization.yaml
@@ -13,3 +13,8 @@ resources:
   - temporal-workers/ebay-externalsecret.yaml
   - temporal-workers/temporal-worker-deployment.yaml
   - vpa.yaml
+  - kopiur/deal-scout-data.yaml
+
+# Uniform kopiur backup fields (repository, copyMethod, populator) for the per-PVC stub(s) in kopiur/.
+components:
+  - ../../common/kopiur-backup

--- a/my-apps/utility/deal-scout/namespace.yaml
+++ b/my-apps/utility/deal-scout/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: deal-scout
+  labels:
+    # kopiur-managed: ClusterExternalSecret cred fanout + ClusterRepository
+    # tenancy (allowedNamespaces selector).
+    kopiur.home-operations.com/repo: cluster-kopia

--- a/my-apps/utility/deal-scout/pvc.yaml
+++ b/my-apps/utility/deal-scout/pvc.yaml
@@ -3,6 +3,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: deal-scout-data
   namespace: deal-scout
+  annotations:
+    # Immutable dataSourceRef on a Bound PVC — mask the SSA dry-run diff
+    # (the AppSet ignoreDifferences handles the live compare).
+    argocd.argoproj.io/compare-options: ServerSideDiff=false
+    argocd.argoproj.io/sync-options: ServerSideApply=false
 spec:
   accessModes:
     - ReadWriteOnce
@@ -10,3 +15,12 @@ spec:
   resources:
     requests:
       storage: 1Gi
+  # kopiur restore-before-bind: on recreate this binds Pending until the
+  # Restore populator hydrates it from the latest kopia snapshot. No-op while
+  # Bound. Backup/restore CRs in kopiur/deal-scout-data.yaml; uniform fields
+  # come from the ../../common/kopiur-backup component; the mover uid:gid
+  # lives in the stub.
+  dataSourceRef:
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: deal-scout-data-restore


### PR DESCRIPTION
## What changed

- kopiur bundle (`SnapshotPolicy` + `SnapshotSchedule` + `Restore`) for `deal-scout/deal-scout-data` and `hindsight/hindsight-db-pvc`
- namespace `kopiur.home-operations.com/repo: cluster-kopia` label on both
- `dataSourceRef` restore-before-bind on both PVCs, behind the SSA diff mask
- shared `../../common/kopiur-backup` component wired into both kustomizations

## Why

Found while running the preflight for the Dell Longhorn evacuation (#1919). Of the **14 volumes whose only replica lives on Dell**, four had no kopiur coverage.

Two of those were deliberate and already recorded — `searxng/redis-data` and `worldmonitor/worldmonitor-redis-data` both carry `backup-exempt: "true"` with a fully-qualified reason. No change needed.

The other two are the real gap, and both are databases:

| PVC | What it is |
|---|---|
| `deal-scout/deal-scout-data` | SQLite. Scraped listings plus feedback and learned reject signals — **not** reproducible by re-scraping. |
| `hindsight/hindsight-db-pvc` | `pgvector/pgvector:pg16` as a plain Deployment, **not** CloudNativePG, so no CNPG backup covers it. Runs as uid/gid 999. |

Both match the "user content, non-CNPG databases" rule in `docs/storage-architecture.md`.

## Validation

- `validate-kopiur-coverage.py` initially **failed** both PVCs with `backed up but dataSourceRef is not a kopiur Restore → recreates EMPTY in DR`. Adding `dataSourceRef` cleared it; now `policies=2 restores=2 pvcs=2`, **0 warnings, 0 failures**.
- Both kustomizations render; all three CRs appear per app with the correct names and namespaces.
- Mover `securityContext` matches each workload's runtime uid/gid (1000 for deal-scout, 999 for hindsight) per the mover-permissions gotcha.
- Cron slots 3:55 and 3:57, after the last taken slot at 3:53.

## Operational impact

Additive. No existing PVC data is moved or rewritten — `dataSourceRef` is a no-op while a PVC is Bound. First snapshots run on the nightly schedule; this PR is a prerequisite for evacuating the Dell disk so nothing unbacked gets rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7CB3ozWPCw1iuSLjmenKe