### PR TITLE
renovate: hold temporal Postgres below 18 via allowedVersions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -264,6 +264,12 @@
       automerge: false,
     },
     {
+      description: 'temporal Postgres: hold at 17.x — Temporal upstream has not declared PG18 support; lifting the hold means a deliberate dump/restore migration (runbook 2026-07-18)',
+      matchPackageNames: ['postgres'],
+      matchFileNames: ['my-apps/development/temporal/postgres/deployment.yaml'],
+      allowedVersions: '<18',
+    },
+    {
       description: 'Pin project-nomad MySQL to 8.x (AdonisJS/Lucid not tested with MySQL 9)',
       matchPackageNames: ['mysql'],
       matchFileNames: ['my-apps/home/project-nomad/**'],


### PR DESCRIPTION
Replaces the forever-unticked "Update postgres Docker tag to v18" dashboard entry with policy: `allowedVersions: '<18'` scoped to temporal's deployment file, same pattern as the project-nomad MySQL `<9` hold. Renovate stops proposing 18.x for temporal entirely; 17.x minors keep automerging; the `**/postgres/deployment.yaml` major-approval gate (#1990) still covers every other app's next major (PG19 etc.).

Lift when Temporal upstream declares PG18 support and the dump/restore migration (2026-07-18 runbook) is scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)