### PR TITLE
deal-scout: v0.8.13

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.8.9@sha256:3594e7b685d9ab3b5c620c2d52d4b1af6def9ce46888ec04f9364bfdd60e7795
+          image: ghcr.io/mitchross/deal-scout:v0.8.13@sha256:022e31af0bbee42e5aaa0d8ab148e70c916d63eaab747b1749c04c9f5f3a4b9d
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.8.9@sha256:4714cd679a0c045e918483bcc9338ca6e2b4e377fd07e7022067d8dd778159af
+          image: ghcr.io/mitchross/deal-scout-worker:v0.8.13@sha256:8c6fada639060f913be71c9993c3bb64773098ededa2d7e0fb86de590b5b9fcb
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.8.13.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.8.13`.