### PR TITLE
fix(radar-ng): co-locate shared RWO workloads

### DIFF
--- a/my-apps/development/radar-ng/deployment-tile-server.yaml
+++ b/my-apps/development/radar-ng/deployment-tile-server.yaml
@@ -34,6 +34,18 @@ spec:
         # ReplicaSet roll on each gitops bump.
         config-rev: "2026-05-10-forecast-ttl-300"
     spec:
+      # Prefer the node already hosting the worker that shares these RWO
+      # volumes. This keeps tile-server replacements co-located while still
+      # allowing tile-server to bootstrap first when no worker exists yet.
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: radar-ng-worker
+                topologyKey: kubernetes.io/hostname
       # Spread replicas across nodes so a single node failure can't take
       # the API offline. ScheduleAnyway lets the second pod schedule even
       # if there's only one matching node available.

--- a/my-apps/development/radar-ng/pvcs.yaml
+++ b/my-apps/development/radar-ng/pvcs.yaml
@@ -17,9 +17,9 @@
 # faster than any NFS/share-manager path and sidesteps the errno-95 O_TMPFILE class
 # of NFS bugs (see openmeteo-data).
 #   MULTI-NODE CAVEAT: RWO-shared-by-many-pods only holds while they co-locate on
-#   one node. Before adding worker nodes, pin radar-ng workers + tile-server +
-#   temporal-worker together with podAffinity (as open-meteo already does), or move
-#   these back to a real RWX class.
+#   one node. The worker has required podAffinity to tile-server, and tile-server
+#   prefers the existing worker's node during replacement. Keep those constraints
+#   in place or move these back to a real RWX class.
 #
 # All three hold backup-exempt REBUILDABLE data, so the immutable storageClass/
 # accessMode change is applied by delete+recreate of the PVCs; tiles regenerate.

--- a/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
@@ -43,6 +43,16 @@ spec:
       labels:
         app: radar-ng-worker
     spec:
+      # tiles/grids/state are RWO volumes also mounted by tile-server. Follow
+      # the serving pod onto the same node so Longhorn never has to attach the
+      # same block volumes to two nodes after a rebuild or rollout.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: tile-server
+              topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## Summary
- require the Temporal worker to run with the tile server that owns its shared RWO volumes
- prefer the existing worker node when the tile server rolls
- update the stale multi-node caveat

## Validation
- `kubectl kustomize my-apps/development/radar-ng`
- server-side dry-run of the rendered manifests
- `git diff --check`

Fixes the post-restore Multi-Attach deadlock without hard-coding a node.