### PR TITLE
omni: size worker boot disks for the image cache, give the general worker Longhorn

### DIFF
--- a/omni/cluster-template/cluster-template-threadripper-gpu-workers.yaml
+++ b/omni/cluster-template/cluster-template-threadripper-gpu-workers.yaml
@@ -69,6 +69,15 @@ patches:
       udev:
         rules:
         - SUBSYSTEM=="bdi", ACTION=="add", ATTR{read_ahead_kb}="131072"
+- name: image-gc-thresholds
+  inline:
+    machine:
+      kubelet:
+        # Trim the image cache long before the 10%-free eviction line: a full
+        # nodefs taints the node AND flips every Longhorn disk on it NotReady.
+        extraConfig:
+          imageGCHighThresholdPercent: 70
+          imageGCLowThresholdPercent: 55
 ---
 kind: ControlPlane
 machineClass:
@@ -285,6 +294,37 @@ patches:
           maxPods: 150
       sysctls:
         net.core.bpf_jit_harden: 1
+- name: general-longhorn-disks
+  inline:
+    machine:
+      # All-or-nothing annotation: every disk the node should register must be
+      # listed here. Omitting one leaves the node with zero usable disks.
+      nodeLabels:
+        node.longhorn.io/create-default-disk: "config"
+      nodeAnnotations:
+        node.longhorn.io/default-disks-config: >-
+          [{"name":"talos-ephemeral","path":"/var/lib/longhorn","allowScheduling":false,"diskType":"filesystem","storageReserved":17179869184,"tags":[]},{"name":"tr-ssd","path":"/var/mnt/longhorn-tr-ssd","allowScheduling":true,"diskType":"filesystem","storageReserved":0,"tags":[]}]
+      kubelet:
+        extraMounts:
+        - destination: /var/lib/longhorn
+          type: bind
+          source: /var/local/longhorn
+          options:
+          - bind
+          - rshared
+          - rw
+- name: general-longhorn-ssd-volume
+  inline:
+    apiVersion: v1alpha1
+    kind: UserVolumeConfig
+    name: longhorn-tr-ssd
+    provisioning:
+      # The only non-system disk is the 140 GiB ssd-ent device. Do NOT add a
+      # `disk.transport == 'scsi'` clause: virtio-scsi never matches it.
+      diskSelector:
+        match: "!system_disk && disk.size >= 100u * GB"
+      minSize: 100GB
+      grow: true
 ---
 kind: Workers
 name: gpu-workers

--- a/omni/machine-classes/dell-worker.yaml
+++ b/omni/machine-classes/dell-worker.yaml
@@ -20,9 +20,9 @@ spec:
       # The OptiPlex has 64 GiB physical RAM. Keep 16 GiB for Proxmox and the
       # provider; the live VM was already proven at this 48 GiB allocation.
       memory: 49152
-      # local-lvm on the Dell is only ~137 GiB total. Keep Longhorn data on the
-      # dedicated Samsung disk below; 64 GiB is sufficient for Talos/images.
-      disk_size: 64
+      # Boot disk carries Talos + the container image cache; 64 GiB put this node
+      # in permanent DiskPressure. Must stay under the local-lvm thin pool size.
+      disk_size: 128
       storage_selector: name == "local-lvm"
       network_bridge: vmbr0
       disk_ssd: true

--- a/omni/machine-classes/hp-worker.yaml
+++ b/omni/machine-classes/hp-worker.yaml
@@ -18,9 +18,9 @@ spec:
       cores: 4
       sockets: 1
       memory: 12288
-      # Boot/image disk on the NVMe `local-lvm` thin pool (~141 GiB free).
-      # Longhorn data lives on the separate SSD below, never here.
-      disk_size: 64
+      # Boot disk carries Talos + the container image cache; 64 GiB put the peer
+      # workers in DiskPressure. Must stay under the local-lvm thin pool size.
+      disk_size: 128
       storage_selector: name == "local-lvm"
       network_bridge: vmbr0
       disk_ssd: true

--- a/omni/machine-classes/threadripper-worker.yaml
+++ b/omni/machine-classes/threadripper-worker.yaml
@@ -1,7 +1,6 @@
 ---
 # omnictl apply -f omni/machine-classes/threadripper-worker.yaml
-# General-purpose Threadripper worker. It is compute-only for Longhorn: the
-# existing GPU worker remains the sole local block-storage target.
+# General-purpose Threadripper worker, and a Longhorn replica target.
 metadata:
   namespace: default
   type: MachineClasses.omni.sidero.dev
@@ -19,10 +18,9 @@ spec:
       # Threadripper guests must total <=100 GiB so Proxmox and the qemu
       # per-VM overhead never push the host into swap.
       memory: 24576
-      # Keep this boot/image disk off the two NVMe Longhorn pools. The Proxmox
-      # `local-lvm` thin pool is ~152 GiB and was only 2% used when selected;
-      # 64 GiB leaves roughly 85 GiB of physical-pool headroom.
-      disk_size: 64
+      # Boot disk carries Talos + the container image cache; 64 GiB put this node
+      # in permanent DiskPressure. Must stay under the local-lvm thin pool size.
+      disk_size: 128
       storage_selector: name == "local-lvm"
       network_bridge: vmbr0
       disk_ssd: true
@@ -30,6 +28,16 @@ spec:
       disk_iothread: true
       disk_cache: none
       disk_aio: io_uring
+      # Longhorn replica target on `ssd-ent` (THICK LVM, shared with the GPU
+      # worker's flash tier). Untagged on purpose: default pool, not `flash`.
+      additional_disks:
+        - storage_selector: name == "ssd-ent"
+          disk_size: 140
+          disk_ssd: true
+          disk_discard: true
+          disk_iothread: true
+          disk_cache: none
+          disk_aio: io_uring
       cpu_type: host
       machine_type: q35
       bios: ovmf


### PR DESCRIPTION
## Why

The three CPU workers were provisioned with **64 GiB boot disks**. Talos keeps the container image cache on `EPHEMERAL`, which lives on that disk, and this cluster's image working set is ~40–50 GiB. All three sat permanently near kubelet's `nodefs.available<10%` eviction line.

When a node crossed it, the failure was not contained to that node: the `disk-pressure:NoSchedule` taint made Longhorn mark **every disk on the node NotReady** — so the Dell's 400 GiB SSD reported `Waiting for disk dell-ssd to be ready` while sitting **96% empty (413 G free of 429 G)**, and 17 pods hung `Pending`. The storage was never the problem.

`workers-97cs4s` was also the only worker with **no Longhorn disk at all** (`spec.disks: {}`) while carrying 47 pods, `maxPods: 150` and `serializeImagePulls: false` — the most image churn in the cluster on the smallest disk in the cluster.

## What changed

- Boot disks **64 → 128 GiB** on `threadripper-worker`, `dell-worker`, `hp-worker`.
- `threadripper-worker` gains a **140 GiB Longhorn disk on `ssd-ent`** (thick LVM), untagged so it joins the default pool rather than the `flash` tier. Adds a 4th replica target.
- Cluster-wide kubelet `imageGCHighThresholdPercent: 70` / `Low: 55`, so the cache is trimmed on a schedule instead of walking up to the eviction threshold. No-op on the 450 GiB GPU worker (currently 28%).

## Already applied on the Proxmox side

The provider does not resize existing VMs (noted in `worker.yaml`), so the live hosts were changed directly:

| Host | thin pool | boot LV | Longhorn disk |
|---|---|---|---|
| Threadripper `.14` | `pve/data` 141 → **153 GiB** | vm-101 64 → **128 GiB** | **new** `ssd-ent` 140 GiB |
| Dell `.16` | `pve/data` 138 → **152 GiB** | vm-100 64 → **128 GiB** | unchanged (400 GiB) |
| HP `.20` | `pve/data` 141 → **153 GiB** | vm-100 64 → **128 GiB** | unchanged (850 GiB) |

Pools were extended from each VG's free extents. **Every boot pool is now larger than the sum of its volumes**, so thin overcommit on the boot pools is zero and the LVs cannot overfill them — which matters because nothing runs `fstrim` inside Talos, so thin allocation only ever grows.

## Remaining steps (not done here)

1. `omnictl cluster template sync -f omni/cluster-template/cluster-template-threadripper-gpu-workers.yaml` — the diff is purely additive (3 new ConfigPatches, no modifications).
2. Rolling reboot, one node at a time, so Talos grows `EPHEMERAL` into the new space and formats the new `ssd-ent` volume. Node capacity still reports `63268Mi` until then — Talos does not grow it online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)