### PR TITLE
kopiur: let epoch advance so index blobs actually compact

### DIFF
--- a/infrastructure/controllers/kopiur/clusterrepository.yaml
+++ b/infrastructure/controllers/kopiur/clusterrepository.yaml
@@ -7,9 +7,10 @@
 # VolSync repo at s3://volsync-kopia/cluster. So the proven backup path is
 # untouched, and karakeep's first kopiur snapshot captures its CURRENT data.
 #
-# ⚠️ ACCESS: confirm the rustfs workload key (rustfs-workload-access-key) has
-# read/write on the `kopiur` bucket — the existing policy may scope it to
-# volsync-kopia only. If denied, widen the RustFS bucket policy (or use admin creds).
+# ACCESS: the rustfs workload key has full head/list/put/delete on the `kopiur`
+# bucket — verified against the live endpoint, so do NOT re-litigate bucket
+# policy when this repo misbehaves. A slow or hanging connect here is index-blob
+# bloat (see bootstrap.failurePolicy below), never a 403.
 # Endpoint is the S3 API port :30292 (NOT the console :30293).
 #
 # Field shapes confirmed vs deploy/examples/backends/s3-minio-http.yaml:
@@ -43,6 +44,23 @@ spec:
       key: KOPIA_PASSWORD
   create:
     enabled: true
+  parameters:
+    epoch:
+      # Maintenance runs on schedule and reclaims 0 bytes because compaction is
+      # gated on epoch advance: an epoch cannot close before minDuration, and
+      # compaction trails two epochs behind — 48h at kopia's 24h default. This
+      # repo generates index blobs faster than that, so the count only ever
+      # grows (2045 and climbing). 6h puts compaction ~12h behind instead.
+      minDuration: 6h
+  # Opening this repo takes ~90s — kopia merges ~2000 content-index blobs on
+  # every connect — against the 120s default deadline. A connect that crosses
+  # the deadline is killed, which fails the health probe, trips the circuit
+  # breaker, and moves the repo to Degraded; Degraded then blocks the very
+  # maintenance that would compact the index, so each cycle makes the next
+  # connect slower. Keep this headroom until maintenance has the index down.
+  bootstrap:
+    failurePolicy:
+      activeDeadlineSeconds: 600
   # No credentialProjection: the kopiur-rustfs Secret is delivered to every
   # consumer namespace by the ClusterExternalSecret (see externalsecret.yaml),
   # so the operator needs no cluster-wide secrets-write RBAC.


### PR DESCRIPTION
Maintenance has been running on schedule and reclaiming 0 bytes, while content-index blobs climbed past the 1000 warn threshold to 2045. The cause is kopia's epoch-advance gate, not a blocked or deferred maintenance run: an epoch cannot close before parameters.epoch.minDuration, and compaction trails two epochs behind it. At kopia's 24h default that is a 48h lag, and this repo produces index blobs faster than it can clear them, so the count only grows.

Set minDuration to 6h, putting compaction roughly 12h behind instead.

Also raise the bootstrap connect deadline. Opening the repo currently takes ~90s (kopia merges all index blobs on connect) against the 120s default. Connects that cross the deadline are killed, which fails the health probe, trips the circuit breaker and moves the repo to Degraded — which in turn pauses backups until the next successful connect. The headroom keeps that from flapping while the index is still large; it can come back down once it is compacted.

The circuit breaker is deliberately left on (health.probe.onFailure stays Degrade). Switching it to Alert would silence the flapping without addressing the cause, and the probe is the only sensor for a wiped or unreachable backend.

Strike the bucket-policy warning: the workload key was verified against the live endpoint with head/list/put/delete all succeeding, and a full recursive walk completes. Slow connects here are index bloat, never a 403.


Claude-Session: https://claude.ai/code/session_01355s3vVbPnNcn3MvXvsQ7i