### PR TITLE
cobalt: add web frontend at dl.vanillax.me, make API public

### DIFF
--- a/my-apps/media/cobalt/deployment.yaml
+++ b/my-apps/media/cobalt/deployment.yaml
@@ -32,6 +32,13 @@ spec:
         env:
         - name: API_URL
           value: "https://cobalt.vanillax.me/"
+        # Now that the API is internet-facing, keep browsers on our own frontend
+        # instead of letting any site call it as a free backend. Only a browser
+        # guard — it does not stop scripted clients (see TURNSTILE_* for that).
+        - name: CORS_WILDCARD
+          value: "0"
+        - name: CORS_URL
+          value: "https://dl.vanillax.me"
         ports:
         - name: http
           containerPort: 9000

--- a/my-apps/media/cobalt/kustomization.yaml
+++ b/my-apps/media/cobalt/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
 - deployment.yaml
 - service.yaml
 - http-route.yaml
+- web-deployment.yaml
+- web-service.yaml
+- web-http-route.yaml
 - vpa.yaml
 
 namespace: cobalt

--- a/my-apps/media/cobalt/vpa.yaml
+++ b/my-apps/media/cobalt/vpa.yaml
@@ -20,3 +20,25 @@ spec:
         maxAllowed:
           cpu: "1"
           memory: 1Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: cobalt-web
+  namespace: cobalt
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cobalt-web
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "2"
+          memory: 3Gi

--- a/my-apps/media/cobalt/web-deployment.yaml
+++ b/my-apps/media/cobalt/web-deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cobalt-web
+  namespace: cobalt
+  labels:
+    app.kubernetes.io/name: cobalt-web
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cobalt-web
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cobalt-web
+    spec:
+      containers:
+      # imputnet publishes no frontend image — this community image ships the
+      # cobalt sources and runs `svelte-kit build` on every container start,
+      # baking the two WEB_* vars below into the static bundle. So: the rootfs
+      # must stay writable, and a cold start is a full SvelteKit build (~1-2 min),
+      # which is what the startupProbe budget below is for.
+      - name: cobalt-web
+        image: ghcr.io/spotdemo4/cobalt-web:11.7@sha256:30392487965b2c96f70f04ec5e3ef24a7804eec6ef0c7b9fd7d1e19ed955d1c9
+        imagePullPolicy: IfNotPresent
+        env:
+        # The browser calls the API directly, so this must be the PUBLIC api
+        # hostname — an in-cluster Service URL would be unreachable from the client.
+        - name: WEB_DEFAULT_API
+          value: "https://cobalt.vanillax.me/"
+        - name: WEB_HOST
+          value: "dl.vanillax.me"
+        ports:
+        - name: http
+          containerPort: 8787
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
+        resources:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+          limits:
+            # The startup SvelteKit build is the memory high-water mark, not serving.
+            memory: 3Gi
+        startupProbe:
+          httpGet:
+            path: /
+            port: http
+          periodSeconds: 10
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          periodSeconds: 10

--- a/my-apps/media/cobalt/web-http-route.yaml
+++ b/my-apps/media/cobalt/web-http-route.yaml
@@ -1,16 +1,13 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: cobalt
+  name: cobalt-web
   namespace: cobalt
   labels:
     external-dns: "true"
   annotations:
     external-dns.alpha.kubernetes.io/target: "vanillax.me"
 spec:
-  # External, not internal: cobalt streams the file from the API straight to the
-  # visitor's browser, so the API host has to be reachable by the client — an
-  # internal-only API would break dl.vanillax.me for everyone off the LAN.
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway
@@ -18,7 +15,7 @@ spec:
     namespace: gateway
     sectionName: https
   hostnames:
-  - cobalt.vanillax.me
+  - dl.vanillax.me
   rules:
   - matches:
     - path:
@@ -27,6 +24,6 @@ spec:
     backendRefs:
     - group: ""
       kind: Service
-      name: cobalt
-      port: 9000
+      name: cobalt-web
+      port: 8787
       weight: 1

--- a/my-apps/media/cobalt/web-service.yaml
+++ b/my-apps/media/cobalt/web-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cobalt-web
+  namespace: cobalt
+spec:
+  selector:
+    app.kubernetes.io/name: cobalt-web
+  ports:
+    - name: http
+      port: 8787
+      targetPort: 8787
+      protocol: TCP

--- a/my-apps/media/homepage-dashboard/services.yaml
+++ b/my-apps/media/homepage-dashboard/services.yaml
@@ -52,6 +52,10 @@
         icon: mailpit.png
         href: https://mailpit.vanillax.me
         description: Email Testing Server
+    - Cobalt:
+        icon: mdi-download-circle-outline
+        href: https://dl.vanillax.me
+        description: Video & Audio Downloader
 - Public · Privacy:
     - SearXNG:
         icon: searxng.png


### PR DESCRIPTION
## What

cobalt has been running in-cluster as **API only** — `cobalt.vanillax.me` returns JSON, there's no page to paste a URL into. This adds the frontend so it works as a public downloader.

New site: **`dl.vanillax.me`**. Paste a link, the file streams straight to your browser. No PVC anywhere in the path — nothing is written to cluster storage.

## Changes

| File | Change |
|---|---|
| `web-deployment.yaml` | cobalt-web frontend, port 8787 (new) |
| `web-service.yaml` / `web-http-route.yaml` | external route at `dl.vanillax.me` (new) |
| `http-route.yaml` | API route `gateway-internal-technitium` → `gateway-external` |
| `deployment.yaml` | `CORS_WILDCARD=0` + `CORS_URL=https://dl.vanillax.me` |
| `vpa.yaml` | VPA for `cobalt-web` |
| `kustomization.yaml` | list the three new resources |
| `homepage-dashboard/services.yaml` | entry under *Public · Tools* |

## Why the API has to go public

cobalt's client runs in the visitor's browser and calls the API directly. An internal-only API leaves `dl.vanillax.me` broken for anyone off the LAN, so the API route moves to `gateway-external` alongside the frontend.

## Review notes

**The frontend image is community-maintained.** imputnet publishes no frontend image (`imputnet/cobalt-web` and `-frontend` don't exist on ghcr; [open request](https://github.com/imputnet/cobalt/issues/1095)). This uses [`spotdemo4/cobalt-web`](https://github.com/spotdemo4/cobalt-web-docker) at `11.7`, pinned to `@sha256:30392487…`, matching the API's 11.7.1.

**Cold starts run a build.** That image never builds the frontend at image-build time — its entrypoint runs `svelte-kit build` on every container start, which is how `WEB_DEFAULT_API`/`WEB_HOST` get baked into the bundle. Consequences, all handled in the manifest: the rootfs must stay writable (no `readOnlyRootFilesystem`), readiness is gated by a `startupProbe` at 30×10s rather than a probe delay, and the 3Gi memory ceiling is sized by the build rather than by serving.

**CORS is a browser guard, not abuse protection.** It stops other sites using the API as a free backend; it does nothing against scripted clients. Real protection is `TURNSTILE_SITEKEY`/`TURNSTILE_SECRET`/`JWT_SECRET` or `API_KEY_URL`, which need a 1Password item + ExternalSecret — deliberately out of scope here, easy follow-up if the public endpoint draws traffic.

## Verification

`kubectl kustomize my-apps/media/cobalt` renders 9 objects clean; both VPAs resolve to their targets; kopiur backup-coverage check passes (no PVCs added).

Not yet applied to the cluster — ArgoCD picks it up on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)