### PR TITLE
kopiur: checkpoint Postgres before CSI snapshots

### DIFF
--- a/my-apps/ai/hindsight/kopiur/hindsight-db.yaml
+++ b/my-apps/ai/hindsight/kopiur/hindsight-db.yaml
@@ -19,6 +19,23 @@ spec:
   identity:
     username: hindsight-db-pvc
     hostname: hindsight
+  hooks:
+    beforeSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app: hindsight-db
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
+          timeout: 2m
+    afterSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app: hindsight-db
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          timeout: 2m
   retention:
     keepDaily: 14
     keepWeekly: 6

--- a/my-apps/ai/hindsight/kopiur/hindsight-db.yaml
+++ b/my-apps/ai/hindsight/kopiur/hindsight-db.yaml
@@ -26,15 +26,7 @@ spec:
             matchLabels:
               app: hindsight-db
           container: postgres
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
-          timeout: 2m
-    afterSnapshot:
-      - workloadExec:
-          podSelector:
-            matchLabels:
-              app: hindsight-db
-          container: postgres
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"CHECKPOINT\""]
           timeout: 2m
   retention:
     keepDaily: 14

--- a/my-apps/development/gitea/kopiur/gitea-postgres-data.yaml
+++ b/my-apps/development/gitea/kopiur/gitea-postgres-data.yaml
@@ -2,8 +2,8 @@
 # gitea-postgres-data backup STUB — uniform fields (repository, copyMethod,
 # populator) injected by ../../common/kopiur-backup. The mover securityContext
 # is per-PVC and stays in THIS stub (docs/domains/storage/kopiur-mover-permissions.md).
-# HOURLY tier: database — caps data loss at ~1h. Kopiur's workload hooks put
-# Postgres in backup mode around the CSI capture for application consistency.
+# HOURLY tier: database — caps data loss at ~1h. The before-hook
+# CHECKPOINTs Postgres so the CSI capture starts from a flushed state.
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
@@ -23,15 +23,7 @@ spec:
             matchLabels:
               app: gitea-postgres
           container: postgres
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
-          timeout: 2m
-    afterSnapshot:
-      - workloadExec:
-          podSelector:
-            matchLabels:
-              app: gitea-postgres
-          container: postgres
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"CHECKPOINT\""]
           timeout: 2m
   retention:
     keepHourly: 24

--- a/my-apps/development/gitea/kopiur/gitea-postgres-data.yaml
+++ b/my-apps/development/gitea/kopiur/gitea-postgres-data.yaml
@@ -2,8 +2,8 @@
 # gitea-postgres-data backup STUB — uniform fields (repository, copyMethod,
 # populator) injected by ../../common/kopiur-backup. The mover securityContext
 # is per-PVC and stays in THIS stub (docs/domains/storage/kopiur-mover-permissions.md).
-# HOURLY tier: database — caps data loss at ~1h. The CSI snapshot is
-# crash-consistent; Postgres WAL-recovers from it like a power loss.
+# HOURLY tier: database — caps data loss at ~1h. Kopiur's workload hooks put
+# Postgres in backup mode around the CSI capture for application consistency.
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
@@ -16,6 +16,23 @@ spec:
   identity:
     username: gitea-postgres-data
     hostname: gitea
+  hooks:
+    beforeSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app: gitea-postgres
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
+          timeout: 2m
+    afterSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app: gitea-postgres
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          timeout: 2m
   retention:
     keepHourly: 24
     keepDaily: 7

--- a/my-apps/development/posthog/kopiur/postgres-data.yaml
+++ b/my-apps/development/posthog/kopiur/postgres-data.yaml
@@ -4,8 +4,8 @@
 # (project/personal API keys, users, dashboards, flag+cohort definitions) that
 # must survive cluster rebuild; ClickHouse/Kafka/Redis stay exempt (event
 # history rebuilds empty). DAILY tier: dashboards/flags edits risk <=24h;
-# API keys effectively never change. CSI snapshot is crash-consistent;
-# Postgres WAL-recovers from it like a power loss.
+# API keys effectively never change. Kopiur's workload hooks put Postgres in
+# backup mode around the CSI capture for application consistency.
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
@@ -18,6 +18,25 @@ spec:
   identity:
     username: postgres-data
     hostname: posthog
+  hooks:
+    beforeSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: posthog
+              app.kubernetes.io/component: db
+          container: db
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
+          timeout: 2m
+    afterSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: posthog
+              app.kubernetes.io/component: db
+          container: db
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          timeout: 2m
   retention:
     keepDaily: 14
     keepWeekly: 6

--- a/my-apps/development/posthog/kopiur/postgres-data.yaml
+++ b/my-apps/development/posthog/kopiur/postgres-data.yaml
@@ -4,8 +4,8 @@
 # (project/personal API keys, users, dashboards, flag+cohort definitions) that
 # must survive cluster rebuild; ClickHouse/Kafka/Redis stay exempt (event
 # history rebuilds empty). DAILY tier: dashboards/flags edits risk <=24h;
-# API keys effectively never change. Kopiur's workload hooks put Postgres in
-# backup mode around the CSI capture for application consistency.
+# API keys effectively never change. The before-hook
+# CHECKPOINTs Postgres so the CSI capture starts from a flushed state.
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
@@ -26,16 +26,7 @@ spec:
               app.kubernetes.io/name: posthog
               app.kubernetes.io/component: db
           container: db
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
-          timeout: 2m
-    afterSnapshot:
-      - workloadExec:
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/name: posthog
-              app.kubernetes.io/component: db
-          container: db
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"CHECKPOINT\""]
           timeout: 2m
   retention:
     keepDaily: 14

--- a/my-apps/development/temporal/kopiur/temporal-postgres-data.yaml
+++ b/my-apps/development/temporal/kopiur/temporal-postgres-data.yaml
@@ -2,8 +2,8 @@
 # temporal-postgres-data backup STUB — uniform fields (repository, copyMethod,
 # populator) injected by ../../common/kopiur-backup. The mover securityContext
 # is per-PVC and stays in THIS stub (docs/domains/storage/kopiur-mover-permissions.md).
-# HOURLY tier: database — caps data loss at ~1h. Kopiur's workload hooks put
-# Postgres in backup mode around the CSI capture for application consistency.
+# HOURLY tier: database — caps data loss at ~1h. The before-hook
+# CHECKPOINTs Postgres so the CSI capture starts from a flushed state.
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
@@ -27,15 +27,7 @@ spec:
             matchLabels:
               app: temporal-postgres
           container: postgres
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
-          timeout: 2m
-    afterSnapshot:
-      - workloadExec:
-          podSelector:
-            matchLabels:
-              app: temporal-postgres
-          container: postgres
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"CHECKPOINT\""]
           timeout: 2m
   retention:
     keepHourly: 24

--- a/my-apps/development/temporal/kopiur/temporal-postgres-data.yaml
+++ b/my-apps/development/temporal/kopiur/temporal-postgres-data.yaml
@@ -2,8 +2,8 @@
 # temporal-postgres-data backup STUB — uniform fields (repository, copyMethod,
 # populator) injected by ../../common/kopiur-backup. The mover securityContext
 # is per-PVC and stays in THIS stub (docs/domains/storage/kopiur-mover-permissions.md).
-# HOURLY tier: database — caps data loss at ~1h. The CSI snapshot is
-# crash-consistent; Postgres WAL-recovers from it like a power loss.
+# HOURLY tier: database — caps data loss at ~1h. Kopiur's workload hooks put
+# Postgres in backup mode around the CSI capture for application consistency.
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
@@ -20,6 +20,23 @@ spec:
   identity:
     username: temporal-postgres-data
     hostname: temporal
+  hooks:
+    beforeSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app: temporal-postgres
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
+          timeout: 2m
+    afterSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app: temporal-postgres
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          timeout: 2m
   retention:
     keepHourly: 24
     keepDaily: 7

--- a/my-apps/home/intercept/kopiur/postgres-data.yaml
+++ b/my-apps/home/intercept/kopiur/postgres-data.yaml
@@ -11,6 +11,23 @@ spec:
   identity:
     username: intercept-postgres-data
     hostname: intercept
+  hooks:
+    beforeSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: intercept-postgres
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
+          timeout: 2m
+    afterSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: intercept-postgres
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          timeout: 2m
   retention:
     keepHourly: 24
     keepDaily: 7

--- a/my-apps/home/intercept/kopiur/postgres-data.yaml
+++ b/my-apps/home/intercept/kopiur/postgres-data.yaml
@@ -18,15 +18,7 @@ spec:
             matchLabels:
               app.kubernetes.io/name: intercept-postgres
           container: postgres
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
-          timeout: 2m
-    afterSnapshot:
-      - workloadExec:
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/name: intercept-postgres
-          container: postgres
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"CHECKPOINT\""]
           timeout: 2m
   retention:
     keepHourly: 24

--- a/my-apps/home/paperless-ngx/kopiur/paperless-postgres-data.yaml
+++ b/my-apps/home/paperless-ngx/kopiur/paperless-postgres-data.yaml
@@ -3,8 +3,8 @@
 # copyMethod, populator) injected by ../../common/kopiur-backup. The mover
 # securityContext is per-PVC and stays in THIS stub
 # (docs/domains/storage/kopiur-mover-permissions.md).
-# HOURLY tier: database — caps data loss at ~1h. Kopiur's workload hooks put
-# Postgres in backup mode around the CSI capture for application consistency.
+# HOURLY tier: database — caps data loss at ~1h. The before-hook
+# CHECKPOINTs Postgres so the CSI capture starts from a flushed state.
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
@@ -24,15 +24,7 @@ spec:
             matchLabels:
               app: paperless-postgres
           container: postgres
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
-          timeout: 2m
-    afterSnapshot:
-      - workloadExec:
-          podSelector:
-            matchLabels:
-              app: paperless-postgres
-          container: postgres
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"CHECKPOINT\""]
           timeout: 2m
   retention:
     keepHourly: 24

--- a/my-apps/home/paperless-ngx/kopiur/paperless-postgres-data.yaml
+++ b/my-apps/home/paperless-ngx/kopiur/paperless-postgres-data.yaml
@@ -3,8 +3,8 @@
 # copyMethod, populator) injected by ../../common/kopiur-backup. The mover
 # securityContext is per-PVC and stays in THIS stub
 # (docs/domains/storage/kopiur-mover-permissions.md).
-# HOURLY tier: database — caps data loss at ~1h. The CSI snapshot is
-# crash-consistent; Postgres WAL-recovers from it like a power loss.
+# HOURLY tier: database — caps data loss at ~1h. Kopiur's workload hooks put
+# Postgres in backup mode around the CSI capture for application consistency.
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
@@ -17,6 +17,23 @@ spec:
   identity:
     username: paperless-postgres-data
     hostname: paperless-ngx
+  hooks:
+    beforeSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app: paperless-postgres
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
+          timeout: 2m
+    afterSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app: paperless-postgres
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          timeout: 2m
   retention:
     keepHourly: 24
     keepDaily: 7

--- a/my-apps/media/immich/kopiur/immich-postgres-data.yaml
+++ b/my-apps/media/immich/kopiur/immich-postgres-data.yaml
@@ -3,8 +3,8 @@
 # immich-postgres-data backup STUB — uniform fields (repository, copyMethod,
 # populator) injected by ../../common/kopiur-backup. The mover securityContext
 # is per-PVC and stays in THIS stub (docs/domains/storage/kopiur-mover-permissions.md).
-# HOURLY tier: database — caps data loss at ~1h. Kopiur's workload hooks put
-# Postgres in backup mode around the CSI capture for application consistency.
+# HOURLY tier: database — caps data loss at ~1h. The before-hook
+# CHECKPOINTs Postgres so the CSI capture starts from a flushed state.
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
@@ -24,15 +24,7 @@ spec:
             matchLabels:
               app: immich-postgres
           container: postgres
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
-          timeout: 2m
-    afterSnapshot:
-      - workloadExec:
-          podSelector:
-            matchLabels:
-              app: immich-postgres
-          container: postgres
-          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"CHECKPOINT\""]
           timeout: 2m
   retention:
     keepHourly: 24

--- a/my-apps/media/immich/kopiur/immich-postgres-data.yaml
+++ b/my-apps/media/immich/kopiur/immich-postgres-data.yaml
@@ -3,8 +3,8 @@
 # immich-postgres-data backup STUB — uniform fields (repository, copyMethod,
 # populator) injected by ../../common/kopiur-backup. The mover securityContext
 # is per-PVC and stays in THIS stub (docs/domains/storage/kopiur-mover-permissions.md).
-# HOURLY tier: database — caps data loss at ~1h. The CSI snapshot is
-# crash-consistent; Postgres WAL-recovers from it like a power loss.
+# HOURLY tier: database — caps data loss at ~1h. Kopiur's workload hooks put
+# Postgres in backup mode around the CSI capture for application consistency.
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
@@ -17,6 +17,23 @@ spec:
   identity:
     username: immich-postgres-data
     hostname: immich
+  hooks:
+    beforeSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app: immich-postgres
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_start('kopiur', true)\""]
+          timeout: 2m
+    afterSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app: immich-postgres
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"SELECT pg_backup_stop()\""]
+          timeout: 2m
   retention:
     keepHourly: 24
     keepDaily: 7


### PR DESCRIPTION
## Why

Today's rebuild restored PostHog's Postgres with a zeroed `pg_logical/replorigin_checkpoint` (PANIC on startup) — evidence that a purely crash-consistent capture can land mid-write of derived state files. This PR adds kopiur workload hooks to all 7 plain-Postgres SnapshotPolicies so captures start from a flushed state.

## Why CHECKPOINT and not pg_backup_start/stop (the original draft)

Backup mode is session-scoped in PG15+: it aborts the instant the session that called `pg_backup_start` disconnects, and kopiur's `workloadExec` hooks are independent one-shot execs. **Proven live on gitea-postgres (18.6):** `pg_backup_start` succeeds, then a separate-session `pg_backup_stop()` fails with `ERROR: backup is not in progress` (exit 1) — meaning the original two-hook design would have failed every `afterSnapshot` hook and aborted every scheduled backup. Upstream kopiur's own hook example has the same flaw (written for pre-15 exclusive backup mode).

For an atomic block-level CSI snapshot of the entire PGDATA volume, backup mode adds nothing anyway — it exists for non-atomic file-level copies. A single `beforeSnapshot` `CHECKPOINT` (superuser, ~instant on these DBs) flushes dirty buffers and derived files right before the capture, with no second hook that can fail.

## Verification

- All 7 app trees render (`kubectl kustomize`, `--enable-helm` where applicable); CI green.
- Post-merge canary (next step): trigger a manual PostHog Snapshot, confirm `status.hooks.preCompletedAt`, a `Succeeded` snapshot with non-zero stats, and a `CHECKPOINT` entry in Postgres logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)