### PR TITLE
omni: add HP 600 G4 Proxmox provider and hp-worker node

### DIFF
--- a/omni/.gitignore
+++ b/omni/.gitignore
@@ -10,6 +10,8 @@ proxmox-provider/.env
 proxmox-provider/config.yaml
 proxmox-provider-dell/.env
 proxmox-provider-dell/config.yaml
+proxmox-provider-hp/.env
+proxmox-provider-hp/config.yaml
 
 # GPG keys (encryption keys for etcd)
 *.asc

--- a/omni/cluster-template/cluster-template-threadripper-gpu-workers.yaml
+++ b/omni/cluster-template/cluster-template-threadripper-gpu-workers.yaml
@@ -189,6 +189,76 @@ patches:
       grow: true
 ---
 kind: Workers
+name: hp-workers
+machineClass:
+  name: hp-worker
+  size: 1
+systemExtensions:
+- siderolabs/iscsi-tools # renovate: datasource=docker depName=siderolabs/iscsi-tools
+- siderolabs/nfs-utils # renovate: datasource=docker depName=siderolabs/nfs-utils
+- siderolabs/nfsrahead # renovate: datasource=docker depName=siderolabs/nfsrahead
+- siderolabs/util-linux-tools # renovate: datasource=docker depName=siderolabs/util-linux-tools
+- siderolabs/qemu-guest-agent # renovate: datasource=docker depName=siderolabs/qemu-guest-agent
+patches:
+- name: hp-worker
+  inline:
+    machine:
+      # Wired LAN, so plain DHCP-on-all-links (the Talos default) is used
+      # rather than the Dell's static address — that pin exists only to give
+      # the media bridge a stable binding to ARP-learn, which does not apply
+      # here. Leaving DHCP alone also means the node survives a PCIe
+      # re-enumeration when disks change; see the removed gpu-network-dhcp
+      # patch below for what pinning an interface name cost last time.
+      nodeLabels:
+        node.vanillax.dev/class: hp-worker
+        # Own failure domain: a separate physical box from the Threadripper
+        # (house) and the Dell (yard). Named after the machine, not the room,
+        # because this mini PC is expected to move.
+        topology.kubernetes.io/zone: hp
+      kubelet:
+        nodeIP:
+          validSubnets:
+          - 192.168.10.0/24
+        extraConfig:
+          serializeImagePulls: false
+      sysctls:
+        net.core.bpf_jit_harden: 1
+- name: hp-longhorn-disks
+  inline:
+    machine:
+      # All-or-nothing annotation: every disk the node should register must be
+      # listed here. Omitting talos-ephemeral does not leave it at defaults —
+      # it leaves the node with zero usable disks.
+      nodeLabels:
+        node.longhorn.io/create-default-disk: "config"
+      nodeAnnotations:
+        node.longhorn.io/default-disks-config: >-
+          [{"name":"talos-ephemeral","path":"/var/lib/longhorn","allowScheduling":false,"diskType":"filesystem","storageReserved":17179869184,"tags":[]},{"name":"hp-ssd","path":"/var/mnt/longhorn-hp-ssd","allowScheduling":true,"diskType":"filesystem","storageReserved":0,"tags":["hp-ssd"]}]
+      kubelet:
+        extraMounts:
+        - destination: /var/lib/longhorn
+          type: bind
+          source: /var/local/longhorn
+          options:
+          - bind
+          - rshared
+          - rw
+- name: hp-longhorn-ssd-volume
+  inline:
+    apiVersion: v1alpha1
+    kind: UserVolumeConfig
+    name: longhorn-hp-ssd
+    provisioning:
+      # Size is the only thing distinguishing this 850 GiB scsi1 device from
+      # the 64 GiB boot disk. Do NOT add a `disk.transport == 'scsi'` clause:
+      # Proxmox virtio-scsi disks never match it and the volume silently goes
+      # unprovisioned.
+      diskSelector:
+        match: "!system_disk && disk.size >= 700u * GB"
+      minSize: 700GB
+      grow: true
+---
+kind: Workers
 name: workers
 machineClass:
   name: threadripper-worker

--- a/omni/machine-classes/hp-worker.yaml
+++ b/omni/machine-classes/hp-worker.yaml
@@ -1,0 +1,47 @@
+---
+# omnictl apply -f omni/machine-classes/hp-worker.yaml
+# CPU worker on the HP 600 G4 mini (192.168.10.20), wired LAN.
+metadata:
+  namespace: default
+  type: MachineClasses.omni.sidero.dev
+  id: hp-worker
+spec:
+  matchlabels: []
+  autoprovision:
+    providerid: proxmox-hp
+    kernelargs: []
+    metavalues: []
+    providerdata: |
+      # i5-8500T, 6 physical cores / 16 GiB on the host. 4 cores + 12 GiB keeps
+      # two cores and ~4 GiB for Proxmox, the provider agent, and qemu overhead
+      # so a 16 GiB box never reaches for swap.
+      cores: 4
+      sockets: 1
+      memory: 12288
+      # Boot/image disk on the NVMe `local-lvm` thin pool (~141 GiB free).
+      # Longhorn data lives on the separate SSD below, never here.
+      disk_size: 64
+      storage_selector: name == "local-lvm"
+      network_bridge: vmbr0
+      disk_ssd: true
+      disk_discard: true
+      disk_iothread: true
+      disk_cache: none
+      disk_aio: io_uring
+      # Dedicated Longhorn disk on the 931 GiB PNY CS900 SSD (/dev/sda),
+      # exposed as the thick-LVM Proxmox storage `hp-ssd-vmstore`. 850 GiB
+      # leaves ~81 GiB of device headroom. Do not use LVM-thin: this repo has
+      # measured its metadata commits collapsing fsync performance.
+      additional_disks:
+        - storage_selector: name == "hp-ssd-vmstore"
+          disk_size: 850
+          disk_ssd: true
+          disk_discard: true
+          disk_iothread: true
+          disk_cache: none
+          disk_aio: io_uring
+      cpu_type: host
+      machine_type: q35
+      bios: seabios
+      vga: std
+      balloon: false

--- a/omni/proxmox-provider-hp/.env.example
+++ b/omni/proxmox-provider-hp/.env.example
@@ -1,0 +1,8 @@
+# Copy to .env and fill in. .env is gitignored.
+# Omni instance on the NUC.
+OMNI_API_ENDPOINT=https://omni.example.com/
+
+# Infrastructure Provider Key for provider id "proxmox-hp", minted with
+# `omnictl infraprovider create proxmox-hp`.
+# This is an Infrastructure Provider Key, NOT a service account key.
+OMNI_INFRA_PROVIDER_KEY=your-infra-provider-key-here

--- a/omni/proxmox-provider-hp/config.yaml.example
+++ b/omni/proxmox-provider-hp/config.yaml.example
@@ -1,0 +1,12 @@
+# Copy to config.yaml and fill in credentials. config.yaml is gitignored.
+proxmox:
+  # HP 600 G4 mini host (wired LAN).
+  url: "https://192.168.10.20:8006/api2/json"
+  insecureSkipVerify: true
+
+  # Dedicated omni@pve account with the Administrator role at `/`, same as the
+  # Dell host. API tokens are NOT used: they have had insufficient permissions
+  # AND the user@realm!tokenid secret format breaks on special characters.
+  username: "omni"
+  password: "CHANGE_ME"
+  realm: "pve"

--- a/omni/proxmox-provider-hp/docker-compose.yml
+++ b/omni/proxmox-provider-hp/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  omni-infra-provider-proxmox-hp:
+    # Third instance of the Sidero Proxmox provider, pointed at the HP 600 G4
+    # host (192.168.10.20) and registered in Omni as provider id "proxmox-hp".
+    # Pinned to a tagged release plus content digest so all three provider
+    # instances run the same build; Renovate tracks the tag.
+    image: ghcr.io/siderolabs/omni-infra-provider-proxmox:v0.2.0@sha256:c0d0687e87d9f2fb77c7a9d6d7263820953d20441200f3de64b22afaa7ff273e
+    container_name: omni-infra-provider-proxmox-hp
+    env_file:
+      - .env
+    volumes:
+      - ./config.yaml:/config.yaml:ro
+    command: >
+      --config-file /config.yaml
+      --omni-api-endpoint ${OMNI_API_ENDPOINT}
+      --omni-service-account-key ${OMNI_INFRA_PROVIDER_KEY}
+      --id proxmox-hp
+      --provider-name "Proxmox HP"
+      --provider-description "Proxmox infrastructure provider - HP 600 G4 mini host"
+    restart: unless-stopped
+    network_mode: host


### PR DESCRIPTION
Adds the HP 600 G4 mini (192.168.10.20) as a third Omni infrastructure provider and brings up one worker from it. **Already applied and verified live** — this PR records the state that is running.

## What changed

| File | Purpose |
|---|---|
| `omni/proxmox-provider-hp/` | Third provider compose stack + `.env`/`config.yaml` examples |
| `omni/machine-classes/hp-worker.yaml` | `hp-worker` class on provider `proxmox-hp` |
| `omni/cluster-template/...-threadripper-gpu-workers.yaml` | `hp-workers` machine set (size 1) |
| `omni/.gitignore` | Ignore the new provider's `.env` and `config.yaml` |

## Host

i5-8500T (6c) / 16 GiB / 238G NVMe + a spare 931G PNY CS900 SSD. VM sized 4 cores / 12 GiB, leaving headroom so a 16 GiB box never reaches for swap.

## Storage

The spare SSD follows the existing `dell-ssd` pattern: thick LVM VG `hp-ssd-vmstore` on `/dev/sda` → 850 GiB `scsi1` → Talos `UserVolumeConfig` → Longhorn disk `hp-ssd` (tag `hp-ssd`) at `/var/mnt/longhorn-hp-ssd`.

LVM-**thin** is deliberately avoided per the rule established on the Dell class — thin-pool metadata commits were measured collapsing fsync performance.

## Verification

```
...-hp-workers-gkfrw8   Ready   hp   v1.36.3
```

- All pods on the node `Running` (Cilium, both CSI node plugins, Longhorn manager/CSI/engine-image, node-exporter, OTEL agent)
- Longhorn disk `hp-ssd`: **912.2 GB**, Ready + Schedulable. Cluster schedulable capacity 1.72 TB → **2.63 TB**
- `talos-ephemeral` registered with `allowScheduling: false` — the 64G boot disk never takes replicas
- `omnictl cluster template diff` was **purely additive** before syncing: 5 new resources, all scoped to `hp-workers`, zero edits to existing machine sets

## Notes on two gotchas this had to avoid

- The `diskSelector` carries **no** `disk.transport == 'scsi'` clause — Proxmox virtio-scsi never matches it and the volume would silently go unprovisioned.
- `node.longhorn.io/default-disks-config` is all-or-nothing, so `talos-ephemeral` is listed explicitly; omitting it registers **zero** disks rather than falling back to defaults.

The node uses plain DHCP. The Dell's static-address patch is deliberately not copied — that exists only so the wifi media bridge has a stable binding to ARP-learn, which does not apply to a wired host.

## Zone naming

`topology.kubernetes.io/zone: hp` — named after the machine rather than a room, since this mini PC may move to the shed. Nothing in the repo uses zone-based `topologySpreadConstraints`; the only live consumer is Longhorn's `replica-zone-soft-anti-affinity=true`, so a distinct zone makes Longhorn *prefer* placing a replica here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)