### PR TITLE
posthog: pin all workloads to the Threadripper workers

### DIFF
--- a/my-apps/development/posthog/kustomization.yaml
+++ b/my-apps/development/posthog/kustomization.yaml
@@ -42,3 +42,31 @@ configMapGenerator:
 
 components:
   - ../../common/kopiur-backup
+
+# Zone `house` IS the Threadripper box, so this pins every workload to its two
+# workers — the AVX2 selector alone also matches the smaller Dell and HP nodes.
+patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: not-used
+      spec:
+        template:
+          spec:
+            nodeSelector:
+              topology.kubernetes.io/zone: house
+  - target:
+      kind: Job
+    patch: |-
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: not-used
+      spec:
+        template:
+          spec:
+            nodeSelector:
+              topology.kubernetes.io/zone: house


### PR DESCRIPTION
Pins every PostHog workload to the two Threadripper workers via `topology.kubernetes.io/zone: house`.

## Why the existing selector wasn't doing this

Five workloads already carried `feature.node.kubernetes.io/cpu-cpuid.AVX2`. That is a **CPU-capability** guard, not a placement one — and it doesn't discriminate:

```
gpu-workers-kc4r57   AVX2=true     (Threadripper, family 23)
workers-97cs4s       AVX2=true     (Threadripper, family 23)
dell-workers-kxcwdc  AVX2=true     (Intel, family 6)
hp-workers-gkfrw8    AVX2=true     (Intel, family 6)
```

All four workers report AVX2, so nothing was keeping PostHog off the smaller Dell and HP nodes. It landed on the Threadripper by luck, not by rule.

NFD can't express this constraint honestly either: the only labels separating the Threadripper are vendor/family identity and AMD-only flags (`SVM*`, `CLZERO`, `SSE4A`) that PostHog never uses. Notably NFD also sets `AVXSLOW` on the Threadripper — Zen+ splits 256-bit AVX2 into two 128-bit ops — so a genuine capability selector would point *away* from it. Placement is the right tool here, not capability.

## Approach

One Kustomize patch over `kind: Deployment` and `kind: Job` rather than editing 23 files. Strategic merge combines the `nodeSelector` maps, so the five workloads that already declare AVX2 keep it:

```
web -> {feature.node.kubernetes.io/cpu-cpuid.AVX2: "true",
        topology.kubernetes.io/zone: house}
```

`zone: house` is the Threadripper box. The control plane is excluded twice over — `NoSchedule` taint and no AVX2 label — so this resolves to exactly the two workers.

## Verification

Against a real `kubectl kustomize` build:

- **23/23** workloads (20 Deployments + 3 Jobs) carry `zone: house`
- **5/5** pre-existing AVX2 selectors preserved, merged not replaced
- All 4 PVC-backed Deployments (`clickhouse`, `db`, `kafka`, `redis7`) already use `strategy: Recreate` — no Multi-Attach risk from the rollout
- All 16 running PostHog pods are **already** on these two nodes, so nothing is displaced and no new capacity is consumed

## Rollout note

This changes the pod template, so all 20 Deployments roll. Both target nodes are tight on *requested* memory (gpu-workers 93%, workers-97cs4s 79%), and `web`/`worker` request 4Gi each under surge-first RollingUpdate. Expect those two to roll one at a time; a surging replica may sit Pending briefly until its predecessor exits. No outage risk (`maxUnavailable` is 0 at 1 replica), but worth watching rather than merging unattended.

Unrelated and pre-existing: `recording-api` is currently Pending on `workers-97cs4s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)