### PR TITLE
kopiur: allow a declared operator-owned PVC to skip restore-before-bind

### DIFF
--- a/my-apps/development/kafka/kopiur/kafka-data.yaml
+++ b/my-apps/development/kafka/kopiur/kafka-data.yaml
@@ -9,6 +9,17 @@ metadata:
   namespace: kafka
   annotations:
     argocd.argoproj.io/sync-wave: "-3"
+    # Strimzi creates this PVC from the Kafka CR's storage block, so it is never
+    # rendered and cannot carry a dataSourceRef. Combined with the deliberate
+    # "no Restore CR" decision below, that tripped the [dsr] hard failure and
+    # blocked every PR in the repo. Declared rather than silenced.
+    storage.vanillax.dev/operator-owned-pvc: "true"
+    storage.vanillax.dev/no-restore-before-bind-reason: >-
+      Strimzi owns the claim; this dev log is disposable, so a rebuild starts on
+      an empty volume rather than gating wave 0 on a restore. Backups still run
+      and DR is a manual restore. Re-adding restore-before-bind needs a mover
+      that can WRITE the archived tree - the 1001:0 mover could read it for
+      backup but not recreate it, which wedged the old restore gate.
 spec:
   sources:
     - pvc:

--- a/scripts/validate-kopiur-coverage.py
+++ b/scripts/validate-kopiur-coverage.py
@@ -41,6 +41,17 @@ REPO_LABEL = "kopiur.home-operations.com/repo"
 REPO_LABEL_VAL = "cluster-kopia"
 EXEMPT_LABEL = "backup-exempt"
 EXEMPT_REASON = "storage.vanillax.dev/backup-exempt-reason"
+# Deliberate opt-out from restore-before-bind, for a PVC an OPERATOR creates.
+# Strimzi builds data-0-dev-kafka-dual-role-0 from the Kafka CR's storage block,
+# so it is never rendered and cannot carry a dataSourceRef; the kafka bundle
+# also declines a Restore CR on purpose (its 1001:0 mover can read the tree for
+# backup but not recreate it, which wedged the old restore gate). Backups still
+# run; DR for that volume is a documented manual step.
+#
+# Annotated, not silent: the [dsr] rule stays a hard failure for anyone who has
+# not written down the decision, exactly like backup-exempt.
+OPERATOR_PVC_ANN = "storage.vanillax.dev/operator-owned-pvc"
+OPERATOR_PVC_REASON = "storage.vanillax.dev/no-restore-before-bind-reason"
 SYSTEM_NS = {
     "kube-system", "argocd", "longhorn-system", "kopiur-system", "cert-manager",
     "external-secrets", "kube-node-lease", "kube-public", "monitoring", "gateway",
@@ -122,7 +133,21 @@ def main():
             pvc = pvcs.get((pns, pvcname))
             if pvc is None:
                 direct = direct_restore_pvcs.get((pns, pvcname, pname))
-                if direct is None:
+                panns = anns_of(p)
+                if direct is None and panns.get(OPERATOR_PVC_ANN) == "true":
+                    if not panns.get(OPERATOR_PVC_REASON):
+                        warns.append(
+                            f"[dsr]     SnapshotPolicy {pns}/{pname} declares "
+                            f"{OPERATOR_PVC_ANN} but no {OPERATOR_PVC_REASON} "
+                            "annotation — record why DR is manual here"
+                        )
+                    else:
+                        warns.append(
+                            f"[dsr]     SnapshotPolicy {pns}/{pname} backs up "
+                            f"operator-owned PVC '{pvcname}' with no "
+                            "restore-before-bind — DR is a manual step by decision"
+                        )
+                elif direct is None:
                     fails.append(
                         f"[dsr]     SnapshotPolicy {pns}/{pname} backs up PVC "
                         f"'{pvcname}' but neither that PVC nor a matching "


### PR DESCRIPTION
## Why every PR is red

`main` is red too. The `[dsr]` rule requires a backed-up PVC to be either **rendered** or covered by a matching `Restore.target.pvc`. `kafka/kafka-data` is neither — and both halves are intentional:

- **Strimzi owns the claim.** `data-0-dev-kafka-dual-role-0` is created from the Kafka CR's `storage:` block, so it never appears in rendered manifests and cannot carry a `dataSourceRef`.
- **The bundle deliberately ships no Restore CR.** Its own comment says why: the `1001:0` mover can *read* the tree for backup but not recreate it, which wedged the old restore gate, and this dev log is treated as disposable.

So this is a **validator-vs-design conflict**, not a broken app.

## What changed

An explicit opt-out on the SnapshotPolicy, mirroring how `backup-exempt` already works:

```yaml
storage.vanillax.dev/operator-owned-pvc: "true"
storage.vanillax.dev/no-restore-before-bind-reason: >-
  Strimzi owns the claim; this dev log is disposable...
```

Declared, not silenced — the reason lives on the policy itself, and it downgrades to a **warning** rather than vanishing, so the tradeoff stays visible in every CI run.

## The rule keeps its teeth

All three paths verified:

| Case | Result |
|---|---|
| Policy with an unrendered PVC and **no** annotation | **HARD FAIL** (unchanged) |
| Annotation present, reason missing | WARN — "record why DR is manual here" |
| kafka (annotation + reason) | WARN — "DR is a manual step by decision" |

Full-repo render: **31 policies, 63 PVCs, 0 failures.**

## Not included

The Kafka broker is separately crash-looping on `Invalid cluster.id` — the CR was recreated at 05:58Z today while the PVC dates from Aug 3. That is a runtime data issue, handled separately from this CI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7CB3ozWPCw1iuSLjmenKe