### PR TITLE
deal-scout: v0.11.1

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.11.0@sha256:dec7a80f0e6aad7e45304c5482fbe488949e200272d0d4dcac37d9eacfe90c2d
+          image: ghcr.io/mitchross/deal-scout:v0.11.1@sha256:ea23894a820593fb08ed0034c090391710add321fd4d332d2bb307b8ff4b68c3
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.11.0@sha256:8fede2512e2778ef89309bb9d2e0a1d99590e78af813f64d08627480813bd3b3
+          image: ghcr.io/mitchross/deal-scout-worker:v0.11.1@sha256:3c2efa48f84939a357f050695cc99c0e0b30a36f691c42f72de95405bb605cea
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Hotfix bump. **v0.11.0 currently 500s on `/api/listings`** — this is the fix.

| image | digest |
|---|---|
| `ghcr.io/mitchross/deal-scout` | `sha256:ea23894a820593fb08ed0034c090391710add321fd4d332d2bb307b8ff4b68c3` |
| `ghcr.io/mitchross/deal-scout-worker` | `sha256:3c2efa48f84939a357f050695cc99c0e0b30a36f691c42f72de95405bb605cea` |

`app.py` used `Path` in `_load_cpu_benchmarks()` without importing it (dormant since `30a6f67`). LowCostMiniPCs is the first source to set `cpuKey` without `cpuMark`, so v0.11.0 took that branch for the first time and raised `NameError` — which FastAPI turns into a 500 for the whole response, not just the offending row.

Source: `mitchross/deal-scout@91ad40f` (PR #5, CI green). Both tags verified pullable.

Post-merge: `./scripts/verify-deploy.sh v0.11.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)