### PR TITLE
Fix hardware placement after restore

### DIFF
--- a/my-apps/home/home-assistant/deployment.yaml
+++ b/my-apps/home/home-assistant/deployment.yaml
@@ -29,23 +29,11 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       # Add restart policy for better reliability
       restartPolicy: Always
-      # Pin to the GPU worker (VM 100) — that is where the SONOFF Zigbee dongle
-      # is USB-passed and where cp210x exposes /dev/ttyUSB0. The hostPath device
-      # mount below only resolves on this node.
+      # Pin to the general worker (VM 101), where the SONOFF Zigbee dongle is
+      # USB-passed and cp210x exposes /dev/ttyUSB0. The hostPath device mount
+      # below only resolves on this node.
       nodeSelector:
-        gpu-worker: "true"
-      # Pod affinity to ensure all home-assistant pods stay on same node (RWO volume requirement)
-      # This prevents Multi-Attach errors if replicas are increased
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                - home-assistant
-            topologyKey: kubernetes.io/hostname
+        node.vanillax.dev/class: general-worker
       initContainers:
         - name: copy-config
           image: alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
@@ -152,7 +140,7 @@ spec:
         - name: config-files
           configMap:
             name: config
-        # SONOFF Zigbee dongle char device on the gpu-worker node. cp210x must
+        # SONOFF Zigbee dongle char device on the general-worker node. cp210x must
         # be loaded (Talos single-node-gpu.yaml) for this to exist. If the path
         # ever shifts (e.g. a second serial device), switch to the stable
         # /dev/serial/by-id/usb-… symlink target.

--- a/my-apps/media/jellyfin/deployment.yaml
+++ b/my-apps/media/jellyfin/deployment.yaml
@@ -17,17 +17,6 @@ spec:
       annotations:
         instrumentation.opentelemetry.io/inject-dotnet: "opentelemetry/default"
     spec:
-      # Pod affinity to ensure all jellyfin pods stay on same node (RWO volumes requirement)
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - jellyfin
-            topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## What changed

- pin Home Assistant to the general worker VM that owns the Zigbee USB passthrough
- remove required self-affinity from Home Assistant and Jellyfin

## Why

A one-replica Deployment cannot bootstrap when required pod affinity demands an already-running copy of itself. Home Assistant was also pinned to the GPU worker even though the Zigbee device is attached to VM 101/general-worker.

## Validation

- `git diff --check`
- `kustomize build my-apps/media/jellyfin`
- `kustomize build my-apps/home/home-assistant`