### PR TITLE
deal-scout: v0.8.11

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.8.9@sha256:3594e7b685d9ab3b5c620c2d52d4b1af6def9ce46888ec04f9364bfdd60e7795
+          image: ghcr.io/mitchross/deal-scout:v0.8.11@sha256:94a2e71683b806f12c2aca6b0205f116533c0a3af1767ac133ec6b1fe6dc900e
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.8.9@sha256:4714cd679a0c045e918483bcc9338ca6e2b4e377fd07e7022067d8dd778159af
+          image: ghcr.io/mitchross/deal-scout-worker:v0.8.11@sha256:b4b2ae50d178f47e127890ca69df4d49e6f261f76ec87b0c2e410657d36a9d88
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.8.11.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.8.11`.