### PR TITLE
coroot: park every component on the unschedulable nodeSelector

### DIFF
--- a/monitoring/coroot/coroot.yaml
+++ b/monitoring/coroot/coroot.yaml
@@ -8,8 +8,8 @@
 # 1 GB/s of disk reads (cluster-agent another 550 MB/s), saturating both the
 # SATA and NVMe thin pools on the Proxmox host — IO pressure stall 57%, load 96.
 # Everything else in the cluster combined reads <30 MB/s.
-# nodeAgent/clusterAgent have no replicas field, so they are parked on an
-# unschedulable nodeSelector — that is the only way to zero a DaemonSet here.
+# operator 1.9.6 reads `replicas: 0` as unset and applies its default (keeper 3,
+# clickhouse 1, coroot 1) — only the unschedulable nodeSelector actually zeroes a component.
 apiVersion: coroot.com/v1
 kind: Coroot
 metadata:
@@ -18,6 +18,8 @@ metadata:
 spec:
   communityEdition: {}
   replicas: 0
+  nodeSelector:
+    coroot.vanillax.dev/enabled: "true"
   metricsRefreshInterval: 30s
   storage:
     size: 10Gi
@@ -31,6 +33,8 @@ spec:
       memory: 1Gi
   prometheus:
     retention: 2d
+    nodeSelector:
+      coroot.vanillax.dev/enabled: "true"
     storage:
       size: 10Gi
       className: longhorn
@@ -43,6 +47,8 @@ spec:
         memory: 1Gi
   clickhouse:
     replicas: 0
+    nodeSelector:
+      coroot.vanillax.dev/enabled: "true"
     storage:
       size: 10Gi
       className: longhorn
@@ -55,6 +61,8 @@ spec:
         memory: 2Gi
     keeper:
       replicas: 0
+      nodeSelector:
+        coroot.vanillax.dev/enabled: "true"
       storage:
         size: 2Gi
         className: longhorn


### PR DESCRIPTION
## Problem

Coroot was believed to be disabled. It was not.

`coroot-operator:1.9.6` reads `replicas: 0` as *unset* and substitutes its own defaults (keeper 3, clickhouse 1, coroot 1). The zero-value is indistinguishable from absent, so the intent never reached the workloads:

| | Value |
|---|---|
| Git (`coroot.yaml`) | `replicas: 0` / `clickhouse.replicas: 0` / `keeper.replicas: 0` |
| Live CR in cluster | `0 / 0 / 0` |
| ArgoCD app status | `Synced` + `Healthy` |
| Actual StatefulSet | **`spec.replicas=3`**, created 2026-08-14 |

GitOps applied the config faithfully and every status surface reported success while the operator silently overrode all of it.

## Impact

The stack ran 30+ hours and produced nothing at all:

- **Keeper never formed quorum.** Election terms reached 214/216 — each node independently ran 200+ elections in a partition of one. The `no hope to get quorum` counter is at **53,983**.
- **ClickHouse was therefore read-only**, unable to obtain a ZooKeeper session; every replicated table stuck in `Table was in readonly mode`.
- **coroot itself logged `audited 0 apps` / `checked 0 apps` / `evaluated 0 alerts`** on every iteration, and the UI reported `No data is available yet`.

Cost of producing that nothing: ~2.5 cores on the solar-powered shed worker (plus 1.7 on the HP), holding that node at 75% CPU / load 27 continuously.

## Change

Extends the nodeSelector-parking pattern already used for `nodeAgent`/`clusterAgent` to the four components that were actually running: `spec`, `prometheus`, `clickhouse`, and `clickhouse.keeper`.

All six nodeSelector paths were verified present in the CRD before writing, and `coroot.vanillax.dev/enabled` matches zero nodes, so every component parks Pending and consumes no CPU.

`replicas: 0` is retained — it documents correct intent and begins working if upstream fixes the zero-value handling.

Nothing is deleted. PVCs are retained (`reclaimPolicy: Delete` only applies on removal), and reverting this commit restores the stack.

## Follow-up required after sync

The StatefulSets are `RollingUpdate` + `OrderedReady`. A parked pod never becomes Ready, so the rollout stalls after the first ordinal and the remaining keepers keep running. One nudge is needed once ArgoCD syncs:

```bash
kubectl -n coroot delete pod -l app.kubernetes.io/part-of=coroot
```

The controller recreates ordinal 0 against the new template, it goes Pending, and `OrderedReady` never creates 1 and 2 — settling all three at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)