### PR TITLE
deal-scout: v0.10.0

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.9.0@sha256:bf7067438b725ec23959f66462c91922762911feab91d4e3328de889d9dc1fdd
+          image: ghcr.io/mitchross/deal-scout:v0.10.0@sha256:c45549a631fdf88a86da5cf832ece835996c8555c465e6d8180b62e9be25fd21
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.9.0@sha256:6414b51a75885c334c0eab67a9ec4a1689d16ef4ab807c0cc529cd6c3354f938
+          image: ghcr.io/mitchross/deal-scout-worker:v0.10.0@sha256:c8d2cdbbb13ee55bbbde892ad4b76ee8d37e4e9d2b472da7f25b7f3e4ad7c0eb
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
v0.10.0 — market-researched steal thresholds + 3-lane search

### Classification
- New CPU class: `intel_12_13_sff` (i5-12500/13500 non-T desktop SFF)
- CPU gates updated from live eBay sold anchors:
  - intel_t_10_11: \$250→\$175 (10500T mini 16GB steal)
  - intel_tiger_u: \$250→\$150 (NUC11 i5 steal)
  - ryzen_ge_4000: \$275→\$200 (4650GE/4750GE with 16GB)
  - ryzen_ge_5000: \$325→\$300 (5650GE/5750GE)
  - intel_t_12: \$300→\$275 (12500T mini)
  - ryzen_mobile: \$350→\$375 (7735HS \$325-350, 7840HS \$400-450)
- Base thresholds tightened: base16 \$220→\$175, base32 \$300→\$275
- Lapnode gates: \$150→\$125 steal (broken-screen ThinkPad)

### Search
- 31 eBay queries across 3 lanes (SFF DDR4, Mini/Tiny, Modern mini)
- 12 Walmart queries with SFF and Ryzen targets
- Lapnode (broken-screen ThinkPad) and bulk lot queries

### Images
- `ghcr.io/mitchross/deal-scout:v0.10.0@sha256:c45549a…`
- `ghcr.io/mitchross/deal-scout-worker:v0.10.0@sha256:c8d2cdb…`