### PR TITLE
Raise Cilium endpoint-create burst capacity

### DIFF
--- a/infrastructure/networking/cilium/values.yaml
+++ b/infrastructure/networking/cilium/values.yaml
@@ -113,6 +113,16 @@ k8sClientRateLimit:
   qps: 20
   burst: 40
 
+# A node/agent restart causes kubelet to recreate many pod sandboxes at once.
+# Cilium's endpoint-create limiter defaults to only 0.5 requests/s with a burst
+# of 4 and returned 429s during the 2026-08-14 rebuild, delaying ArgoCD and every
+# other replacement pod. Start with enough queue/parallel headroom for the
+# bootstrap burst; Cilium's default auto-adjustment remains enabled and tunes
+# these values back toward the observed endpoint-generation time afterward.
+# https://docs.cilium.io/en/stable/configuration/api-rate-limiting/
+extraConfig:
+  api-rate-limit: "endpoint-create=rate-limit:2/s,rate-burst:16,parallel-requests:8,max-wait-duration:30s"
+
 # Gateway API Support
 gatewayAPI:
   enabled: true


### PR DESCRIPTION
## What changed

- configure Cilium's supported `api-rate-limit` override for endpoint creation
- raise the initial rate to 2/s, burst to 16, and parallel work to 8
- allow queued endpoint creates to wait up to 30 seconds
- retain Cilium's adaptive limiter tuning

## Why

During the 2026-08-14 rebuild, an agent restart caused kubelet to recreate many pod sandboxes at once. The default endpoint-create limiter rejected requests with `429 putEndpointIdTooManyRequests`, delaying ArgoCD and other replacement pods even after the agents were Ready.

Live metrics confirmed 429 responses on three worker agents. Cilium documents `api-rate-limit` as the supported override for this API.

This changes only the Cilium ConfigMap render. `rollOutCiliumPods` remains false, so syncing the PR does not trigger another agent rollout.

## Validation

- `kubectl kustomize infrastructure/networking/cilium --enable-helm`
- rendered ConfigMap contains the expected `api-rate-limit` value
- `git diff --check`
- `bash scripts/validate-argocd-apps.sh`
