### PR TITLE
vllm: native 262144 context, max-num-seqs 2->3

### DIFF
--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -74,20 +74,29 @@ spec:
             - "--gpu-memory-utilization"
             - "0.92"
             - "--max-model-len"
-            # HALVED for the FP8 experiment (was 262144 with the AWQ-INT4 model).
-            # FP8 weights are ~28.7GB vs the AWQ's ~16GB, so on 48GB at 0.92 util the
-            # KV budget drops by roughly half. 262144 would very likely OOM or shrink
-            # the KV pool to nothing at boot. Raise back toward 262144 only after
-            # reading the actual "GPU KV cache size" line in the startup logs.
-            - "131072"
+            # Native Qwen3.8 context, no YaRN. This costs far less KV than "64
+            # layers" implies: full_attention_interval=4 means only 16 of the 64
+            # layers build a real KV cache (the other 48 are Gated DeltaNet, with
+            # a fixed-size recurrent state instead), so KV works out to
+            #   16 layers x 4 kv-heads x 256 head-dim x 2 (K,V) x 1B fp8 = 32KiB/token.
+            # Raising this does NOT add capacity — the pool is one shared token
+            # budget across all requests; it only raises the per-request ceiling.
+            # Always confirm against the "GPU KV cache size" line in the boot log.
+            - "262144"
             - "--max-num-seqs"
-            - "2"                                      # 262K = deep single-stream; low concurrency keeps the KV pool sane
+            # Three real consumers (Perplexica, pi, Deal Scout) hit this endpoint
+            # at once; at 2 the third ALWAYS queued no matter how much cache was
+            # free. Each slot reserves one GDN recurrent-state set, measured at
+            # ~7.5 blocks (~11.8K tokens) out of a ~303K pool. Don't raise further
+            # without re-reading the boot log: slots come out of the same pool
+            # that still has to admit one full 262144-token request.
+            - "3"
             - "--limit-mm-per-prompt"
             - '{"image": 16}'                          # vision-capable; JSON form required (not image=N).
                                                        # Bumped 4->16: agents (pi/Open WebUI) accumulate screenshots
                                                        # across a turn and Pi resends the whole convo, so a low cap
                                                        # wedges chats with "At most N image(s) per prompt". 16 = ample
-                                                       # headroom; still bounded by the 262K context + max-num-seqs=2.
+                                                       # headroom; still bounded by the 262K context + max-num-seqs=3.
                                                        # NOTE: vLLM profiles startup mem as limit x max-image-tokens,
                                                        # which trims KV cache on this 0.92-util/262K box. If the pod
                                                        # OOMs or KV cache shrinks at boot, drop back toward 8.


### PR DESCRIPTION
Gate 1 of the dual-vs-single 3090 investigation. **vLLM flags only** — two values change, nothing else.

## What changes

| Flag | Before | After |
|---|---:|---:|
| `--max-model-len` | 131072 | **262144** |
| `--max-num-seqs` | 2 | **3** |

Deliberately unchanged: `Qwen3.8-27B-FP8` checkpoint, `TP=2`, Marlin weight-only FP8 fallback, `gpu-memory-utilization 0.92`, `fp8_e4m3` KV at default (uncalibrated, scale 1.0), prefix caching, chunked prefill, `max-num-batched-tokens 8192`, vision config, 200W/card, no YaRN.

## Why 262144

The 131072 cap was set defensively when the FP8 checkpoint landed, assuming 262144 would OOM or leave no KV pool. The live boot log disproves it:

```
GPU KV cache size: 302,921 tokens
Maximum concurrency for 131,072 tokens per request: 2.31x
```

We were capped at 2.31x a context we were not allowed to reach.

Qwen3.8 is a hybrid model — `full_attention_interval: 4`, so only **16 of 64 layers** build a real KV cache (the other 48 are Gated DeltaNet with fixed-size recurrent state):

```
16 layers x 4 kv-heads x 256 head-dim x 2 (K,V) x 1B fp8 = 32 KiB/token
```

Cross-check: 302,921 x 32 KiB = 9.24 GiB vs the measured 2 x 4.99 = 9.98 GiB pool; the delta is GDN state pages.

One 262144-token request needs `ceil(262144/1568) = 168` blocks of ~193 available, so it fits. Nothing in the memory accounting scales with `max_model_len` — activation peak is driven by `max-num-batched-tokens 8192` under chunked prefill. `262144` + fp8 KV is also what the [official vLLM recipe](https://recipes.vllm.ai/Qwen/Qwen3.8-27B) uses for this model.

Note this raises the **per-request ceiling**, not total capacity — the pool stays one shared token budget.

## Why max-num-seqs 3

Baseline A runs three real consumers concurrently (Perplexica, pi, Deal Scout). At `2`, the third queued unconditionally regardless of free cache — that measures the scheduler, not the hardware.

Each slot reserves one GDN recurrent-state set, measured at ~7.5 blocks (~11.8K tokens) of a ~303K pool. Multimodal profiling and CUDA graphs add nothing (capture sizes are already `[1,2,4]`).

## Expected result (boot log is source of truth)

`kv_cache_size_tokens` ~291,161 (-3.9%), concurrency ~1.11x at 262144. **Acceptance: must stay >= 262,144 and boot healthy with zero OOM/restarts.** If it lands lower we stop and report why — no silent reduction of context, memory utilization, KV precision, or quantization.

## Rollback

`git revert` this commit. ArgoCD (automated + selfHeal) restores 131072/2 on the next sync; costs one ~8 min engine reload.

## Not addressed here

Lines 55-60 still claim the FP8 experiment was "Expected to FAIL on these cards" — disproven, it boots via Marlin. Left alone to keep this PR to the two approved flags; worth a cleanup PR with the `docs/domains/ai-gpu/model-catalog.md` correction (still claims vLLM=0 / llama.cpp=1, inverted from live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)