### PR TITLE
kopiur: give restore movers 2h to outwait infra convergence

### DIFF
--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -173,6 +173,15 @@ half-converged cluster.
   `Failed`, a `Restore` stuck without ever populating its PVC (PVC `Pending`
   long after the repo is confirmed reachable), or a `Snapshot` stuck in error.
   Watch with `kubectl -n <ns> get snapshotpolicy,snapshotschedule,restore,snapshot`.
+- **A `Failed` Restore is terminal — kopiur never retries it** (no spec change
+  resets it; the component sets a 2h mover-startup deadline so this only happens
+  after a sustained outage). Recovery: delete the Failed CRs and let Argo
+  recreate them — each fresh CR pins the then-latest snapshot; the unbound PVC
+  is untouched.
+
+  ```bash
+  kubectl get restore -A --no-headers | awk '$3=="Failed" {system("kubectl -n "$1" delete restore "$2)}'
+  ```
 - **Privileged-mover namespaces may lag a grant race** (upstream kopiur #194):
   in the three root-mover namespaces (home-assistant, tubesync, nginx-example)
   the controller can miss the `privileged-movers` annotation event when the

--- a/my-apps/common/kopiur-backup/kustomization.yaml
+++ b/my-apps/common/kopiur-backup/kustomization.yaml
@@ -82,3 +82,10 @@ patches:
         path: /spec/policy
         value:
           onMissingSnapshot: Continue
+      # If the mover can't start within this window, the Restore fails permanently
+      # and must be deleted and recreated. 2h rides out slow infra during a rebuild
+      # (the 300s default is too short and killed a whole restore wave once).
+      - op: add
+        path: /spec/failurePolicy
+        value:
+          podStartupDeadlineSeconds: 7200


### PR DESCRIPTION
## Why

During today's rebuild, the VXLAN outage left restore mover pods unschedulable for ~55 minutes. kopiur's default `podStartupDeadlineSeconds` (300s) expired and marked all 31 restore-wave `Restore` CRs `Failed` (`MoverPodWedged`). A Failed Restore is terminal upstream (source-verified: no retry, no spec-change reset — only a fresh CR re-runs), so every backed-up PVC sat `Pending` and 235 pods were unschedulable until manual CR deletion. A transient infra hiccup during the restore wave should never require manual intervention.

## What

- `my-apps/common/kopiur-backup/kustomization.yaml`: inject `failurePolicy.podStartupDeadlineSeconds: 7200` into every `Restore` via the shared component. Snapshots intentionally untouched — a Failed Snapshot self-retries on the next cron, and a long deadline there would block subsequent runs under `concurrencyPolicy: Forbid`.
- `docs/disaster-recovery.md`: record the terminal-Failed rule + delete-and-let-Argo-recreate recovery in the restore-wave section.

## Verification

- `kubectl kustomize my-apps/ai/open-webui` renders `failurePolicy.podStartupDeadlineSeconds: 7200` on the Restore; no stub sets its own `failurePolicy`.
- The recovery path was proven live today: canary Restore delete → Argo recreate → `Completed`, PVC `Bound`, verify job passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)