### PR TITLE
cobalt: rename API route to force the external-gateway swap

### DIFF
--- a/my-apps/media/cobalt/http-route.yaml
+++ b/my-apps/media/cobalt/http-route.yaml
@@ -1,10 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  # Renamed from "cobalt" to force a create+prune. Re-parenting this route in
-  # place never took: ArgoCD kept it OutOfSync while reporting a successful
-  # sync, so the gateway swap below silently stayed on the internal gateway.
-  # The name also just reads better now that cobalt-web owns the frontend route.
+  # Renamed from "cobalt": re-parenting an HTTPRoute in place silently no-ops, a rename forces create+prune.
   name: cobalt-api
   namespace: cobalt
   labels:
@@ -12,9 +9,7 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/target: "vanillax.me"
 spec:
-  # External, not internal: cobalt streams the file from the API straight to the
-  # visitor's browser, so the API host has to be reachable by the client — an
-  # internal-only API would break dl.vanillax.me for everyone off the LAN.
+  # Must be external: the browser calls this API directly, so internal-only breaks dl.vanillax.me off-LAN.
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway

--- a/my-apps/media/cobalt/http-route.yaml
+++ b/my-apps/media/cobalt/http-route.yaml
@@ -1,7 +1,11 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: cobalt
+  # Renamed from "cobalt" to force a create+prune. Re-parenting this route in
+  # place never took: ArgoCD kept it OutOfSync while reporting a successful
+  # sync, so the gateway swap below silently stayed on the internal gateway.
+  # The name also just reads better now that cobalt-web owns the frontend route.
+  name: cobalt-api
   namespace: cobalt
   labels:
     external-dns: "true"


### PR DESCRIPTION
## Problem

#2001 moved the cobalt API route to `gateway-external` so the browser can reach it from outside the LAN. **The swap never landed.**

```
$ kubectl get httproute -n cobalt
cobalt      -> gateway-internal-technitium   | accepted=True   <-- should be gateway-external
cobalt-web  -> gateway-external              | accepted=True

$ kubectl get app my-apps-cobalt -n argocd
OutOfSync   Healthy
  HTTPRoute/cobalt   OutOfSync
  operationState: Succeeded | "successfully synced (all tasks run)"
```

ArgoCD detects the drift, reports a successful sync, and the field never changes. A hard refresh (`argocd.argoproj.io/refresh=hard`) does not clear it.

**User-visible effect:** `dl.vanillax.me` loads from anywhere — it's a static bundle served through Cloudflare — but **every download fails off-LAN**, because public DNS hands the client `192.168.10.52` for the API:

```
$ dig @1.1.1.1 +short cobalt.vanillax.me
192.168.10.52
```

## Fix

Rename the resource `cobalt` → `cobalt-api`. That turns the blocked in-place update into a create + prune, which the my-apps AppSet already permits (`prune: true`, `selfHeal: true`). `cobalt-api` is also the clearer name now that `cobalt-web` owns the frontend route.

Renders as expected:

| route | hostname | gateway |
|---|---|---|
| `cobalt-api` | cobalt.vanillax.me | gateway-external / https |
| `cobalt-web` | dl.vanillax.me | gateway-external / https |

## Expect on merge

- brief blip on `cobalt.vanillax.me` while the old route is pruned and the new one is admitted
- the public DNS record should flip from the `192.168.10.52` A record to the CNAME-to-`vanillax.me` that other external apps get — which also stops that internal IP being publicly queryable
- downloads start working from outside the LAN

Verify:
```
kubectl get httproute -n cobalt
dig @1.1.1.1 +short cobalt.vanillax.me     # expect Cloudflare IPs, not 192.168.10.x
```

## Not fixed here

The underlying in-place re-parenting failure. This PR routes around it for one resource; the next gateway migration will hit it again. Worth a separate look at the global HTTPRoute `ignoreDifferences` on `parentRefs[].group`/`.kind` (`infrastructure/controllers/argocd/values.yaml:80-86`) interacting with `ServerSideApply=true` + `RespectIgnoreDifferences=true` — stripping ignored fields from the applied manifest can break the merge key on a list-type field. I could not confirm that mechanism (the live object returned no `managedFields`), so it's a hypothesis, not a diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)