### PR TITLE
fix(talos): reconcile VXLAN checksum offload after rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Network
 | **ArgoCD not syncing** | `kubectl get applicationsets -n argocd` · `kubectl describe applicationset infrastructure -n argocd` · check for stale operations before reverting Git: `kubectl get application argocd -n argocd -o yaml` |
 | **Cilium issues** | `cilium status` · `kubectl logs -n kube-system -l k8s-app=cilium` · `cilium connectivity test` |
 | **Storage issues** | `kubectl get pvc -A` · `kubectl get pods -n longhorn-system` |
+| **Longhorn manager crashlooping on the webhook / every PVC Pending** | Check cross-node pod networking first: `kubectl exec -n kube-system <cilium-pod> -c cilium-agent -- cilium-health status`. `Node 1/1` with `Endpoints 0/1` means the pod overlay is broken to that node, not Longhorn — see [Wi-Fi worker: VXLAN overlay failure](docs/domains/networking/wifi-proxmox-talos-worker.md#known-failure-pod-overlay-vxlan-does-not-cross-the-wi-fi-bridge) |
 | **Secrets not syncing** | `kubectl get externalsecret -A` · `kubectl get pods -n 1passwordconnect` · `kubectl describe clustersecretstore 1password` |
 | **GPU issues** | `kubectl get nodes -l feature.node.kubernetes.io/pci-0300_10de.present=true` · `kubectl get pods -n gpu-operator` |
 | **Backup issues** | `kubectl -n <ns> get snapshotpolicy,snapshotschedule,restore,snapshot` (Snapshot should reach `Succeeded` with non-zero files) · `kubectl -n <ns> get secret kopiur-rustfs` · `kubectl get pods -n kopiur-system` |

--- a/docs/domains/networking/wifi-proxmox-talos-worker.md
+++ b/docs/domains/networking/wifi-proxmox-talos-worker.md
@@ -140,132 +140,39 @@ replacement; do not combine it into a blind template sync.
   not restore NVIDIA passthrough unless the extra idle power is intentionally
   accepted.
 
-## Known failure: pod overlay (VXLAN) does not cross the Wi-Fi bridge
+## Known failure: nodes are Ready, but pods cannot cross nodes
 
-**Observed 2026-08-14, on the clean-slate rebuild of `talos-threadripper-gpu-workers`.**
+After a clean rebuild, all four nodes can be `Ready` while Longhorn managers
+crashloop and new PVCs remain `Pending`. `Ready` only proves that the nodes can
+reach Kubernetes; it does not prove that pods can reach pods on other nodes.
 
-The Dell worker joins the cluster, reports `Ready`, and is reachable at
-`192.168.10.119` — but **no pod on it can talk to a pod on any other node**.
-Node-to-node L3 works; the Cilium VXLAN overlay does not survive the AX86U
-media bridge.
-
-### Symptom
-
-Longhorn never finishes bootstrapping. `longhorn-manager` on the Dell node
-crashloops with:
-
-```
-level=fatal msg="Error starting webhooks: admission webhook service is not
-accessible on cluster after 2m0s sec: timed out waiting for endpoint
-https://longhorn-admission-webhook.longhorn-system.svc:9502/v1/healthz"
-```
-
-and earlier, DNS itself times out from that pod:
-
-```
-dial tcp: lookup longhorn-admission-webhook.longhorn-system.svc on 10.96.0.10:53:
-read udp 10.244.3.201:37863->10.96.0.10:53: i/o timeout
-```
-
-The tell is that this **flips with webhook leadership**. `longhorn-admission-webhook`
-is served by a `longhorn-manager` pod, so:
-
-- webhook lands on the Dell pod → the three Threadripper managers time out
-- webhook lands on a Threadripper pod → the Dell manager times out
-
-Whoever is co-located with the webhook works. That symmetry rules out a
-Longhorn bug and points squarely at cross-node pod networking.
-
-Downstream, every PVC stays `Pending`, so most of the cluster sits unschedulable
-with `pod has unbound immediate PersistentVolumeClaims`.
-
-### Diagnosis (one command)
+Check Cilium from an agent pod:
 
 ```bash
-kubectl exec -n kube-system <cilium-pod-on-dell> -c cilium-agent -- cilium-health status
+kubectl exec -n kube-system <cilium-pod> -- cilium-health status --probe
 ```
 
-```
-Cluster health:                     1/4 reachable
-Name                                IP               Node   Endpoints
-  ...dell-workers-... (localhost)   192.168.10.119   1/1    1/1
-  ...control-planes-...             192.168.10.139   1/1    0/1
-  ...gpu-workers-...                192.168.10.177   1/1    0/1
-  ...workers-...                    192.168.10.166   1/1    0/1
-```
+`Node 1/1` with `Endpoints 0/1` means the normal network works but the pod
+overlay does not. In the 2026-08-14 rebuild, the cause was a virtio checksum
+offload bug—not the AX86U bridge, MTU, Cilium state, or the Dell's dedicated
+2.5 GbE card.
 
-**`Node 1/1` with `Endpoints 0/1` is the signature.** The node IP is reachable;
-the overlay path to pods on that node is not. If both columns were `0/1` this
-would be ordinary L3 loss and a different problem.
+Keep both offload guards in the cluster-level Talos `EthernetConfig`:
 
-### What the evidence actually shows
-
-Packet capture on both ends (`talosctl pcap -i eth0`, 25 s, taken 2026-08-14)
-disproves the simple "the bridge blocks VXLAN" reading:
-
-```
-DELL eth0 (192.168.10.119) — VXLAN packets
-   109  192.168.10.177 -> 192.168.10.119
-   107  192.168.10.119 -> 192.168.10.177     <- flowing BOTH ways
-     1  192.168.10.166 -> 192.168.10.119
-     1  192.168.10.139 -> 192.168.10.119
+```yaml
+apiVersion: v1alpha1
+kind: EthernetConfig
+name: eth0
+features:
+  tx-checksum-ip-generic: false
+  tx-udp_tnl-csum-segmentation: false
 ```
 
-VXLAN is on the wire in both directions between the Dell node and `.177`.
-Packets arrive and are still not usable — so the traffic is being dropped
-*after* decapsulation, not filtered on the link.
+An unchanged template sync may do nothing because Omni already considers the
+config current. Adding the second guard produced a real config change and made
+Talos re-apply the settings. It did not visibly reboot the nodes.
 
-Two hypotheses are ruled out by this:
-
-- **Not MTU.** DNS queries (~70 bytes) and `cilium-health` probes time out.
-  MTU problems let small packets through and break large ones. A TCP connect
-  timing out on a 60-byte SYN is not an MTU symptom.
-- **Not stale Cilium state.** `cilium-dbg node list` on the Dell node lists all
-  four nodes with correct pod CIDRs and node IPs, identical to the view from a
-  Threadripper node.
-
-### The asymmetry worth chasing
-
-`tx-checksum-ip-generic` on `eth0`, read from `talosctl get ethernetstatus`:
-
-| Node | Setting |
-| --- | --- |
-| `192.168.10.119` (Dell) | **off** |
-| `192.168.10.166` (workers) | **on** |
-| `192.168.10.177` (gpu-workers) | **on** |
-| `192.168.10.139` (control-plane) | **on** |
-
-The cluster-scoped `vxlan-inner-checksum` patch sets this to `false`, so it
-should be **off on all four**. It is off on exactly one. Three nodes are
-transmitting VXLAN under precisely the condition the patch exists to avoid,
-which fits packets arriving and then being discarded.
-
-**Unconfirmed:** why the patch took on one node and not the others. Reading the
-running machine config to prove it (`talosctl get machineconfig`) returned
-nothing in this Talos version, so the delivery path was never verified — only
-the resulting state. Establish that before changing anything.
-
-This also fits the strongest piece of evidence: **the same topology worked
-before the cluster was rebuilt.** That points at configuration drift introduced
-during reprovisioning, not at the Wi-Fi link being fundamentally unsuitable.
-
-### Options
-
-- **First, explain the asymmetry.** Confirm whether the `EthernetConfig`
-  document reached the three Threadripper nodes at all. If it did not, that is
-  the bug, and it is a config-delivery problem rather than a network one.
-- **Do not reach for an MTU change.** It does not match the symptom, and it is
-  architectural churn against a topology with a working history.
-- **Making the Dell node compute-only does not fix this.** Pods on it still
-  cannot reach pods elsewhere; it only avoids putting Longhorn replicas across
-  Wi-Fi.
-- **Wired Ethernet for the Dell host** remains the durable answer, but the
-  evidence above says something regressed in the rebuild — find that first.
-
-### Do not
-
-- Do not keep restarting `longhorn-manager`. It will crashloop indefinitely,
-  because the webhook it needs is unreachable by design of the current network.
-- Do not raise Longhorn replica counts to "heal" the volumes. That puts
-  synchronous replication across Wi-Fi, which the rollout notes already warn
-  against.
+Success means Cilium reports `4/4 reachable`, including every endpoint, and all
+Longhorn managers return to `2/2 Running`. Let existing CrashLoop backoff expire;
+do not keep restarting Longhorn, change MTU, or redesign the bridge for this
+symptom.

--- a/docs/domains/networking/wifi-proxmox-talos-worker.md
+++ b/docs/domains/networking/wifi-proxmox-talos-worker.md
@@ -198,36 +198,69 @@ Name                                IP               Node   Endpoints
 the overlay path to pods on that node is not. If both columns were `0/1` this
 would be ordinary L3 loss and a different problem.
 
-### Cause (candidates, unverified)
+### What the evidence actually shows
 
-The bridge passes plain unicast but not the VXLAN-encapsulated pod traffic on
-UDP 8472. Most likely one of:
+Packet capture on both ends (`talosctl pcap -i eth0`, 25 s, taken 2026-08-14)
+disproves the simple "the bridge blocks VXLAN" reading:
 
-1. **MTU.** Cilium derives the tunnel MTU from the device (1500 → 1450). If the
-   Wi-Fi path has a smaller effective MTU, large encapsulated frames vanish
-   silently. Small packets may still get through, which fits DNS sometimes
-   answering and sometimes not.
-2. **The AX86U L3 filter.** Its filter only forwards inbound unicast for
-   *learned* bindings — see the static-address rationale in the
-   `dell-proxmox-worker` patch. VXLAN arriving for the node may not match a
-   learned binding.
-3. **Checksum offload.** The cluster-level `vxlan-inner-checksum` patch sets
-   `tx-checksum-ip-generic: false` on `eth0`. The Dell node *does* use `eth0`,
-   so the patch applies — but it has not been confirmed effective across the
-   bridge.
+```
+DELL eth0 (192.168.10.119) — VXLAN packets
+   109  192.168.10.177 -> 192.168.10.119
+   107  192.168.10.119 -> 192.168.10.177     <- flowing BOTH ways
+     1  192.168.10.166 -> 192.168.10.119
+     1  192.168.10.139 -> 192.168.10.119
+```
+
+VXLAN is on the wire in both directions between the Dell node and `.177`.
+Packets arrive and are still not usable — so the traffic is being dropped
+*after* decapsulation, not filtered on the link.
+
+Two hypotheses are ruled out by this:
+
+- **Not MTU.** DNS queries (~70 bytes) and `cilium-health` probes time out.
+  MTU problems let small packets through and break large ones. A TCP connect
+  timing out on a 60-byte SYN is not an MTU symptom.
+- **Not stale Cilium state.** `cilium-dbg node list` on the Dell node lists all
+  four nodes with correct pod CIDRs and node IPs, identical to the view from a
+  Threadripper node.
+
+### The asymmetry worth chasing
+
+`tx-checksum-ip-generic` on `eth0`, read from `talosctl get ethernetstatus`:
+
+| Node | Setting |
+| --- | --- |
+| `192.168.10.119` (Dell) | **off** |
+| `192.168.10.166` (workers) | **on** |
+| `192.168.10.177` (gpu-workers) | **on** |
+| `192.168.10.139` (control-plane) | **on** |
+
+The cluster-scoped `vxlan-inner-checksum` patch sets this to `false`, so it
+should be **off on all four**. It is off on exactly one. Three nodes are
+transmitting VXLAN under precisely the condition the patch exists to avoid,
+which fits packets arriving and then being discarded.
+
+**Unconfirmed:** why the patch took on one node and not the others. Reading the
+running machine config to prove it (`talosctl get machineconfig`) returned
+nothing in this Talos version, so the delivery path was never verified — only
+the resulting state. Establish that before changing anything.
+
+This also fits the strongest piece of evidence: **the same topology worked
+before the cluster was rebuilt.** That points at configuration drift introduced
+during reprovisioning, not at the Wi-Fi link being fundamentally unsuitable.
 
 ### Options
 
-- **Lower the MTU** cluster-wide or per-node until it fits the Wi-Fi path, and
-  re-check `cilium-health status`. Cheapest thing to try first.
-- **Make the Dell node compute-only** and keep Longhorn replicas off it — the
-  direction already sketched in
-  `docs/superpowers/plans/2026-08-10-dell-longhorn-compute-only.md`. Note this
-  does **not** fix the underlying problem: any pod on the Dell node still cannot
-  reach pods elsewhere, so it only helps if nothing scheduled there needs
-  cross-node pod traffic.
-- **Get the Dell host onto wired Ethernet.** The reliable fix. Everything above
-  is working around a link that was never meant to carry an overlay.
+- **First, explain the asymmetry.** Confirm whether the `EthernetConfig`
+  document reached the three Threadripper nodes at all. If it did not, that is
+  the bug, and it is a config-delivery problem rather than a network one.
+- **Do not reach for an MTU change.** It does not match the symptom, and it is
+  architectural churn against a topology with a working history.
+- **Making the Dell node compute-only does not fix this.** Pods on it still
+  cannot reach pods elsewhere; it only avoids putting Longhorn replicas across
+  Wi-Fi.
+- **Wired Ethernet for the Dell host** remains the durable answer, but the
+  evidence above says something regressed in the rebuild — find that first.
 
 ### Do not
 

--- a/docs/domains/networking/wifi-proxmox-talos-worker.md
+++ b/docs/domains/networking/wifi-proxmox-talos-worker.md
@@ -139,3 +139,100 @@ replacement; do not combine it into a blind template sync.
 - Roll back by restoring the old MachineSet and machine class from Git, but do
   not restore NVIDIA passthrough unless the extra idle power is intentionally
   accepted.
+
+## Known failure: pod overlay (VXLAN) does not cross the Wi-Fi bridge
+
+**Observed 2026-08-14, on the clean-slate rebuild of `talos-threadripper-gpu-workers`.**
+
+The Dell worker joins the cluster, reports `Ready`, and is reachable at
+`192.168.10.119` — but **no pod on it can talk to a pod on any other node**.
+Node-to-node L3 works; the Cilium VXLAN overlay does not survive the AX86U
+media bridge.
+
+### Symptom
+
+Longhorn never finishes bootstrapping. `longhorn-manager` on the Dell node
+crashloops with:
+
+```
+level=fatal msg="Error starting webhooks: admission webhook service is not
+accessible on cluster after 2m0s sec: timed out waiting for endpoint
+https://longhorn-admission-webhook.longhorn-system.svc:9502/v1/healthz"
+```
+
+and earlier, DNS itself times out from that pod:
+
+```
+dial tcp: lookup longhorn-admission-webhook.longhorn-system.svc on 10.96.0.10:53:
+read udp 10.244.3.201:37863->10.96.0.10:53: i/o timeout
+```
+
+The tell is that this **flips with webhook leadership**. `longhorn-admission-webhook`
+is served by a `longhorn-manager` pod, so:
+
+- webhook lands on the Dell pod → the three Threadripper managers time out
+- webhook lands on a Threadripper pod → the Dell manager times out
+
+Whoever is co-located with the webhook works. That symmetry rules out a
+Longhorn bug and points squarely at cross-node pod networking.
+
+Downstream, every PVC stays `Pending`, so most of the cluster sits unschedulable
+with `pod has unbound immediate PersistentVolumeClaims`.
+
+### Diagnosis (one command)
+
+```bash
+kubectl exec -n kube-system <cilium-pod-on-dell> -c cilium-agent -- cilium-health status
+```
+
+```
+Cluster health:                     1/4 reachable
+Name                                IP               Node   Endpoints
+  ...dell-workers-... (localhost)   192.168.10.119   1/1    1/1
+  ...control-planes-...             192.168.10.139   1/1    0/1
+  ...gpu-workers-...                192.168.10.177   1/1    0/1
+  ...workers-...                    192.168.10.166   1/1    0/1
+```
+
+**`Node 1/1` with `Endpoints 0/1` is the signature.** The node IP is reachable;
+the overlay path to pods on that node is not. If both columns were `0/1` this
+would be ordinary L3 loss and a different problem.
+
+### Cause (candidates, unverified)
+
+The bridge passes plain unicast but not the VXLAN-encapsulated pod traffic on
+UDP 8472. Most likely one of:
+
+1. **MTU.** Cilium derives the tunnel MTU from the device (1500 → 1450). If the
+   Wi-Fi path has a smaller effective MTU, large encapsulated frames vanish
+   silently. Small packets may still get through, which fits DNS sometimes
+   answering and sometimes not.
+2. **The AX86U L3 filter.** Its filter only forwards inbound unicast for
+   *learned* bindings — see the static-address rationale in the
+   `dell-proxmox-worker` patch. VXLAN arriving for the node may not match a
+   learned binding.
+3. **Checksum offload.** The cluster-level `vxlan-inner-checksum` patch sets
+   `tx-checksum-ip-generic: false` on `eth0`. The Dell node *does* use `eth0`,
+   so the patch applies — but it has not been confirmed effective across the
+   bridge.
+
+### Options
+
+- **Lower the MTU** cluster-wide or per-node until it fits the Wi-Fi path, and
+  re-check `cilium-health status`. Cheapest thing to try first.
+- **Make the Dell node compute-only** and keep Longhorn replicas off it — the
+  direction already sketched in
+  `docs/superpowers/plans/2026-08-10-dell-longhorn-compute-only.md`. Note this
+  does **not** fix the underlying problem: any pod on the Dell node still cannot
+  reach pods elsewhere, so it only helps if nothing scheduled there needs
+  cross-node pod traffic.
+- **Get the Dell host onto wired Ethernet.** The reliable fix. Everything above
+  is working around a link that was never meant to carry an overlay.
+
+### Do not
+
+- Do not keep restarting `longhorn-manager`. It will crashloop indefinitely,
+  because the webhook it needs is unreachable by design of the current network.
+- Do not raise Longhorn replica counts to "heal" the volumes. That puts
+  synchronous replication across Wi-Fi, which the rollout notes already warn
+  against.

--- a/omni/cluster-template/cluster-template-threadripper-gpu-workers.yaml
+++ b/omni/cluster-template/cluster-template-threadripper-gpu-workers.yaml
@@ -42,6 +42,7 @@ patches:
     name: eth0
     features:
       tx-checksum-ip-generic: false
+      tx-udp_tnl-csum-segmentation: false
 - file: patches/docker-hub-auth.yaml
 - name: node-performance
   inline:


### PR DESCRIPTION
## Problem

After a clean rebuild, every node was Kubernetes Ready and Omni reported current machine configs, but cross-node pod TCP to the Dell worker failed. Longhorn managers crashlooped and new PVCs remained Pending.

## Verified cause

- Cilium showed node IP 1/1 but endpoint 0/1 across the Dell boundary.
- UDP 8472 VXLAN flowed in both directions, ruling out the AX86U bridge as a link filter.
- A controlled cross-node TCP request timed out while Dell Tcp InCsumErrors increased.
- Talos runtime had checksum offload enabled on the three Threadripper virtio interfaces despite the existing cluster EthernetConfig being present in every rendered Omni machine patch.

This was checksum-offload drift after initial provisioning, not MTU, stale Cilium state, the dedicated Dell 2.5 GbE card, or Longhorn itself.

## Fix

Keep tx-checksum-ip-generic disabled and also disable tx-udp_tnl-csum-segmentation. The semantic config change made Talos reconcile Ethernet features; no visible node reboot occurred.

## Verification

- Cilium: 4/4 nodes and endpoints reachable
- Dell Tcp InCsumErrors: zero delta during a forced full health probe
- All Longhorn managers: 2/2 Running
- All Longhorn-system pods and instance managers: Running

The repo documentation is intentionally short; detailed packet and counter evidence is retained in Mink.