### PR TITLE
vllm: set the Baseline B ceiling to 180000 after measuring a 198,529-token pool

### DIFF
--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -54,8 +54,8 @@ spec:
             - "--gpu-memory-utilization"
             - "0.972"                                  # upstream's measured working value on a headless 3090
             - "--max-model-len"
-            # Measured pool on this card is 198,529 tokens (boot log "GPU KV cache size").
-            # 180000 leaves ~18.5K of margin above Pi's measured 158,083-token peak.
+            # 180000 leaves 18,529 tokens of physical KV-pool headroom and
+            # 21,917 tokens above Pi's measured 158,083-token peak.
             - "180000"
             - "--max-num-seqs"
             # Each slot reserves a GDN recurrent-state set from the same pool that

--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -54,9 +54,9 @@ spec:
             - "--gpu-memory-utilization"
             - "0.972"                                  # upstream's measured working value on a headless 3090
             - "--max-model-len"
-            # STAGE 3 PROBE VALUE ONLY. The real ceiling comes from the boot log's
-            # "GPU KV cache size" line — never assume it, always re-read it.
-            - "150000"
+            # Measured pool on this card is 198,529 tokens (boot log "GPU KV cache size").
+            # 180000 leaves ~18.5K of margin above Pi's measured 158,083-token peak.
+            - "180000"
             - "--max-num-seqs"
             # Each slot reserves a GDN recurrent-state set from the same pool that
             # must still admit one full-length request. Matches Baseline A for comparability.


### PR DESCRIPTION
Sets the real Baseline B context ceiling now that the card has been measured. **One value changes.**

## Measured, not assumed

The Stage 3 probe booted at `150000` purely to read the engine's own pool size. On a clean-card profile (`Free memory on device 23.3/23.56 GiB`):

```
weights resident   15.43 GiB     activation peak  0.75 GiB
CUDA graphs         0.45 GiB     KV cache memory  6.50 GiB
GPU KV cache size = 198,529 tokens        max concurrency @150K = 1.32x
```

That is **above** the 192.4K upstream measured for this exact quantization step, on stock vLLM with no custom image.

## Why 180000 and not 190000

Pi peaked at **158,083** tokens in Baseline A, and Baseline A's peak resident context was **160,468** against a 313,367-token pool — 51.2% utilisation, which produced a 97.5% prefix-cache hit rate and zero preemptions.

The open question is whether a 198,529-token pool preserves that cache behaviour, so **margin is worth more than per-request ceiling**:

| ceiling | % of pool | concurrency | margin over Pi's 158,083 |
|---|---|---|---|
| 190000 | 95.7% | ~1.04x | 31,917 |
| **180000** | **90.7%** | **~1.10x** | **21,917** |

180000 still exceeds anything Baseline A actually demanded.

## Verified during the Stage 3 boot

- **INT8 `lm_head` genuinely active** — `find_matched_target('lm_head', …)` → `re:.*lm_head$` → `group_1` `num_bits=8, group_size=128`; checkpoint has `weight_packed`/`weight_scale` and **no** dense `lm_head.weight`; `Using MarlinLinearKernel for CompressedTensorsWNA16`; weights at 15.43 GiB vs 16.84 for the BF16-head variant, so a silent dequantization was impossible.
- **`embed_tokens` still BF16** — shard byte-identical to pristine.
- **Async scheduling on** — an explicitly-set `async_scheduling=True` *raises* on incompatibility in `config/vllm.py`; the silent-disable paths only run when the value is `None`. The engine booted, so it is enabled.
- **GPU1 completely free** (1 MiB) — the second 3090 is released.

## Note on the Stage 3 restart

The first startup attempt failed with `Available KV cache memory: 4.42 GiB` because the outgoing TP=2 pod had not finished releasing VRAM when the new pod profiled (`free: 15 MB` at map time). This is the known dirty-GPU hazard; it failed **loudly** rather than silently serving a ~40% short pool, because 4.42 GiB could not admit a 150,000-token request. The restart profiled a clean card. **Not a model failure** — the clean profile is the authoritative measurement.

## Unchanged

Stock `vllm/vllm-openai:v0.27.1@sha256:0a51ea5b…bfd967`, same checkpoint, `--gpu-memory-utilization 0.972`, `--max-num-seqs 3`, `--max-num-batched-tokens 2048`, `--language-model-only`, `--async-scheduling`, FP8 KV, prefix caching, chunked prefill, `max_cudagraph_capture_size 4`, TP=1, one GPU, 200 W cap.

The custom `vllm-qwen38` image and INT8-embedding Path A remain **parked as fallback only**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r9VGfUmjAinBBJSEy5s2y
