### PR TITLE
fix(temporal): roll Postgres back to 17.6; gate majors on all plain-Postgres images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -256,9 +256,9 @@
       // Minors/patches keep automerging per the repo-wide rule. PG19 GA is
       // ~Sept 2026. Migration runbook captured 2026-07-18 (dump/restore
       // via temp postgres:17 pod on the same PVC).
-      description: 'gitea plain-Postgres image: MAJOR bumps require dependency-dashboard approval — PG data dirs are not major-version compatible; manual dump/restore needed (2026-07-17 incident, PR #1621)',
-      matchPackageNames: ['postgres'],
-      matchFileNames: ['my-apps/development/gitea/postgres/deployment.yaml'],
+      description: 'plain-Postgres images (all apps): MAJOR bumps require dependency-dashboard approval — PG data dirs are not major-version compatible; manual dump/restore needed (2026-07-17 incident PR #1621; repeated 2026-08-14 on temporal, PR #1979)',
+      matchPackageNames: ['postgres', 'docker.io/library/postgres'],
+      matchFileNames: ['**/postgres/deployment.yaml'],
       matchUpdateTypes: ['major'],
       dependencyDashboardApproval: true,
       automerge: false,

--- a/my-apps/development/temporal/postgres/deployment.yaml
+++ b/my-apps/development/temporal/postgres/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           # Held at 17 (not gitea's 18) until Temporal upstream declares
           # PG18 support — temporal-sql-tool schema setup is the risk, and
           # a wedged schema hook deadlocks the whole app sync.
-          image: postgres:18.6
+          image: postgres:17.6
           securityContext:
             runAsUser: 999
             runAsGroup: 999


### PR DESCRIPTION
## Urgent half

Renovate PR #1979 was hand-merged during today's recovery and bumped temporal's postgres `17.6 → 18.6` — past the in-file hold comment ("Held at 17 until Temporal upstream declares PG18 support"). Temporal's data dir was initdb'd under 17.6 yesterday (CNPG cutover), and **PG 18 refuses a 17-format data directory**. The pod is currently stuck in a Longhorn attach; the moment it attaches it will crashloop with `database files are incompatible with server`. Rolling back to 17.6 restores the documented hold with zero data risk. (keep/gitea/paperless/intercept went 18.4→18.6 — patch-level, fine. PostHog stays hand-pinned at 15.12.)

## Durable half

Same failure shape as the 2026-07-17 gitea incident (#1621), where the takeaway was "the PR looked like every other green bump and was merged by hand" — but the `dependencyDashboardApproval` gate added then only matched gitea's file. Widened to `**/postgres/deployment.yaml` and both package spellings (`postgres`, `docker.io/library/postgres`) so a plain-Postgres major never becomes a mergeable PR anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)