### PR TITLE
fix kopiur Longhorn clone staging

### DIFF
--- a/infrastructure/storage/longhorn/kustomization.yaml
+++ b/infrastructure/storage/longhorn/kustomization.yaml
@@ -9,6 +9,10 @@ resources:
   - node-failure-settings.yaml
   # Fast local flash tier — enterprise-SSD Longhorn disk (tag `flash`).
   - storageclass-flash.yaml
+  # Disposable kopiur snapshot clones. WFFC lets the mover pod choose the
+  # preferred node before Longhorn provisions the clone, avoiding the V1 clone
+  # attachment handoff race seen with the Immediate-binding default class.
+  - storageclass-kopiur-staging.yaml
   # The chart-created `longhorn` StorageClass provisions V1-engine volumes
   # (chart default; the dataEngine:v2 routing was removed 2026-06-12 when the
   # V2/SPDK experiment was retired — see values.yaml header).
@@ -20,4 +24,3 @@ helmCharts:
     namespace: longhorn-system
     valuesFile: values.yaml
     includeCRDs: true
-

--- a/infrastructure/storage/longhorn/storageclass-kopiur-staging.yaml
+++ b/infrastructure/storage/longhorn/storageclass-kopiur-staging.yaml
@@ -1,0 +1,31 @@
+# Temporary snapshot clones mounted by kopiur backup movers.
+#
+# Longhorn's default `longhorn` class binds immediately. For a CSI snapshot
+# clone that means Longhorn chooses the clone location before Kubernetes knows
+# where the consuming mover pod will run. Longhorn V1 can then spend minutes
+# handing the completed clone from one node to another (longhorn/longhorn
+# #13335), and a disrupted handoff can leave the backup Job wedged.
+#
+# WaitForFirstConsumer reverses that order: schedule the mover first, then pass
+# its node to Longhorn as the preferred provisioning location. Keep
+# best-effort locality rather than strict-local: the general worker is
+# compute-only, and strict-local plus an unavailable local Longhorn disk can
+# deadlock provisioning.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-kopiur-staging
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
+  fsType: "ext4"
+  dataEngine: "v1"
+  dataLocality: "best-effort"
+  disableRevisionCounter: "true"
+  unmapMarkSnapChainRemoved: "ignored"

--- a/my-apps/common/kopiur-backup/kustomization.yaml
+++ b/my-apps/common/kopiur-backup/kustomization.yaml
@@ -39,6 +39,13 @@ patches:
       - op: add
         path: /spec/volumeSnapshotClassName
         value: longhorn-snapclass
+      # Stage the disposable snapshot clone with WFFC so the mover is scheduled
+      # before Longhorn picks the clone's preferred node. This avoids the V1
+      # Immediate-binding clone handoff race (longhorn/longhorn #13335).
+      - op: add
+        path: /spec/staging
+        value:
+          storageClassName: longhorn-kopiur-staging
       - op: add
         path: /spec/repository
         value:


### PR DESCRIPTION
## What changed

- add a dedicated `longhorn-kopiur-staging` StorageClass for disposable backup clones
- use `WaitForFirstConsumer` so the Kopiur mover is scheduled before Longhorn provisions its staged clone
- inject that staging class into every shared Kopiur `SnapshotPolicy`

## Why

Longhorn v1.12.0 V1-engine snapshot clones use the default `Immediate` class today. That can place the temporary clone before its mover pod is scheduled, triggering the cross-node clone/attachment handoff delay documented in longhorn/longhorn#13335. During this rebuild, multiple movers waited on that path and one clone hit transient block I/O/mkfs errors.

This change affects only disposable Kopiur staging PVCs. Normal application PVCs remain on their existing classes. It deliberately keeps `dataLocality: best-effort`; `strict-local` can deadlock on the compute-only worker and conflicts with the cluster's offline rebuilding behavior.

## Validation

- rendered the Longhorn and Paperless Kustomize trees
- server-side dry-run accepted the new StorageClass
- server-side dry-run accepted the rendered SnapshotPolicy staging field
- `git diff --check`

After merge, the live canary is a fresh Paperless PostgreSQL backup: verify the staged PVC starts Pending, binds after the mover is scheduled, and the Snapshot completes with non-zero files.