### PR TITLE
deal-scout: v0.9.0

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.8.13@sha256:022e31af0bbee42e5aaa0d8ab148e70c916d63eaab747b1749c04c9f5f3a4b9d
+          image: ghcr.io/mitchross/deal-scout:v0.9.0@sha256:bf7067438b725ec23959f66462c91922762911feab91d4e3328de889d9dc1fdd
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.8.13@sha256:8c6fada639060f913be71c9993c3bb64773098ededa2d7e0fb86de590b5b9fcb
+          image: ghcr.io/mitchross/deal-scout-worker:v0.9.0@sha256:6414b51a75885c334c0eab67a9ec4a1689d16ef4ab807c0cc529cd6c3354f938
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
v0.9.0 — minor release

### Changes
- **minipcs.zip feed** — new REST adapter, ~4000 listings with 3DMark benchmarks
- **Value scoring** — cpuMark/\$ ranking with barebones penalty
- **Benchmark enrichment** — cpuMark/gpuMark lookup for all sources
- **Walmart scraper** — CDP-based, 9 search queries, multiline price parsing

### Images
- `ghcr.io/mitchross/deal-scout:v0.9.0@sha256:bf7067438b725ec23959f66462c91922762911feab91d4e3328de889d9dc1fdd`
- `ghcr.io/mitchross/deal-scout-worker:v0.9.0@sha256:6414b51a75885c334c0eab67a9ec4a1689d16ef4ab807c0cc529cd6c3354f938`