### PR TITLE
Test Qwen3.8-27B-FP8 on vLLM (Open WebUI pilot only)

### DIFF
--- a/my-apps/ai/llama-cpp/deployment.yaml
+++ b/my-apps/ai/llama-cpp/deployment.yaml
@@ -8,11 +8,10 @@ metadata:
 spec:
   strategy:
     type: Recreate
-  # ACTIVE: temporarily the live backend while Qwen 3.8-27B is evaluated —
-  # it only runs here (no vLLM-compatible 3.8 quant exists for Ampere).
-  # vllm-server is scaled to 0 to free both 3090s. To hand the cards back:
-  # set this to 0 and vllm-server to 1 (one commit).
-  replicas: 1
+  # Scaled to 0: vLLM holds both 3090s while Qwen3.8-27B-FP8 is tested there.
+  # The Qwen 3.8 GGUF presets stay in presets.ini and remain the KNOWN-WORKING
+  # path on these cards — set this back to 1 (and vllm-server to 0) to return.
+  replicas: 0
   selector:
     matchLabels:
       app: llama-cpp-server

--- a/my-apps/ai/open-webui/open-webui-configmap.env
+++ b/my-apps/ai/open-webui/open-webui-configmap.env
@@ -1,24 +1,28 @@
 ENABLE_OPENAI_API=True
-# TEMPORARY (Qwen 3.8-27B evaluation): pointed at llama-cpp, not vLLM.
-# vllm-server is scaled to 0 because Qwen 3.8 has no vLLM-servable quant on
-# Ampere. llama-cpp uses one 3090; vLLM stays parked because its TP=2 deployment
-# requires both cards. Open WebUI is the ONLY consumer moved over — every other
-# app still points at vllm-service and stays down until the cards are handed
-# back. To revert: restore the two vllm-service URLs below,
-# set the model vars back to qwen3.6-27b, and TEMPERATURE back to 0.6.
-OPENAI_API_BASE_URL=http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1
-OPENAI_API_BASE_URLS=http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1
+# Back on vLLM, now serving Qwen3.8-27B-FP8 as `qwen3.8-27b`.
+# Open WebUI is the ONLY consumer pointed at the new model id — this is a
+# deliberate pilot. Perplexica, NOMAD, Karakeep, holmesgpt, litellm, presenton,
+# hindsight, worldmonitor and news-reader still request `qwen3.6-27b` and will
+# 404 until they are rolled over, which happens only if this test passes.
+# If the FP8 model does not boot on Ampere: set vllm-server to 0 and
+# llama-cpp-server to 1, and point the two URLs below back at
+# llama-cpp-service...:8080/v1 with the model vars set to `qwen3.8`.
+OPENAI_API_BASE_URL=http://vllm-service.vllm.svc.cluster.local:8080/v1
+OPENAI_API_BASE_URLS=http://vllm-service.vllm.svc.cluster.local:8080/v1
 OPENAI_API_KEY=sk-required
 OPENAI_API_KEYS=sk-required
 ENABLE_OLLAMA_API=false
-DEFAULT_MODELS=qwen3.8
-VISION_MODELS=qwen3.8
+DEFAULT_MODELS=qwen3.8-27b
+VISION_MODELS=qwen3.8-27b
 CONTEXT_WINDOW=65536
-# 1.0 is Qwen's THINKING-mode default (with top_p 0.95). Open WebUI sends these
-# explicitly on every request, so they OVERRIDE the preset's server-side values
-# — leaving 0.6 here would silently invalidate the evaluation.
-TEMPERATURE=1.0
-TOP_P=0.95
+# Qwen 3.8 publishes DIFFERENT sampling per mode. vLLM is started with
+# --default-chat-template-kwargs {"enable_thinking": false}, i.e. NON-thinking,
+# whose published profile is temp 0.7 / top_p 0.80. Open WebUI sends these
+# explicitly on every request and OVERRIDES the server, so they must match the
+# mode the server actually runs in — the thinking values (1.0 / 0.95) would be
+# wrong here even though they are correct for the llama-cpp `qwen3.8` preset.
+TEMPERATURE=0.7
+TOP_P=0.80
 MIN_P=0.0
 SHOW_THOUGHTS=True
 ENABLE_PERSISTENT_CONFIG=False
@@ -56,10 +60,11 @@ RAG_FILE_MAX_COUNT=10
 RAG_SYSTEM_CONTEXT=True
 ENABLE_TOOLS=True
 OPENAPI_API_ENDPOINTS=mcpo-time:http://mcpo.open-webui.svc.cluster.local:8000:mcp-demo-key;mcpo-multi:http://mcpo-multi.open-webui.svc.cluster.local:8001:mcp-multi-key;mcpo-kiwix:http://mcpo-kiwix.open-webui.svc.cluster.local:8002:mcp-kiwix-key
-# Title/tag generation wants strict output, so use the nothink preset — think
-# tokens break the JSON these background tasks expect.
-TASK_MODEL=qwen3.8-nothink
-TASK_MODEL_EXTERNAL=qwen3.8-nothink
+# vLLM serves a single id (no preset aliases like llama-cpp), and it already
+# runs with enable_thinking=false, so background title/tag generation gets the
+# strict non-thinking output it needs from the same model.
+TASK_MODEL=qwen3.8-27b
+TASK_MODEL_EXTERNAL=qwen3.8-27b
 DEFAULT_SYSTEM_PROMPT="You have access to an offline encyclopedia (Kiwix) via the 'fetch' tool.\nThe Kiwix server is located at: http://kiwix.kiwix.svc.cluster.local:8080\n\nTo search for information:\n1. Use the 'fetch' tool to search: \"http://kiwix.kiwix.svc.cluster.local:8080/search?pattern=YOUR_SEARCH_QUERY\"\n2. The result will be an HTML page containing search results. Read the links from this page.\n3. To read an article, use 'fetch' again on the article URL found in the search results (e.g., \"http://kiwix.kiwix.svc.cluster.local:8080/content/wikipedia_en_all_maxi_2025-08/Article_Name\").\n\nWhen asked about general knowledge or historical facts, ALWAYS check the offline encyclopedia first using these steps.\nCITE your sources by referencing the article title.\n"
 ENABLE_IMAGE_GENERATION=True
 IMAGE_GENERATION_ENGINE=comfyui

--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -6,13 +6,11 @@ metadata:
   labels:
     app: vllm-server
 spec:
-  # Scaled to 0: llama-cpp temporarily holds both 3090s for Qwen 3.8-27B
-  # evaluation. Qwen 3.8 has no vLLM-servable quant on Ampere — its official
-  # FP8 is block-wise W8A8 (Marlin cannot do block-wise; Ampere has no native
-  # FP8) and no AWQ-INT4 exists yet. Restore vLLM by setting this to 1 and
-  # llama-cpp-server to 0. Consumers still reference `qwen3.6-27b` on this
-  # service, so they stay broken until it is back.
-  replicas: 0
+  # ACTIVE: holds both 3090s (TP=2). llama-cpp-server is scaled to 0.
+  # EXPERIMENT IN PROGRESS — serving Qwen3.8-27B-FP8, which is NOT expected to
+  # boot on Ampere (see the model arg below). If it fails, set this to 0 and
+  # llama-cpp-server to 1 to go back to the working Qwen 3.8 GGUF.
+  replicas: 1
   strategy:
     type: Recreate            # whole-card GPU workload; never two pods on the cards at once
   revisionHistoryLimit: 1
@@ -49,12 +47,25 @@ spec:
           imagePullPolicy: IfNotPresent
           # The image entrypoint runs `vllm serve`; the first arg is the positional model_tag.
           args:
-            - "/models/Qwen3.6-27B-AWQ-BF16-INT4"     # default model (higher quality; fits TP=2 / 48GB)
+            # EXPERIMENT: Qwen3.8-27B-FP8. Expected to FAIL on these cards — it is an
+            # official BLOCK-SCALED FP8 W8A8 checkpoint (weight_block_size 128x128,
+            # activation_scheme dynamic). Ampere (SM 8.6) has no FP8 tensor cores, and
+            # vLLM's Ampere fallback is weight-only FP8 via Marlin, which does not
+            # implement block-wise -> expect "type fp8e4nv not supported in this
+            # architecture". vLLM's own recipe lists only H100/H200/B200/GB200/B300/
+            # GB300/MI300X+ for this variant; no Ampere, no consumer cards.
+            # Second independent risk: the recipe requires transformers>=5.8.0 (the
+            # version that wrote config.json). This image is pinned to June 2026 and may
+            # ship older -> config may fail to parse before any kernel is reached.
+            # KNOWN-WORKING fallback is the Qwen 3.8 GGUF on llama-cpp (presets.ini).
+            - "/models/Qwen3.8-27B-FP8"
             # served-model-name is a LIST (nargs+). Keep a single canonical
             # id so Open WebUI's model selector is not cluttered with aliases.
             # The next token MUST be a flag (--tensor-parallel-size) to end the list.
+            # NOTE: only Open WebUI has been moved to this id. Every other consumer
+            # still asks for `qwen3.6-27b` and will 404 until they are rolled over.
             - "--served-model-name"
-            - "qwen3.6-27b"                                    # canonical
+            - "qwen3.8-27b"                                    # canonical
             - "--tensor-parallel-size"
             - "2"                                      # pool both 3090s (48GB). Needs 2 WHOLE cards.
             - "--distributed-executor-backend"
@@ -63,7 +74,12 @@ spec:
             - "--gpu-memory-utilization"
             - "0.92"
             - "--max-model-len"
-            - "262144"                                 # full 262K native context; fits via fp8 KV + TP=2 paged cache
+            # HALVED for the FP8 experiment (was 262144 with the AWQ-INT4 model).
+            # FP8 weights are ~28.7GB vs the AWQ's ~16GB, so on 48GB at 0.92 util the
+            # KV budget drops by roughly half. 262144 would very likely OOM or shrink
+            # the KV pool to nothing at boot. Raise back toward 262144 only after
+            # reading the actual "GPU KV cache size" line in the startup logs.
+            - "131072"
             - "--max-num-seqs"
             - "2"                                      # 262K = deep single-stream; low concurrency keeps the KV pool sane
             - "--limit-mm-per-prompt"


### PR DESCRIPTION
Hands both 3090s back to vLLM to answer empirically whether the official block-scaled FP8 checkpoint runs on Ampere. **Open WebUI is the only consumer moved** — nothing else rolls over unless this passes.

## Changes

| | from | to |
|---|---|---|
| `vllm` replicas | 0 | **1** |
| `vllm` model | `Qwen3.6-27B-AWQ-BF16-INT4` | **`Qwen3.8-27B-FP8`** |
| `vllm` served-model-name | `qwen3.6-27b` | **`qwen3.8-27b`** |
| `vllm` max-model-len | 262144 | **131072** |
| `llama-cpp` replicas | 1 | **0** |
| `open-webui` backend | llama-cpp-service | **vllm-service** |

Model is already staged on the NFS share (29 GB, 66/66 shards) — this is config only.

## This is expected to fail, and that's the point

The checkpoint is **block-scaled FP8 W8A8** (`weight_block_size: [128,128]`, `activation_scheme: dynamic`). Ampere has no FP8 tensor cores, and vLLM's Ampere fallback is *weight-only* FP8 via Marlin, which does not implement block-wise. Likely error:

```
type fp8e4nv not supported in this architecture
```

vLLM's own recipe for this variant lists only H100 / H200 / B200 / GB200 / B300 / GB300 / MI300X+. No Ampere, no consumer cards.

**Second, independent risk:** the recipe requires `transformers>=5.8.0` (the version that wrote `config.json`). This image is digest-pinned to June 2026 and may ship older — config parsing could fail before any kernel is reached.

Ten minutes of runtime beats more speculation, and the fallback is intact.

## Why max-model-len is halved

FP8 weights are ~28.7 GB against the AWQ's ~16 GB, so on 48 GB at `0.92` utilisation the KV budget drops by roughly half. 262144 would likely OOM or shrink the KV pool to nothing. Raise it only after reading the real `GPU KV cache size` line at startup.

## Sampling

Open WebUI moves to `temp 0.7 / top_p 0.80`. vLLM runs with `enable_thinking=false`, and Qwen publishes different sampling per mode — the thinking values (`1.0 / 0.95`) are correct for the llama-cpp `qwen3.8` preset but wrong against a non-thinking server. Open WebUI sends these explicitly and overrides the server, so they must match the mode it actually runs in.

## Expected breakage while merged

Only Open WebUI knows `qwen3.8-27b`. These still request `qwen3.6-27b` and will 404: Perplexica, Project NOMAD, Karakeep, holmesgpt, litellm, presenton, hindsight, worldmonitor, news-reader. They roll over only if this test passes.

## Revert

`vllm` → 0, `llama-cpp` → 1, Open WebUI back to `llama-cpp-service` with model `qwen3.8`. The GGUF path is untouched and known-working on these cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)