### PR TITLE
Gate 2: roll Perplexica + Deal Scout to qwen3.8-27b, add real-world load collector

### DIFF
--- a/benchmarks/ai-realworld-load/.gitignore
+++ b/benchmarks/ai-realworld-load/.gitignore
@@ -1,0 +1,3 @@
+runs/
+.current-run
+__pycache__/

--- a/benchmarks/ai-realworld-load/README.md
+++ b/benchmarks/ai-realworld-load/README.md
@@ -1,0 +1,213 @@
+# Real-world AI load baseline (dual vs single RTX 3090)
+
+Answers one question: **can ONE RTX 3090 serve Perplexica + Pi + Deal Scout
+without materially losing usable context?** Context capacity is the criterion,
+not tokens/sec.
+
+Not ArgoCD-managed — `benchmarks/` sits outside every AppSet glob. Nothing here
+deploys; the collector only reads. Runs land in `runs/` (git-ignored).
+
+## Baselines
+
+| | Hardware | Model | Status |
+|---|---|---|---|
+| **A** | 2x RTX 3090, TP=2, PCIe/no NVLink | Qwen3.8-27B-**FP8** (Marlin weight-only) | this doc |
+| **B** | 1x RTX 3090, TP=1 | Qwen3.8-27B W4A16 AutoRound (INT8 `lm_head`/`embed_tokens`, ~14.26 GiB) | later |
+
+B must reuse the **verbatim prompts in this file** or the comparison is void.
+
+### Baseline A configuration (measured at boot, not assumed)
+
+```
+vLLM 0.27.1 · Qwen3.8-27B-FP8 · TP=2 · mp · no custom all-reduce
+--max-model-len 262144      (native, NO YaRN)
+--max-num-seqs 3
+--gpu-memory-utilization 0.92
+--kv-cache-dtype fp8_e4m3   (uncalibrated, scale 1.0)
+--enable-prefix-caching --enable-chunked-prefill --max-num-batched-tokens 8192
+--limit-mm-per-prompt {"image": 16}
+200W/card power limit
+
+KV capacity ceiling : 313,367 tokens   <- Baseline A ceiling. Not the earlier ~291K estimate.
+Max concurrency     : 1.20x @ 262,144
+Weights             : 14.46 GiB/GPU   KV: 4.99 GiB/GPU   CUDA graphs: 0.46 GiB/GPU
+```
+
+**Do not change** gpu-memory-utilization, KV precision/scales, quantization, or
+any other vLLM tuning during Baseline A.
+
+### FP8 KV cache — stated accurately
+
+> Uncalibrated FP8 KV; vLLM defaults to scale 1.0 when checkpoint scales are
+> unavailable; published vLLM accuracy work suggests this is often good,
+> including strong Qwen3.5-27B long-context results, but our exact RTX
+> 3090/SM86 Qwen3.8 path is not independently validated.
+
+Hence the retrieval sanity check in step 6. `--calculate-kv-scales` stays **off**.
+
+### Preemption is RECOMPUTE — verified in the running engine
+
+Confirmed by reading `vllm/v1/core/sched/scheduler.py` inside the live pod, not
+from docs. `_preempt_request()` calls `_free_request_blocks()` and sets
+`request.num_computed_tokens = 0`. There is no `PreemptionMode` and no
+`swap_out` anywhere under `vllm/v1/` — swap was removed in V1.
+
+A preempted 262K request therefore **re-prefills from token 0** (32 chunks at
+`max-num-batched-tokens 8192`). Prefix caching can partially rescue it, but the
+blocks it would need are the ones evicted under the pressure that caused the
+preemption. At 1.20x concurrency this is the most likely source of a severe
+user-visible stall with no request technically failing — which is why
+`report.py` prints per-event forensics including KV% immediately before.
+
+## What gets measured, and how honestly
+
+| Number | Source | Tag |
+|---|---|---|
+| Peak simultaneous resident context | `kv_cache_usage_perc` x 313,367 | **DERIVED** (upper bound: includes prefix-cache blocks) |
+| Pi peak context | `usage.input` in Pi's session JSONL | **MEASURED** |
+| Perplexica peak context | histogram bucket, Pi excluded by elimination | **DERIVED** (range) |
+| Deal Scout digest prompt | smallest histogram bucket; exact via `/tokenize` after | **DERIVED** |
+| running / waiting / preemptions / KV% | vLLM gauges + counters | **MEASURED** |
+| TTFT / TPOT / queue / prefill | histogram `_sum`/`_count` deltas | **DERIVED** (means) |
+| VRAM / util / power / temp per card | `nvidia-smi` in the powerlimit DaemonSet | **MEASURED** |
+
+vLLM's `request_prompt_tokens` buckets are coarse (…20k, 50k, 100k, 200k, Inf),
+so server-side per-request sizes are **ranges**. Getting exact values would need
+`--enable-log-requests` (a restart) or a logging proxy (changes production app
+behaviour) — both out of scope. Per-request counts are never invented from
+aggregate counters.
+
+## Run sequence
+
+```bash
+cd benchmarks/ai-realworld-load
+
+# 1. start collection (verifies /health first, refuses on an unhealthy server)
+./tools/collect.sh start baseline-a
+
+# 2. watch it, in a second terminal — reads only the collector's files
+./tools/live.sh
+```
+
+Then launch the three workloads **close together** — all three must genuinely
+overlap or the run does not test concurrency. `report.py` fails loudly if they
+never do.
+
+3. **Workload A — Perplexica.** Open <https://perplexica.vanillax.me>, select
+   `Qwen 3.8 27B (vLLM, TP=2)`, paste the Workload A prompt below.
+4. **Within ~30s, Workload B — Pi.** In a clone of `mitchross/deal-scout`:
+   `pi --model qwen3.8-27b` then paste the Workload B prompt.
+5. **Workload C — Deal Scout digest**, once A and B are both generating:
+   ```bash
+   curl -sS -X POST https://deals.vanillax.me/api/digest/generate | jq '.model, .note'
+   ```
+   Read-only summarisation of existing rows; writes one `digests` row. It does
+   not mutate listings.
+6. **Retrieval sanity check**, while long contexts are resident — asks the model
+   to recall something only findable deep in Perplexica's own returned context:
+   in the same Perplexica thread, ask
+   `Quote the exact sentence from your sources that gives the VRAM figure for the Ryzen AI Max+ 395, and name the source.`
+   A confident answer citing nothing, or a number absent from the sources, is
+   the FP8-KV/long-context failure mode we are watching for.
+7. Tell me when all three are active. Leave the collector running until
+   everything finishes.
+
+```bash
+# 8. finalise
+./tools/collect.sh stop
+./tools/report.py runs/<dir> --pi-session ~/.pi/agent/sessions/<deal-scout-dir>/<newest>.jsonl
+```
+
+---
+
+## Workload A — Perplexica (verbatim; reuse for Baseline B)
+
+```
+Research Qwen3.8-27B local inference as of August 2026. Determine the practical
+hardware requirements for running it as a long-context local research and coding
+model. Compare 1x RTX 3090, 2x RTX 3090 over PCIe without NVLink, Ryzen AI Max+
+395, Ryzen AI Max+ PRO 495, and NVIDIA DGX Spark.
+
+Investigate Qwen3.8 itself, not merely Qwen3.6.
+
+For every result distinguish:
+- directly measured Qwen3.8 data
+- same-architecture Qwen3.6 proxy data
+- vendor claims
+- calculated estimates
+- community anecdotes
+
+Research:
+- model and quantization formats
+- inference runtime
+- VRAM/memory usage
+- usable context length
+- KV-cache format
+- long-context retrieval quality
+- prefill performance at large context
+- decode performance
+- speculative decoding/MTP
+- power draw where measured
+- Qwen3.8-specific bugs
+- Claude Code/Codex/Pi compatibility
+- whether one 24GB RTX 3090 can provide roughly 200-256K useful context without
+  unacceptable quality or prefill loss
+- whether dual 3090s materially improve useful context/concurrency
+- current KVarN/TurboQuant/low-bit-KV developments
+
+Use primary sources where possible, plus high-quality GitHub issues and
+community measurements.
+
+Reconcile conflicting measurements rather than picking whichever number looks
+best.
+
+Produce a detailed cited report.
+```
+
+## Workload B — Pi in `mitchross/deal-scout` (verbatim; reuse for Baseline B)
+
+Let Pi read files naturally. Do **not** stuff files into the prompt — the point
+is watching context grow on its own.
+
+```
+Perform a deep READ-ONLY architecture and correctness investigation of this
+repository.
+
+Trace the real system from scraper ingestion through normalization,
+price/quantity extraction, classification, persistence, ranking/filtering,
+Temporal/background processing, dashboard/API output, and local-LLM
+digest/analysis.
+
+Inspect implementation, tests, configuration, docs, git history where useful,
+and representative data handling.
+
+Pay special attention to:
+- product/model numbers incorrectly interpreted as quantities
+- lot/bundle/quantity inference
+- false-positive deal classification
+- duplicate/normalization behavior
+- stale or conflicting business rules
+- where deterministic logic stops and LLM judgment begins
+- guards against hallucinated LLM facts/numbers
+- failure/retry behavior
+- places where a prior debugging fix may have created a new edge case
+
+Run existing tests as appropriate.
+
+Do NOT modify files.
+
+Return the five most important correctness/architecture findings with exact
+files/functions, evidence, and recommended follow-up tests.
+```
+
+## Workload C — Deal Scout digest
+
+Real supported path, confirmed in source: `dashboard/app.py:834`
+`POST /api/digest/generate` -> `generate_digest(conn)`, driven in production by
+`worker/activities.js:82 generateDigest()`.
+
+`build_digest_facts()` is pure SQL and always renders; `narrate_digest()` is the
+optional LLM leg. It is **best-effort by design** — that is exactly why the dead
+`qwen3.6-27b` id produced no error for months, just silently factual digests. If
+`.model` in the response is null, the LLM leg did not run and Workload C
+contributed no load.

--- a/benchmarks/ai-realworld-load/tools/collect.sh
+++ b/benchmarks/ai-realworld-load/tools/collect.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Baseline A collector — real-world three-way load on the dual-3090 vLLM endpoint.
+#
+# NOT ArgoCD-managed. benchmarks/ is outside every AppSet glob (my-apps/*/*,
+# infrastructure explicit list, monitoring/*, infrastructure/database/*/*).
+# Nothing here deploys; it only reads.
+#
+# Design note: samples via THREE long-lived streams rather than per-tick
+# `kubectl exec`. A 2s exec loop costs ~0.5-1s of kubectl overhead per tick and
+# would jitter the sample interval badly. nvidia-smi has a native `-l` loop and
+# the metrics/log streams run their loop inside the pod, so the only per-sample
+# cost is network read.
+#
+# Usage:
+#   collect.sh start [label]   -> begins capture, prints RUN dir
+#   collect.sh stop            -> stops capture, finalizes
+#   collect.sh status          -> is it running?
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNS="$ROOT/runs"
+STATE="$ROOT/.current-run"
+NS=vllm
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+vllm_pod() {
+  kubectl -n "$NS" get pod -l app=vllm-server \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+cmd_start() {
+  local label="${1:-baseline-a}"
+  [ -f "$STATE" ] && die "a run is already active ($(cat "$STATE")). Run: collect.sh stop"
+
+  local pod; pod="$(vllm_pod)"
+  [ -n "$pod" ] || die "no vllm-server pod found"
+  kubectl -n "$NS" exec "$pod" -- curl -sf -o /dev/null http://localhost:8000/health \
+    || die "vLLM /health not OK — refusing to start a run against an unhealthy server"
+
+  local ts run
+  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+  run="$RUNS/${ts}_${label}"
+  mkdir -p "$run"
+  echo "$run" > "$STATE"
+
+  # ---- Immutable run context: what this baseline actually ran against. -------
+  {
+    echo "run_started_utc=$ts"
+    echo "label=$label"
+    echo "pod=$pod"
+    echo "image=$(kubectl -n $NS get pod "$pod" -o jsonpath='{.spec.containers[0].image}')"
+    echo "node=$(kubectl -n $NS get pod "$pod" -o jsonpath='{.spec.nodeName}')"
+    echo "git_head=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null)"
+  } > "$run/context.env"
+
+  kubectl -n "$NS" get deploy vllm-server -o jsonpath='{.spec.template.spec.containers[0].args}' \
+    > "$run/vllm-args.json" 2>/dev/null
+  kubectl -n "$NS" exec "$pod" -- curl -s http://localhost:8000/v1/models \
+    > "$run/models.json" 2>/dev/null
+  # KV capacity ceiling is read from the live engine, never hardcoded — the
+  # report divides by this to turn kv_cache_usage_perc into resident tokens.
+  kubectl -n "$NS" exec "$pod" -- curl -s http://localhost:8000/metrics 2>/dev/null \
+    | grep 'cache_config_info' > "$run/cache-config.txt"
+
+  # ---- Stream 1: vLLM metrics, 2s, filtered inside the pod ------------------
+  # Full /metrics is ~40KB; grepping pod-side keeps this to a few hundred bytes
+  # per tick. Histogram *buckets* are kept in full: when a request finishes,
+  # exactly one bucket increments, which is how per-request sizes get attributed.
+  nohup kubectl -n "$NS" exec "$pod" -- sh -c '
+    while true; do
+      echo "===TICK $(date -u +%Y-%m-%dT%H:%M:%SZ) $(date +%s)"
+      curl -s http://localhost:8000/metrics | grep -E "^vllm:" | grep -vE "_created|estimated_"
+      sleep 2
+    done' > "$run/metrics.stream" 2>"$run/metrics.err" &
+  echo $! > "$run/.pid.metrics"
+
+  # ---- Stream 2: per-GPU telemetry via nvidia-smi native loop ---------------
+  # Runs in the powerlimit DaemonSet, NOT the inference pod, so sampling never
+  # competes with the workload under test.
+  local dspod
+  dspod="$(kubectl -n gpu-operator get pod -l app=nvidia-powerlimit -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)"
+  [ -n "$dspod" ] || dspod="$(kubectl -n gpu-operator get pods -o name 2>/dev/null | grep powerlimit | head -1 | cut -d/ -f2)"
+  if [ -n "$dspod" ]; then
+    nohup kubectl -n gpu-operator exec "$dspod" -- \
+      nvidia-smi --query-gpu=timestamp,index,memory.used,memory.total,utilization.gpu,utilization.memory,power.draw,power.limit,temperature.gpu,pcie.link.gen.current,pcie.link.width.current \
+                 --format=csv,noheader,nounits -l 2 \
+      > "$run/gpu.csv" 2>"$run/gpu.err" &
+    echo $! > "$run/.pid.gpu"
+    echo "gpu_source=gpu-operator/$dspod" >> "$run/context.env"
+  else
+    # Fallback: sample from the inference pod itself. Noted explicitly because
+    # it is a slightly worse measurement, not an equivalent one.
+    nohup kubectl -n "$NS" exec "$pod" -- \
+      nvidia-smi --query-gpu=timestamp,index,memory.used,memory.total,utilization.gpu,utilization.memory,power.draw,power.limit,temperature.gpu,pcie.link.gen.current,pcie.link.width.current \
+                 --format=csv,noheader,nounits -l 2 \
+      > "$run/gpu.csv" 2>"$run/gpu.err" &
+    echo $! > "$run/.pid.gpu"
+    echo "gpu_source=vllm-pod-fallback" >> "$run/context.env"
+  fi
+
+  # ---- Stream 3: full vLLM log for the window ------------------------------
+  # Carries the periodic engine line (Running/Waiting/KV%/prefix-hit-rate) and
+  # any preemption / cache-allocation / context-length errors.
+  nohup kubectl -n "$NS" logs -f "$pod" --since=10s \
+    > "$run/vllm.log" 2>"$run/vllm-log.err" &
+  echo $! > "$run/.pid.logs"
+
+  # ---- Stream 4: pod resource + restart state, 10s ------------------------
+  nohup bash -c '
+    while true; do
+      printf "%s," "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      kubectl -n '"$NS"' get pod '"$pod"' \
+        -o jsonpath="{.status.phase},{.status.containerStatuses[0].ready},{.status.containerStatuses[0].restartCount},{.status.containerStatuses[0].lastState.terminated.reason}" 2>/dev/null
+      echo ""
+      sleep 10
+    done' > "$run/pod.csv" 2>/dev/null &
+  echo $! > "$run/.pid.pod"
+
+  echo "RUN=$run"
+  echo "started 4 streams (metrics 2s / gpu 2s / logs follow / pod 10s)"
+}
+
+cmd_stop() {
+  [ -f "$STATE" ] || die "no active run"
+  local run; run="$(cat "$STATE")"
+
+  for f in "$run"/.pid.*; do
+    [ -e "$f" ] || continue
+    kill "$(cat "$f")" 2>/dev/null
+    rm -f "$f"
+  done
+  sleep 1
+  pkill -f "kubectl -n $NS exec.*8000/metrics" 2>/dev/null
+  pkill -f "nvidia-smi --query-gpu=timestamp" 2>/dev/null
+
+  local pod; pod="$(vllm_pod)"
+  echo "run_ended_utc=$(date -u +%Y%m%dT%H%M%SZ)" >> "$run/context.env"
+  # Final absolute counters — the run's totals are (final - first tick).
+  kubectl -n "$NS" exec "$pod" -- curl -s http://localhost:8000/metrics 2>/dev/null \
+    | grep -E '^vllm:' > "$run/metrics.final"
+  kubectl -n "$NS" get events --sort-by=.lastTimestamp > "$run/events.txt" 2>/dev/null
+
+  rm -f "$STATE"
+  echo "stopped. RUN=$run"
+  echo "next: tools/report.py \"$run\""
+}
+
+cmd_status() {
+  if [ -f "$STATE" ]; then
+    local run; run="$(cat "$STATE")"
+    echo "ACTIVE: $run"
+    echo "metric ticks: $(grep -c '===TICK' "$run/metrics.stream" 2>/dev/null || echo 0)"
+    echo "gpu samples:  $(wc -l < "$run/gpu.csv" 2>/dev/null || echo 0)"
+  else
+    echo "no active run"
+  fi
+}
+
+case "${1:-}" in
+  start)  shift; cmd_start "$@" ;;
+  stop)   cmd_stop ;;
+  status) cmd_status ;;
+  *) echo "usage: $0 {start [label]|stop|status}"; exit 1 ;;
+esac

--- a/benchmarks/ai-realworld-load/tools/live.sh
+++ b/benchmarks/ai-realworld-load/tools/live.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Live view for the active Baseline A run. Reads ONLY the collector's files —
+# it opens no extra connections to vLLM or the GPUs, so watching the run costs
+# the run nothing.
+#
+#   TIME | RUNNING | WAITING | KV% | RESIDENT | GPU0/1 VRAM | GPU0/1 UTIL | GPU0/1 W | PREEMPT
+#
+# RESIDENT = kv_cache_usage_perc x kv_cache_size_tokens, i.e. how much real
+# context is resident across all active requests. This is the number the whole
+# single-vs-dual decision turns on, so it is on screen the entire run.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE="$ROOT/.current-run"
+[ -f "$STATE" ] || { echo "no active run — start one with: tools/collect.sh start"; exit 1; }
+RUN="$(cat "$STATE")"
+
+CAP=$(grep -o 'kv_cache_size_tokens="[0-9]*"' "$RUN/cache-config.txt" 2>/dev/null | grep -o '[0-9]*')
+CAP=${CAP:-313367}
+
+printf '\033[1m%-8s %4s %4s %7s %9s  %6s %6s  %4s %4s  %5s %5s %4s\033[0m\n' \
+  TIME RUN WAIT "KV%" RESIDENT G0MiB G1MiB G0% G1% G0W G1W PREE
+echo "capacity=$CAP tokens   run=$(basename "$RUN")"
+printf '%.0s-' {1..92}; echo
+
+while true; do
+  # Last complete metrics tick.
+  TICK=$(awk '/===TICK/{buf=""} {buf=buf $0 "\n"} END{printf "%s", buf}' "$RUN/metrics.stream" 2>/dev/null)
+  T=$(echo "$TICK"  | awk '/===TICK/{print $2}' | cut -dT -f2 | tr -d 'Z')
+  RUNQ=$(echo "$TICK" | awk -F' ' '/^vllm:num_requests_running/{print $2}' | head -1)
+  WAIT=$(echo "$TICK" | awk -F' ' '/^vllm:num_requests_waiting\{/{print $2}' | head -1)
+  KV=$(echo "$TICK"   | awk -F' ' '/^vllm:kv_cache_usage_perc/{print $2}' | head -1)
+  PRE=$(echo "$TICK"  | awk -F' ' '/^vllm:num_preemptions_total/{print $2}' | head -1)
+
+  # Latest line per GPU index. Must match FIELD 2 exactly: a substring grep for
+  # ", 0," also hits the utilization/temperature columns, which silently made
+  # both columns show the same card.
+  G0=$(awk -F', *' '$2=="0"' "$RUN/gpu.csv" 2>/dev/null | tail -1)
+  G1=$(awk -F', *' '$2=="1"' "$RUN/gpu.csv" 2>/dev/null | tail -1)
+  g0m=$(echo "$G0" | awk -F', ' '{print $3}'); g0u=$(echo "$G0" | awk -F', ' '{print $5}'); g0w=$(echo "$G0" | awk -F', ' '{print $7}')
+  g1m=$(echo "$G1" | awk -F', ' '{print $3}'); g1u=$(echo "$G1" | awk -F', ' '{print $5}'); g1w=$(echo "$G1" | awk -F', ' '{print $7}')
+
+  RES=$(awk -v k="${KV:-0}" -v c="$CAP" 'BEGIN{printf "%d", k*c}')
+  KVP=$(awk -v k="${KV:-0}" 'BEGIN{printf "%.1f", k*100}')
+
+  printf '%-8s %4s %4s %6s%% %9s  %6s %6s  %4s %4s  %5s %5s %4s\n' \
+    "${T:-–}" "${RUNQ:-–}" "${WAIT:-–}" "${KVP:-–}" "${RES:-–}" \
+    "${g0m:-–}" "${g1m:-–}" "${g0u:-–}" "${g1u:-–}" "${g0w:-–}" "${g1w:-–}" "${PRE:-0}"
+  sleep 2
+done

--- a/benchmarks/ai-realworld-load/tools/report.py
+++ b/benchmarks/ai-realworld-load/tools/report.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Baseline A report.
+
+Every number is tagged MEASURED or DERIVED. That distinction is the whole point
+of this run: the single-vs-dual GPU decision rests on peak real context, and a
+derived number that looks measured would quietly corrupt it.
+
+  MEASURED  read directly from a counter/gauge/log the server or client emitted
+  DERIVED   computed from those (e.g. kv_usage_perc x capacity), stated with its
+            formula, and given as a RANGE when the source is a histogram bucket
+
+Usage: report.py <run-dir> [--pi-session <path>]
+"""
+import sys, os, json, re, glob
+from collections import defaultdict
+
+M, D = "MEASURED", "DERIVED"
+
+
+def parse_ticks(path):
+    """metrics.stream -> [(epoch, {metric_key: value})]"""
+    ticks, cur, ts = [], None, None
+    if not os.path.exists(path):
+        return ticks
+    for line in open(path, errors="replace"):
+        line = line.rstrip("\n")
+        if line.startswith("===TICK"):
+            if cur is not None:
+                ticks.append((ts, cur))
+            p = line.split()
+            ts = int(p[2]) if len(p) > 2 and p[2].isdigit() else None
+            cur = {}
+        elif cur is not None and line.startswith("vllm:"):
+            try:
+                key, val = line.rsplit(" ", 1)
+                cur[key] = float(val)
+            except ValueError:
+                pass
+    if cur:
+        ticks.append((ts, cur))
+    return ticks
+
+
+def g(sample, prefix):
+    """First metric whose name starts with prefix (labels vary)."""
+    for k, v in sample.items():
+        if k.startswith(prefix):
+            return v
+    return None
+
+
+def hist_buckets(sample, name):
+    """[(le, cumulative_count)] sorted ascending for a histogram."""
+    out = []
+    for k, v in sample.items():
+        if k.startswith(name + "_bucket"):
+            m = re.search(r'le="([^"]+)"', k)
+            if m:
+                le = float("inf") if m.group(1) in ("+Inf", "Inf") else float(m.group(1))
+                out.append((le, v))
+    return sorted(out)
+
+
+def bucket_range(before, after):
+    """Which bucket(s) gained count between two histogram snapshots.
+
+    Returns list of (lo, hi, n) — a request that completed landed in (lo, hi].
+    This is the ONLY server-side per-request size signal vLLM exposes here, and
+    it is coarse (…20k, 50k, 100k, 200k, Inf), so results are ranges by nature.
+    """
+    b, a = dict(before), dict(after)
+    les = sorted(a)
+    out, prev_le = [], 0.0
+    for le in les:
+        d = a.get(le, 0) - b.get(le, 0)
+        # cumulative: subtract everything already attributed to smaller buckets
+        lower = sum(x[2] for x in out)
+        n = d - lower
+        if n > 0:
+            out.append((prev_le, le, n))
+        prev_le = le
+    return out
+
+
+def fmt(n):
+    return f"{int(n):,}" if n is not None else "–"
+
+
+def section(t):
+    print(f"\n{'='*78}\n{t}\n{'='*78}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+    run = sys.argv[1].rstrip("/")
+    pi_session = None
+    if "--pi-session" in sys.argv:
+        pi_session = sys.argv[sys.argv.index("--pi-session") + 1]
+
+    ctx = {}
+    if os.path.exists(f"{run}/context.env"):
+        for line in open(f"{run}/context.env"):
+            if "=" in line:
+                k, v = line.strip().split("=", 1)
+                ctx[k] = v
+
+    cap = 313367
+    cc = f"{run}/cache-config.txt"
+    if os.path.exists(cc):
+        m = re.search(r'kv_cache_size_tokens="(\d+)"', open(cc).read())
+        if m:
+            cap = int(m.group(1))
+
+    ticks = parse_ticks(f"{run}/metrics.stream")
+    if not ticks:
+        print("no metric ticks captured — was the collector running?")
+        sys.exit(1)
+
+    print(f"BASELINE A — {os.path.basename(run)}")
+    print(f"pod={ctx.get('pod','?')}  node={ctx.get('node','?')}")
+    print(f"window={ctx.get('run_started_utc','?')} .. {ctx.get('run_ended_utc','in progress')}")
+    print(f"KV capacity ceiling = {cap:,} tokens   [{M}, from engine cache_config_info]")
+    print(f"gpu sampling source = {ctx.get('gpu_source','?')}")
+    print(f"ticks captured = {len(ticks)} (~2s apart)")
+
+    # ---------------- headline numbers -------------------------------------
+    section("THE FOUR NUMBERS")
+
+    # NB: every metric key carries Prometheus labels
+    # (vllm:num_requests_running{engine="0",model_name="..."}), so these MUST go
+    # through the prefix helper. Exact-key lookups silently return 0 and make a
+    # loaded run look idle.
+    resident = [(t, (g(s, "vllm:kv_cache_usage_perc") or 0.0) * cap) for t, s in ticks]
+    peak_res = max((r for _, r in resident), default=0)
+    peak_t = max(resident, key=lambda x: x[1])[0] if resident else None
+
+    print(f"\n4. PEAK SIMULTANEOUS RESIDENT CONTEXT : {fmt(peak_res)} tokens   [{D}]")
+    print(f"   formula: max(vllm:kv_cache_usage_perc) x {cap:,}")
+    print(f"   = {peak_res/cap*100:.1f}% of the dual-3090 pool" if cap else "")
+    print(f"   NOTE: KV occupancy includes blocks retained by the prefix cache,")
+    print(f"         so this is an upper bound on live request context.")
+
+    # Per-workload: histogram bucket deltas across the whole run.
+    first, last = ticks[0][1], ticks[-1][1]
+    hb = bucket_range(hist_buckets(first, "vllm:request_prompt_tokens"),
+                      hist_buckets(last, "vllm:request_prompt_tokens"))
+    print(f"\n   completed-request prompt sizes this run (histogram buckets) [{D}, range]:")
+    if hb:
+        for lo, hi, n in hb:
+            hs = "inf" if hi == float("inf") else fmt(hi)
+            print(f"     {int(n):>3} request(s) with prompt in ({fmt(lo)}, {hs}] tokens")
+    else:
+        print("     (none completed in window)")
+
+    # Pi: exact, from its own session file.
+    pi_peak = None
+    if pi_session and os.path.exists(pi_session):
+        best = 0
+        for line in open(pi_session, errors="replace"):
+            try:
+                o = json.loads(line)
+            except Exception:
+                continue
+            u = o.get("usage") or (o.get("message") or {}).get("usage") or {}
+            v = u.get("input")
+            if isinstance(v, (int, float)):
+                best = max(best, int(v))
+        pi_peak = best or None
+
+    print(f"\n2. PI PEAK PROMPT/CONTEXT             : "
+          f"{fmt(pi_peak) if pi_peak else 'run pi, then re-run with --pi-session'}"
+          f"   [{M}, pi session usage.input]")
+    print(f"1. PERPLEXICA PEAK PROMPT/CONTEXT     : see bucket table above   [{D}]")
+    print(f"   attribution: Pi is measured exactly, Deal Scout is ~10k, so the")
+    print(f"   largest remaining bucket is Perplexica by elimination.")
+    print(f"3. DEAL SCOUT DIGEST PROMPT           : smallest bucket above    [{D}]")
+    print(f"   exact value: tokenize the digest prompt via /tokenize post-run.")
+
+    # ---------------- scheduling / preemption ------------------------------
+    section("SCHEDULING — PREEMPTION IS RECOMPUTE-ONLY IN vLLM V1")
+    runq = [(t, g(s, "vllm:num_requests_running") or 0) for t, s in ticks]
+    waitq = [(t, g(s, "vllm:num_requests_waiting{") or 0) for t, s in ticks]
+    pre = [(t, g(s, "vllm:num_preemptions_total") or 0) for t, s in ticks]
+
+    print(f"max concurrent RUNNING sequences : {int(max(v for _,v in runq)):>4}   [{M}]")
+    print(f"max WAITING sequences            : {int(max(v for _,v in waitq)):>4}   [{M}]")
+    print(f"peak KV utilisation              : {max((g(s,'vllm:kv_cache_usage_perc') or 0) for _,s in ticks)*100:>7.1f}%  [{M}]")
+    total_pre = (pre[-1][1] - pre[0][1]) if pre else 0
+    print(f"preemptions during run           : {int(total_pre):>4}   [{M}]")
+
+    ever3 = sum(1 for _, v in runq if v >= 3)
+    print(f"ticks with all 3 running         : {ever3:>4} of {len(ticks)}   [{M}]")
+    if ever3 == 0:
+        print("  !! the three workloads never genuinely overlapped — the run does not")
+        print("     test concurrency. Re-run with tighter launch spacing.")
+
+    if total_pre > 0:
+        print("\n  PREEMPTION FORENSICS (recompute restarts prefill from token 0):")
+        for i in range(1, len(ticks)):
+            d = (g(ticks[i][1], "vllm:num_preemptions_total") or 0) - \
+                (g(ticks[i-1][1], "vllm:num_preemptions_total") or 0)
+            if d > 0:
+                kvb = g(ticks[i-1][1], "vllm:kv_cache_usage_perc") or 0
+                print(f"   +{int(d)} at t={ticks[i][0]}  KV just before = {kvb*100:.1f}% "
+                      f"({fmt(kvb*cap)} tokens resident)   [{M}]")
+        print("   grep vllm.log for the surrounding engine lines to attribute a request id.")
+    else:
+        print("\n  No preemptions — no recompute stalls to account for.")
+
+    # ---------------- latency ----------------------------------------------
+    section("LATENCY")
+    for label, name in (("TTFT", "vllm:time_to_first_token_seconds"),
+                        ("TPOT", "vllm:request_time_per_output_token_seconds"),
+                        ("E2E ", "vllm:e2e_request_latency_seconds"),
+                        ("queue", "vllm:request_queue_time_seconds"),
+                        ("prefill", "vllm:request_prefill_time_seconds")):
+        s0, c0 = g(first, name + "_sum"), g(first, name + "_count")
+        s1, c1 = g(last, name + "_sum"), g(last, name + "_count")
+        if None in (s0, c0, s1, c1) or (c1 - c0) <= 0:
+            print(f"{label:<8}: no completions in window")
+            continue
+        print(f"{label:<8}: mean {(s1-s0)/(c1-c0):7.3f}s over {int(c1-c0)} requests   [{D}, sum/count delta]")
+
+    # ---------------- throughput / cache ------------------------------------
+    section("THROUGHPUT & CACHE")
+    for label, name in (("prompt tokens processed", "vllm:prompt_tokens_total"),
+                        ("generation tokens", "vllm:generation_tokens_total"),
+                        ("prompt tokens from cache", "vllm:prompt_tokens_cached_total")):
+        a, b = g(first, name), g(last, name)
+        if a is not None and b is not None:
+            print(f"{label:<26}: {fmt(b-a):>12}   [{M}, counter delta]")
+    pq0, ph0 = g(first, "vllm:prefix_cache_queries_total"), g(first, "vllm:prefix_cache_hits_total")
+    pq1, ph1 = g(last, "vllm:prefix_cache_queries_total"), g(last, "vllm:prefix_cache_hits_total")
+    if None not in (pq0, ph0, pq1, ph1) and (pq1 - pq0) > 0:
+        print(f"{'prefix cache hit rate':<26}: {(ph1-ph0)/(pq1-pq0)*100:>11.1f}%   [{D}, hits/queries delta]")
+
+    # ---------------- outcomes ----------------------------------------------
+    section("REQUEST OUTCOMES")
+    for k in sorted(last):
+        if k.startswith("vllm:request_success_total"):
+            r = re.search(r'finished_reason="([^"]+)"', k)
+            d = last[k] - first.get(k, 0)
+            if d:
+                flag = "  <-- CONTEXT LIMIT / TRUNCATION" if r and r.group(1) == "length" else ""
+                print(f"  {r.group(1) if r else '?':<12}: {int(d):>4}{flag}   [{M}]")
+
+    # ---------------- GPUs ---------------------------------------------------
+    section("PER-GPU (was one card doing less work?)")
+    per = defaultdict(lambda: defaultdict(list))
+    gp = f"{run}/gpu.csv"
+    if os.path.exists(gp):
+        for line in open(gp, errors="replace"):
+            p = [x.strip() for x in line.split(",")]
+            if len(p) < 9 or not p[1].isdigit():
+                continue
+            i = int(p[1])
+            for key, idx in (("vram", 2), ("util", 4), ("power", 6), ("temp", 8)):
+                try:
+                    per[i][key].append(float(p[idx]))
+                except ValueError:
+                    pass
+    for i in sorted(per):
+        v, u, w, t = per[i]["vram"], per[i]["util"], per[i]["power"], per[i]["temp"]
+        if not v:
+            continue
+        print(f"GPU{i}: VRAM peak {max(v):>7.0f} MiB | util avg {sum(u)/len(u):5.1f}% peak {max(u):5.1f}% "
+              f"| power avg {sum(w)/len(w):5.1f}W peak {max(w):5.1f}W | temp peak {max(t):4.1f}C   [{M}]")
+    if len(per) == 2 and per[0]["util"] and per[1]["util"]:
+        a, b = sum(per[0]["util"])/len(per[0]["util"]), sum(per[1]["util"])/len(per[1]["util"])
+        if max(a, b) > 0:
+            print(f"\nutilisation imbalance: {abs(a-b)/max(a,b)*100:.1f}%   [{D}]")
+            print("  TP=2 over PCIe with no NVLink — large sustained imbalance would")
+            print("  point at NCCL/PCIe stalls rather than genuine idle.")
+
+    # ---------------- health -------------------------------------------------
+    section("POD HEALTH")
+    pp = f"{run}/pod.csv"
+    if os.path.exists(pp):
+        rows = [l.strip() for l in open(pp) if l.strip()]
+        if rows:
+            restarts = set()
+            for r in rows:
+                f_ = r.split(",")
+                if len(f_) > 3 and f_[3].isdigit():
+                    restarts.add(f_[3])
+            print(f"samples={len(rows)}  restart counts seen: {sorted(restarts) or 'n/a'}   [{M}]")
+            print(f"last: {rows[-1]}")
+    for pat, lbl in ((r"OOM|OutOfMemory", "OOM"),
+                     (r"context length|maximum context|too long", "CONTEXT-LIMIT"),
+                     (r"Cache allocation|cannot allocate", "CACHE-ALLOC"),
+                     (r"Preempt", "PREEMPT-LOG")):
+        lp = f"{run}/vllm.log"
+        if os.path.exists(lp):
+            n = len(re.findall(pat, open(lp, errors="replace").read(), re.I))
+            if n:
+                print(f"  vllm.log matches for {lbl}: {n}")
+
+    print("\n" + "=" * 78)
+    print("Reminder: peak resident context is DERIVED (kv% x capacity) and includes")
+    print("prefix-cache-retained blocks. Pi's figure is the only exact per-workload")
+    print("context number available without changing production app behaviour.")
+
+
+if __name__ == "__main__":
+    main()

--- a/my-apps/ai/perplexica/config.json
+++ b/my-apps/ai/perplexica/config.json
@@ -14,14 +14,14 @@
     },
     {
       "id": "llama-cpp-cluster",
-      "name": "vLLM (Qwen3.6-27B)",
+      "name": "vLLM (Qwen3.8-27B)",
       "type": "openai",
       "config": {
         "apiKey": "sk-no-key-required",
         "baseURL": "http://vllm-service.vllm.svc.cluster.local:8080/v1"
       },
       "chatModels": [
-        { "name": "Qwen 3.6 27B (vLLM, TP=2)", "key": "qwen3.6-27b" }
+        { "name": "Qwen 3.8 27B (vLLM, TP=2)", "key": "qwen3.8-27b" }
       ],
       "embeddingModels": []
     }

--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -34,6 +34,13 @@ spec:
           env:
             - name: DATA_DIR
               value: /data
+            # dashboard/app.py defaults this to `qwen3.6-27b`, which the vLLM
+            # endpoint no longer serves — it 404s and the digest silently drops
+            # to facts-only prose. The digest LLM call is best-effort by design,
+            # so nothing errors; it just quietly stops using the model. Pin the
+            # served id explicitly so a backend rename can't fail silently again.
+            - name: DIGEST_LLM_MODEL
+              value: qwen3.8-27b
             - name: INGEST_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Gate 2 of the dual-vs-single 3090 investigation. Follows #1995 (native 262144 context, max-num-seqs 3).

## Consumer rollover

vLLM serves exactly one model id, `qwen3.8-27b`. Only Open WebUI was ever moved to it, so every other consumer has been silently 404ing against the dead `qwen3.6-27b`. Verified against the live endpoint:

| request | result |
|---|---|
| `qwen3.8-27b` | 200, real completion, usage accounted |
| `qwen3.6-27b` | **404 — "The model `qwen3.6-27b` does not exist."** |

This rolls over only the two needed for the baseline. **LiteLLM, Karakeep, Presenton, Project NOMAD, WorldMonitor and HolmesGPT are deliberately still on the dead id** — separate follow-up.

**Perplexica** — seed config only. The init container replaces `.modelProviders` wholesale from the seed on every pod start, so this propagates without touching the PVC. The provider `id` is intentionally left as the misnamed `llama-cpp-cluster`: Perplexica keys a saved model selection off provider id + model key, so renaming it would orphan the selection.

**Deal Scout** — `dashboard/app.py` defaults `DIGEST_LLM_MODEL` to `qwen3.6-27b` and the deployment set no LLM env at all. The digest LLM call is best-effort by design, so the 404 never surfaced as an error; the digest just quietly degraded to facts-only prose. Pinning the id explicitly makes a future backend rename fail loudly.

Pi's `~/.pi/agent/models.json` is a local workstation file, not GitOps — already updated and verified separately.

## Collector (`benchmarks/ai-realworld-load/`)

Read-only, outside every AppSet glob, so ArgoCD never picks it up.

Samples via three long-lived streams rather than a per-tick `kubectl exec` — a 2s exec loop costs ~0.5-1s of overhead per tick and would jitter the interval. `nvidia-smi` uses its native `-l` loop and runs in the powerlimit DaemonSet, not the inference pod, so sampling never competes with the workload under test.

Every number is tagged **MEASURED** or **DERIVED**. That distinction is the point of the exercise: the decision rests on peak real context, and a derived number that reads as measured would corrupt it. vLLM's `request_prompt_tokens` buckets are coarse (…20k/50k/100k/200k/Inf) so server-side per-request sizes are ranges; Pi's session JSONL carries exact `usage.input`, the one exact per-workload figure obtainable without changing production app behaviour.

### Bugs caught by smoke-testing against the live server

All three would have produced confident wrong numbers rather than failing:

1. The root `.gitignore` has a blanket **`bin/`** rule that silently dropped all three scripts — this would have shipped as a README with no collector. Scripts live in `tools/`.
2. `live.sh` matched GPU index with `grep ', 0,'`, which also matches the utilization/temperature columns — both columns showed the same card.
3. `report.py` looked up metrics by exact key, but every vLLM metric carries Prometheus labels, so a fully loaded run reported `RUNNING=0` / `KV=0.0%`.

### Verified end to end under real concurrent load

`RUNNING=3 / WAITING=3` (confirming #1995's `max-num-seqs 3` admits three sequences), peak resident 18,166 tokens, both cards to 100% util and ~199W against the 200W cap, 0 preemptions, 0 restarts.

### Recorded for Baseline B

- Verbatim Perplexica / Pi / Deal Scout prompts, so B is like-for-like
- **313,367 tokens** as the Baseline A capacity ceiling (not the earlier ~291K estimate)
- V1 preemption is **recompute-only**, verified by reading `scheduler.py` in the running pod: `_preempt_request` frees all blocks and sets `num_computed_tokens = 0`; no `PreemptionMode` or `swap_out` exists under `vllm/v1/`. A preempted 262K request re-prefills from token 0.

## Rollback

`git revert`. Perplexica's seed re-applies on next pod start; removing the deal-scout env restores the code default. The collector is inert.

## Not addressed here

`my-apps/ai/vllm/deployment.yaml` lines 55-60 still claim the FP8 experiment was "Expected to FAIL on these cards", and `docs/domains/ai-gpu/model-catalog.md` still says vLLM=0 / llama.cpp=1 — inverted from live. Cleanup PR after Gate 2, as agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)