### PR TITLE
fix(kopiur): shorten Longhorn clone attach retries

### DIFF
--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -10,6 +10,10 @@ resources:
   # movers to the two workers that actually have Longhorn disks so the
   # strict-local WFFC staging class cannot select the compute-only worker.
   - mover-storage-node-policy.yaml
+  # Longhorn creates its CSI sidecar Deployments dynamically, outside this
+  # repository's rendered manifests. Mutate new attacher pods at admission so
+  # a completed V1 clone is retried promptly after an early attach attempt.
+  - longhorn-csi-attacher-retry-policy.yaml
 
 # kopiur publishes its chart as an OCI artifact (release.yaml: helm push →
 # oci://ghcr.io/home-operations/charts). Render it locally like every other

--- a/infrastructure/controllers/kopiur-operator/longhorn-csi-attacher-retry-policy.yaml
+++ b/infrastructure/controllers/kopiur-operator/longhorn-csi-attacher-retry-policy.yaml
@@ -1,0 +1,48 @@
+# Longhorn V1 clone PVCs bind before their clone is ready for workloads. The
+# external-attacher may attempt too early and then use its upstream 5-minute
+# maximum backoff, making an otherwise-complete kopiur backup appear stuck.
+# Longhorn creates this Deployment dynamically, so mutate its pods rather than
+# trying to patch a resource absent from the rendered Helm chart.
+# https://github.com/longhorn/longhorn/issues/13335
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: longhorn-csi-attacher-retry.vanillax.dev
+spec:
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+  matchConditions:
+    - name: longhorn-csi-attacher
+      expression: >-
+        object.metadata.namespace == "longhorn-system" &&
+        has(object.metadata.labels) &&
+        "app" in object.metadata.labels &&
+        object.metadata.labels["app"] == "csi-attacher" &&
+        object.spec.containers.size() > 0 &&
+        object.spec.containers[0].name == "csi-attacher"
+    - name: retry-ceiling-not-already-set
+      expression: >-
+        !object.spec.containers[0].args.exists(a,
+          a.startsWith("--retry-interval-max="))
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: >-
+          [JSONPatch{
+            op: "add",
+            path: "/spec/containers/0/args/-",
+            value: "--retry-interval-max=30s"
+          }]
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: longhorn-csi-attacher-retry.vanillax.dev
+spec:
+  policyName: longhorn-csi-attacher-retry.vanillax.dev


### PR DESCRIPTION
## Summary
- mutate dynamically-created Longhorn CSI attacher pods to cap failed attach retry backoff at 30 seconds
- target only `longhorn-system` pods labeled `app=csi-attacher`
- keep the change next to the Kopiur staging/mover workaround that depends on it

## Why
Longhorn V1 clone PVCs bind before the clone is ready. The external-attacher can fail its first attempt and wait its default maximum of five minutes before trying again, even after the clone completes. This is the remaining delay in the verified Kopiur staging canary and matches longhorn/longhorn#13335.

## Validation
- `kubectl apply --server-side --dry-run=server` accepted the policy and binding
- `kubectl kustomize --enable-helm infrastructure/controllers/kopiur-operator` rendered the policy and `--retry-interval-max=30s` mutation
- fresh live canary will run after merge and Argo sync