### PR TITLE
docs: the restore drill must delete the Restore CR, not just the PVC

### DIFF
--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -292,14 +292,36 @@ PVC: its `kopiur/restore-canary-data.yaml` stub carries the `SnapshotPolicy` +
 The `SnapshotSchedule` keeps a fresh snapshot and a weekly quick verification
 checks repository blobs. Those automated checks do **not** prove a restore. To
 drill the full path, write and hash a sentinel, force and wait for a successful
-snapshot, delete only the canary PVC, and let Argo recreate it via its
-`dataSourceRef` → `Restore` populator:
+snapshot, delete the canary PVC **and its `Restore` CR**, and let Argo recreate
+both so the populator re-hydrates the PVC:
 
 ```
-sentinel (old UID + sha256) → forced kopiur Snapshot
-→ delete ONLY the canary PVC → Git/Argo recreate with dataSourceRef → Restore
+sentinel (new UID + sha256) → forced kopiur Snapshot
+→ delete the canary PVC AND restore-canary-data-restore
+→ Git/Argo recreate both → Restore re-resolves to the new snapshot
 → kopiur populator restore → byte-identical verification
 ```
+
+**Delete the `Restore` CR too — the drill is invalid without it.** A `Restore`
+resolves its source **once, at admission, and never re-resolves**
+(`status.resolved` is pinned; `offset: 0` means "latest as of admission", not
+"latest now"). Delete only the PVC and the populator replays whatever snapshot
+the `Restore` pinned on first use, so the drill reports `RestoreSucceeded`
+against frozen data regardless of whether backups work. Every drill between
+2026-08-03 and 2026-08-13 restored a 2026-06-10 sentinel this way and still
+passed its own success check.
+
+Gate the verdict on the pin before the bytes:
+
+```
+kubectl -n restore-canary get restore restore-canary-data-restore \
+  -o jsonpath='{.status.resolved.pinnedAt} {.status.resolved.kopiaSnapshotID}'
+```
+
+`pinnedAt` must be newer than the drill snapshot. A healthy drill moves
+`Pending → Restoring → Bound`; a PVC that binds instantly never ran the
+populator, and a `TargetAlreadyBound` reason means the `Restore` short-circuited
+because the PVC still existed.
 
 A manually executed passing drill proves the *entire* chain — Git render, kopiur CR wiring,
 kopia round-trip, populator restore — with data integrity checked by hash,

--- a/my-apps/system/restore-canary/README.md
+++ b/my-apps/system/restore-canary/README.md
@@ -7,10 +7,26 @@ drill is intentionally operator-triggered; it is not honest to call the daily
 snapshot itself continuous restore proof.
 
 - **Drill**: write and hash a sentinel, force/wait for a successful snapshot,
-  delete only the `restore-canary-data` PVC, let Argo recreate it, then verify
-  the restored sentinel byte-for-byte. Record the result using the namespace
-  annotations documented in the DR runbook. The old VolSync-specific helper
-  was removed; do not reuse it for kopiur.
+  delete the `restore-canary-data` PVC **and the `restore-canary-data-restore`
+  Restore CR**, let Argo recreate both, then verify the restored sentinel
+  byte-for-byte. Record the result using the namespace annotations documented in
+  the DR runbook. The old VolSync-specific helper was removed; do not reuse it
+  for kopiur.
+- **Deleting the Restore CR is mandatory, not optional.** A `Restore` resolves
+  its source **once, at admission, and never re-resolves** — `offset: 0` means
+  "latest as of admission", not "latest now". Delete only the PVC and the
+  populator re-hydrates from whatever snapshot the Restore pinned the first time
+  it ran, so the drill replays a frozen snapshot and passes no matter how
+  broken (or healthy) backups actually are. This silently invalidated every
+  drill between 2026-08-03 and 2026-08-13, which restored a 2026-06-10 sentinel
+  while reporting `RestoreSucceeded`.
+- **Gate the verdict on the pin, not just the bytes.** Before trusting a PASS,
+  confirm the Restore re-resolved to the snapshot you just took:
+  `kubectl -n restore-canary get restore restore-canary-data-restore \
+  -o jsonpath='{.status.resolved.pinnedAt} {.status.resolved.kopiaSnapshotID}'`
+  A `pinnedAt` older than the drill snapshot means the result is meaningless.
+  A healthy drill goes `Pending -> Restoring -> Bound`; a PVC that binds
+  instantly never ran the populator.
 - **Full documentation**: `docs/disaster-recovery.md` (what it proves, what it
   does not, bootstrap procedure, failure interpretation, cleanup).
 - **Hard rule**: destructive actions are scoped to namespace `restore-canary`


### PR DESCRIPTION
## The bug

The documented DR drill said to **delete only the canary PVC**. That makes the drill unfalsifiable.

A kopiur `Restore` resolves its source **once, at admission, and never re-resolves** — `status.resolved` is pinned, so `fromPolicy.offset: 0` means *"latest as of admission"*, not *"latest now"*.

Leave the `Restore` CR in place and the populator re-hydrates from whatever snapshot it pinned the first time it ran. The drill then replays frozen data and reports `RestoreSucceeded` whether backups are perfectly healthy or completely broken. **It cannot fail, which means it also cannot pass.**

Every drill between 2026-08-03 and 2026-08-13 restored a **2026-06-10** sentinel this way while passing its own success check.

## Verified fix

Re-ran the drill deleting both the PVC and the `Restore` CR:

```
Restore recreated  -> unpinned (TargetAlreadyBound while old PVC existed)
PVC deleted        -> Longhorn volume destroyed (reclaim: Delete)
new PVC            -> Pending -> Restoring -> Bound
Restore re-pinned  -> 69606fe751bf0bff4250060bbf4901d8  (the drill snapshot)
sentinel           -> byte-identical, sha256 matched
```

## Changes

- Drill procedure now deletes the PVC **and** `restore-canary-data-restore`
- Documents *why* it is mandatory, so it does not get "simplified" back
- Adds a pin check to gate the verdict before trusting the bytes:
  ```
  kubectl -n restore-canary get restore restore-canary-data-restore \
    -o jsonpath='{.status.resolved.pinnedAt} {.status.resolved.kopiaSnapshotID}'
  ```
- Notes the healthy state transition (`Pending → Restoring → Bound`); a PVC that binds instantly never ran the populator, and `TargetAlreadyBound` means the Restore short-circuited

Docs only — no manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01355s3vVbPnNcn3MvXvsQ7i