### PR TITLE
pin kopiur staging clones to storage nodes

### DIFF
--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -1,6 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kopiur-system
+# Do not add a top-level `namespace:` transformer here. The Helm release already
+# renders its namespaced objects into kopiur-system, while Kubernetes 1.36's
+# MutatingAdmissionPolicy kinds below are cluster-scoped and not yet known to
+# the kubectl-bundled Kustomize schema.
+
+resources:
+  # Kopiur does not currently expose mover node affinity. Restrict staged-PVC
+  # movers to the two workers that actually have Longhorn disks so the
+  # strict-local WFFC staging class cannot select the compute-only worker.
+  - mover-storage-node-policy.yaml
 
 # kopiur publishes its chart as an OCI artifact (release.yaml: helm push →
 # oci://ghcr.io/home-operations/charts). Render it locally like every other

--- a/infrastructure/controllers/kopiur-operator/mover-storage-node-policy.yaml
+++ b/infrastructure/controllers/kopiur-operator/mover-storage-node-policy.yaml
@@ -1,0 +1,54 @@
+# Kopiur 0.10.2 exposes mover security/resource overrides but no scheduling
+# affinity. Its snapshot movers consume short-lived `*-src` Longhorn PVCs, so
+# place those pods only on workers that declare Longhorn disk configuration.
+# Together with the strict-local WFFC staging class, this keeps each mover,
+# clone engine, and clone replica on one storage-capable node.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: kopiur-mover-storage-node.vanillax.dev
+spec:
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+  matchConditions:
+    - name: kopiur-staged-pvc-mover
+      expression: >-
+        has(object.metadata.labels) &&
+        "app.kubernetes.io/managed-by" in object.metadata.labels &&
+        object.metadata.labels["app.kubernetes.io/managed-by"] == "kopiur" &&
+        object.spec.volumes.exists(v,
+          has(v.persistentVolumeClaim) &&
+          v.persistentVolumeClaim.claimName.endsWith("-src"))
+    - name: storage-node-selector-not-already-set
+      expression: >-
+        !has(object.spec.nodeSelector) ||
+        !("node.longhorn.io/create-default-disk" in object.spec.nodeSelector)
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: >-
+          has(object.spec.nodeSelector)
+          ? [JSONPatch{
+              op: "add",
+              path: "/spec/nodeSelector/" +
+                jsonpatch.escapeKey("node.longhorn.io/create-default-disk"),
+              value: "config"
+            }]
+          : [JSONPatch{
+              op: "add",
+              path: "/spec/nodeSelector",
+              value: {"node.longhorn.io/create-default-disk": "config"}
+            }]
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: kopiur-mover-storage-node.vanillax.dev
+spec:
+  policyName: kopiur-mover-storage-node.vanillax.dev

--- a/infrastructure/storage/longhorn/storageclass-kopiur-staging.yaml
+++ b/infrastructure/storage/longhorn/storageclass-kopiur-staging.yaml
@@ -7,14 +7,16 @@
 # #13335), and a disrupted handoff can leave the backup Job wedged.
 #
 # WaitForFirstConsumer reverses that order: schedule the mover first, then pass
-# its node to Longhorn as the preferred provisioning location. Keep
-# best-effort locality rather than strict-local: the general worker is
-# compute-only, and strict-local plus an unavailable local Longhorn disk can
-# deadlock provisioning.
+# its node to Longhorn. The kopiur-operator application installs an admission
+# policy that restricts mover pods to nodes carrying
+# `node.longhorn.io/create-default-disk=config`, so strict-local can safely put
+# the temporary one-replica clone on the mover's storage-capable node. If no
+# such node can host it, fail closed instead of falling back to a cross-node
+# clone/attachment handoff.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: longhorn-kopiur-staging
+  name: longhorn-kopiur-staging-local
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
 provisioner: driver.longhorn.io
@@ -26,6 +28,6 @@ parameters:
   staleReplicaTimeout: "30"
   fsType: "ext4"
   dataEngine: "v1"
-  dataLocality: "best-effort"
+  dataLocality: "strict-local"
   disableRevisionCounter: "true"
   unmapMarkSnapChainRemoved: "ignored"

--- a/my-apps/common/kopiur-backup/kustomization.yaml
+++ b/my-apps/common/kopiur-backup/kustomization.yaml
@@ -45,7 +45,7 @@ patches:
       - op: add
         path: /spec/staging
         value:
-          storageClassName: longhorn-kopiur-staging
+          storageClassName: longhorn-kopiur-staging-local
       - op: add
         path: /spec/repository
         value:


### PR DESCRIPTION
## What changed

- restrict Kopiur staged-PVC mover pods to workers labeled `node.longhorn.io/create-default-disk=config` using Kubernetes 1.36 native `MutatingAdmissionPolicy`
- replace the best-effort staging class with `longhorn-kopiur-staging-local`
- use one `strict-local` replica with `WaitForFirstConsumer`
- point shared Kopiur policies at the local staging class

## Why

PR #1983 correctly delayed provisioning until the mover was scheduled, but the live canary proved `dataLocality: best-effort` still allowed Longhorn to create the clone engine/replica on GPU while the mover was selected for Dell. The same clone handoff remained.

This follow-up makes placement deterministic: admission limits movers to the two storage-capable workers, WFFC selects one of them, and strict-local forces the disposable clone onto that same selected node. If neither storage node can host the clone, the backup fails closed instead of falling back across the degraded overlay.

## Validation

- Kubernetes API server accepted the rendered MutatingAdmissionPolicy and binding in server-side dry-run, including CEL type checking
- Kubernetes API server accepted the strict-local WFFC StorageClass in server-side dry-run
- rendered Kopiur operator, Longhorn, and restore-canary Kustomize trees
- verified removing the redundant top-level operator namespace transformer produces no changes to existing Helm-rendered resources
- rendered restore-canary policy references `longhorn-kopiur-staging-local`
- `git diff --check`

## Live proof after merge

Create a restore-canary Snapshot and verify:

1. mover pod nodeSelector is injected
2. mover node, temporary Longhorn engine, and temporary replica are identical
3. Snapshot succeeds with non-zero files
4. canary Snapshot CR is deleted afterward so its disposable backup and staging resources are cleaned up.