### PR TITLE
claude: cap comment length at one line, two at most

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,0 +1,46 @@
+# Comment length
+
+Root `CLAUDE.md` § "Comment Style" says *when* a comment is earned. This file caps *how long* it may be, because "earned" keeps getting used to justify paragraphs.
+
+## The cap
+
+**One line. Two if the second genuinely carries new information. Never three.**
+
+If it needs more than two lines, the extra belongs somewhere else:
+
+| Content | Goes to |
+|---|---|
+| Why this change, what broke, what was tried | commit message / PR body |
+| Investigation, symptoms, root-cause theory | Mink note (`mink note --category resources`) |
+| Procedure, runbook, architecture | `docs/` |
+| The one thing a future editor must not break | the in-file comment |
+
+The file comment answers **"what will bite me if I edit this line?"** — not "what happened last Tuesday."
+
+## Don't
+
+- Narrate forensics. No "this never took; ArgoCD reported success while the live field stayed X, and a hard refresh didn't clear it."
+- Restate the YAML. `# port 8787` above `containerPort: 8787` is noise.
+- Chain consequences. Pick the one that bites; drop "which is why…" clauses.
+- Explain an upstream project's design at length. Link it or name it.
+- Justify yourself. The comment is for the next editor, not a defense of the commit.
+
+## Example — an actual violation
+
+Written:
+
+```yaml
+# imputnet publishes no frontend image — this community image ships the
+# cobalt sources and runs `svelte-kit build` on every container start,
+# baking the two WEB_* vars below into the static bundle. So: the rootfs
+# must stay writable, and a cold start is a full SvelteKit build (~1-2 min),
+# which is what the startupProbe budget below is for.
+```
+
+Should have been:
+
+```yaml
+# Builds at container start, not image build: rootfs must stay writable, ~1-2 min cold start.
+```
+
+Everything else was commit-message and Mink-note material. It was already in both.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,8 @@ Comments earn their place in two ways only:
 
 Do **not** write changelog/jira-style comments: no per-version release-note summaries, no "assessed on date, no impact" entries, no restating upstream changelogs — git history and release pages already record that. A version bump only warrants a comment if it changes how something works or adds a new gotcha. Don't match the legacy comment density in older files; it's accumulated cruft, not the standard.
 
+**Hard cap: one line, two at most — never three.** Earning a comment does not earn a paragraph. Forensics go in the commit message, rationale in a Mink note, procedure in `docs/`. See `.claude/rules/comments.md`.
+
 ## Critical Rules
 
 ### DO:

--- a/my-apps/media/cobalt/deployment.yaml
+++ b/my-apps/media/cobalt/deployment.yaml
@@ -32,9 +32,7 @@ spec:
         env:
         - name: API_URL
           value: "https://cobalt.vanillax.me/"
-        # Now that the API is internet-facing, keep browsers on our own frontend
-        # instead of letting any site call it as a free backend. Only a browser
-        # guard — it does not stop scripted clients (see TURNSTILE_* for that).
+        # Keeps other sites from using this API as a free backend. Browser-only guard; scripts ignore CORS.
         - name: CORS_WILDCARD
           value: "0"
         - name: CORS_URL

--- a/my-apps/media/cobalt/web-deployment.yaml
+++ b/my-apps/media/cobalt/web-deployment.yaml
@@ -18,17 +18,12 @@ spec:
         app.kubernetes.io/name: cobalt-web
     spec:
       containers:
-      # imputnet publishes no frontend image — this community image ships the
-      # cobalt sources and runs `svelte-kit build` on every container start,
-      # baking the two WEB_* vars below into the static bundle. So: the rootfs
-      # must stay writable, and a cold start is a full SvelteKit build (~1-2 min),
-      # which is what the startupProbe budget below is for.
+      # Builds at container start, not image build: rootfs must stay writable, ~1-2 min cold start.
       - name: cobalt-web
         image: ghcr.io/spotdemo4/cobalt-web:11.7@sha256:30392487965b2c96f70f04ec5e3ef24a7804eec6ef0c7b9fd7d1e19ed955d1c9
         imagePullPolicy: IfNotPresent
         env:
-        # The browser calls the API directly, so this must be the PUBLIC api
-        # hostname — an in-cluster Service URL would be unreachable from the client.
+        # Must be the public hostname — the browser calls this, not the cluster.
         - name: WEB_DEFAULT_API
           value: "https://cobalt.vanillax.me/"
         - name: WEB_HOST
@@ -45,7 +40,7 @@ spec:
             cpu: 200m
             memory: 512Mi
           limits:
-            # The startup SvelteKit build is the memory high-water mark, not serving.
+            # Sized by the startup build, not by serving.
             memory: 3Gi
         startupProbe:
           httpGet:


### PR DESCRIPTION
## Why

`CLAUDE.md` § "Comment Style" says *when* a comment is earned. It never says **how long** it may be — so "earned" kept getting stretched into paragraphs. Recent example, all of it justified under the existing rule and all of it too long:

```yaml
# imputnet publishes no frontend image — this community image ships the
# cobalt sources and runs `svelte-kit build` on every container start,
# baking the two WEB_* vars below into the static bundle. So: the rootfs
# must stay writable, and a cold start is a full SvelteKit build (~1-2 min),
# which is what the startupProbe budget below is for.
```

That content was already in the commit message *and* a Mink note. The file needed one line:

```yaml
# Builds at container start, not image build: rootfs must stay writable, ~1-2 min cold start.
```

## What

- `.claude/rules/comments.md` — hard cap (**one line, two at most, never three**) plus a routing table for the overflow: forensics → commit message, rationale → Mink note, procedure → `docs/`, the-thing-that-bites → the file.
- `CLAUDE.md` — two-line pointer from the existing Comment Style section, so the cap is visible where the topic already lives.
- Trims the cobalt comments that prompted this (5 lines → 1, 3 → 1, 2 → 1).

Loads automatically — `.claude/rules/*.md` is already picked up as project instructions the same way `mink.md` is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)