### PR TITLE
deal-scout: run lowcostminipcs cluster-side

### DIFF
--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: DEAL_SCOUT_API
               value: "http://deal-scout:8000"
             - name: CLUSTER_SOURCES
-              value: "ebay,slickdeals,msu,comprenew"
+              value: "ebay,slickdeals,msu,comprenew,lowcostminipcs"
             - name: DEAL_SCOUT_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
One-line follow-up to #1997 (deal-scout v0.11.0).

```diff
- value: "ebay,slickdeals,msu,comprenew"
+ value: "ebay,slickdeals,msu,comprenew,lowcostminipcs"
```

v0.11.0 rewrote the LowCostMiniPCs adapter as a plain `fetch` over the site's server-rendered table, so it no longer needs the CDP browser and no longer belongs on the desktop runner.

`CLUSTER_SOURCES` overrides the worker's built-in default (`worker/index.js:17`) and becomes the `deal-scout-cluster-scan` schedule's `args: [{ sources }]`. Without this the cluster scan keeps skipping the source, and v0.11.0 is a no-op for the thing it was released to do.

Excluding it here was correct until now — the source genuinely needed a browser. That's what changed.

Verify after sync: the next `deal-scout-cluster-scan` should report a `lowcostminipcs` count (~1,400 rows) with no CDP involvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)