### PR TITLE
posthog: force-sync RemoteConfig so session replay survives a Redis wipe

### DIFF
--- a/my-apps/development/posthog/core/capture.yaml
+++ b/my-apps/development/posthog/core/capture.yaml
@@ -224,6 +224,13 @@ spec:
               value: "redis7"
             - name: COOKIELESS_REDIS_PORT
               value: "6379"
+            # Without this the service cannot decrypt the remote config payload and
+            # serves an all-false fallback — session replay never starts in the SDK.
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: posthog-secrets
+                  key: posthog-secret
           ports:
             - containerPort: 3001
               name: http

--- a/my-apps/development/posthog/core/jobs.yaml
+++ b/my-apps/development/posthog/core/jobs.yaml
@@ -177,3 +177,100 @@ spec:
             memory: 2Gi
           limits:
             memory: 4Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: posthog-remote-config-sync
+  namespace: posthog
+  labels:
+    app.kubernetes.io/name: posthog
+    app.kubernetes.io/component: remote-config-sync
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: posthog
+        app.kubernetes.io/component: remote-config-sync
+    spec:
+      restartPolicy: OnFailure
+      nodeSelector:
+        feature.node.kubernetes.io/cpu-cpuid.AVX2: "true"
+      containers:
+      - name: remote-config-sync
+        # Keep on the same monolith digest as web/workers.
+        image: posthog/posthog:latest@sha256:18cd79f19ce8972869b845d2a708139d27ec59b6e3f8b9a5cfbd22e8521ccdf3
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          echo "Waiting for Postgres..."
+          TIMEOUT=120; ELAPSED=0
+          until python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('db', 5432))" 2>/dev/null; do
+            sleep 2; ELAPSED=$((ELAPSED + 2))
+            [ $ELAPSED -ge $TIMEOUT ] && echo "Postgres timeout" && exit 1
+          done
+          echo "Waiting for Redis..."
+          ELAPSED=0
+          until python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('redis7', 6379))" 2>/dev/null; do
+            sleep 2; ELAPSED=$((ELAPSED + 2))
+            [ $ELAPSED -ge $TIMEOUT ] && echo "Redis timeout" && exit 1
+          done
+          # RemoteConfig.sync() diffs against Postgres, never against Redis, so a
+          # wiped Redis is NEVER repaired by the normal path — it logs "unchanged"
+          # and writes nothing. The flags service then serves an all-false fallback
+          # config and session replay silently stops in every browser. force=True
+          # is what actually rewrites the cache; there is no celery beat here.
+          echo "Force-syncing RemoteConfig to Redis..."
+          python - <<'PY'
+          import os
+
+          os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+
+          import django
+
+          django.setup()
+
+          from posthog.models.remote_config import RemoteConfig
+
+          for remote_config in RemoteConfig.objects.all():
+              remote_config.sync(force=True)
+              print(f"force-synced team {remote_config.team_id}")
+          PY
+          echo "RemoteConfig sync complete"
+        envFrom:
+        - configMapRef:
+            name: posthog-env
+        env:
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: posthog-secrets
+              key: posthog-secret
+        - name: ENCRYPTION_SALT_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: posthog-secrets
+              key: encryption-salt-keys
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: posthog-secrets
+              key: posthog-db-password
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: posthog-secrets
+              key: posthog-db-url
+        resources:
+          requests:
+            cpu: 250m
+            memory: 1Gi
+          limits:
+            memory: 2Gi


### PR DESCRIPTION
Session replay had never captured anything - the
session_recording_snapshot_item_events topic high-watermark was 0. The pipeline was entirely healthy: replay-capture connected to Kafka, /s/ routed correctly, session_recording_opt_in true, and a valid sessionRecording config sitting in Postgres. The browser was simply being told not to record.

/flags?v=2&config=true returned sessionRecording: false (and heatmaps, capturePerformance, surveys all false). The flags service reads that config from the Redis key cache/team_tokens/<token>/array/config.json, which did not exist - it logged "Config cache miss - returning fallback config" and served an all-false default.

It could never recover on its own:

- PostHog's Redis is intentionally disposable/backup-exempt, so a reboot wipes it.
- RemoteConfig.sync() diffs the built config against Postgres, never against Redis. With the DB unchanged it logs "RemoteConfig for team 1 is unchanged" and writes nothing, so a wiped cache is never rebuilt.
- There is no celery beat deployment here, so the "sync all remote configs" schedule sitting in redbeat never fires regardless.

The result is silent and permanent: every pod healthy, no errors logged, and replay dead in every browser.

- core/jobs.yaml: add posthog-remote-config-sync, a Sync hook at wave 4 that runs RemoteConfig.sync(force=True). force is the only path that actually rewrites the cache, so every deploy and every cluster rebuild self-heals.
- core/capture.yaml: give feature-flags SECRET_KEY. It was logging "No FLAGS_SECRET_KEYS or SECRET_KEY configured; encrypted remote config payloads cannot be decrypted". This was not the root cause - the force-sync was - but the service needs it to decrypt encrypted payloads.

Verified live: the endpoint now returns a real sessionRecording object with endpoint "/s/", and heatmaps/capturePerformance are populated.