### PR TITLE
deal-scout: v0.11.0

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.10.0@sha256:c45549a631fdf88a86da5cf832ece835996c8555c465e6d8180b62e9be25fd21
+          image: ghcr.io/mitchross/deal-scout:v0.11.0@sha256:dec7a80f0e6aad7e45304c5482fbe488949e200272d0d4dcac37d9eacfe90c2d
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.10.0@sha256:c8d2cdbbb13ee55bbbde892ad4b76ee8d37e4e9d2b472da7f25b7f3e4ad7c0eb
+          image: ghcr.io/mitchross/deal-scout-worker:v0.11.0@sha256:8fede2512e2778ef89309bb9d2e0a1d99590e78af813f64d08627480813bd3b3
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Bumps both deal-scout images to `v0.11.0`, pinned by digest.

| image | digest |
|---|---|
| `ghcr.io/mitchross/deal-scout` | `sha256:dec7a80f0e6aad7e45304c5482fbe488949e200272d0d4dcac37d9eacfe90c2d` |
| `ghcr.io/mitchross/deal-scout-worker` | `sha256:8fede2512e2778ef89309bb9d2e0a1d99590e78af813f64d08627480813bd3b3` |

Built locally from `mitchross/deal-scout@2ccf4e2` (master, CI green) via `scripts/release.sh --minor --local`. Both tags verified pullable from GHCR.

**What's in it** — LowCostMiniPCs becomes a cluster-side structured feed: the adapter was pointing at a Shopify path this site doesn't have and ran through CDP for a page that needs no browser, so it now runs in-cluster on a plain fetch instead of depending on the desktop runner. It also carries a classifier change (an explicit `variant` flag so eBay multi-config listings can't read as steals) and the CI fixes that got `master` green again.

Post-merge: `./scripts/verify-deploy.sh v0.11.0` from the LAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)