### PR TITLE
Fix Karakeep Chrome image source

### DIFF
--- a/my-apps/media/karakeep/chrome/deployment-chrome.yaml
+++ b/my-apps/media/karakeep/chrome/deployment-chrome.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: chrome
-          image: gcr.io/zenika-hub/alpine-chrome:124
+          image: docker.io/zenika/alpine-chrome:124@sha256:20cddfa693fe823aa45c93739ed3b4f500dcb81c559d71fd67e2a5a786ac24be
           imagePullPolicy: IfNotPresent
           command:
             - chromium-browser


### PR DESCRIPTION
## What changed

- move the Karakeep Chrome sidecar image from the retired GCR path to the official Zenika Docker Hub repository
- pin the `124` image by registry digest

## Why

The existing `gcr.io/zenika-hub/alpine-chrome:124` image now fails with HTTP 403, leaving Karakeep Chrome in `ImagePullBackOff`. The same upstream image remains published as `docker.io/zenika/alpine-chrome:124`.

## Validation

- resolved the digest with `crane digest` (registry metadata only; no image pull)
- `kubectl kustomize my-apps/media/karakeep`
- `git diff --check`