### PR TITLE
cilium: pin 1.20.0-rc.0, hold Renovate below 1.20.0 final

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -94,6 +94,14 @@
       prCreation: 'immediate',
     },
     {
+      description: 'Cilium pinned to 1.20.0-rc.0: 1.20.0 final has two CNI-breaking xDS bugs (ADS livelock cilium/cilium#47624, split-mode stale NetworkPolicy NACK that wedged the hp node 2026-08-16). Hold every update until a 1.20.x fixes BOTH; cilium never automerges — a CNI minor is major-risk.',
+      matchPackageNames: [
+        'cilium',
+      ],
+      allowedVersions: '<1.20.0',
+      automerge: false,
+    },
+    {
       description: 'Enable container digest updates',
       matchDatasources: [
         'docker',

--- a/infrastructure/networking/cilium/kustomization.yaml
+++ b/infrastructure/networking/cilium/kustomization.yaml
@@ -15,7 +15,9 @@ resources:
 helmCharts:
 - name: cilium
   repo: https://helm.cilium.io
-  version: 1.20.0
+  # Pinned to rc.0: 1.20.0 final split-xDS replays stale NetworkPolicy resources on new
+  # streams (Envoy NACK wedged hp's CNI 2026-08-16); betting the regression landed after rc.0.
+  version: 1.20.0-rc.0
   releaseName: cilium
   includeCRDs: true
   namespace: kube-system

--- a/infrastructure/networking/cilium/values.yaml
+++ b/infrastructure/networking/cilium/values.yaml
@@ -123,6 +123,11 @@ k8sClientRateLimit:
 extraConfig:
   api-rate-limit: "endpoint-create=rate-limit:2/s,rate-burst:16,parallel-requests:8,max-wait-duration:30s"
 
+# 1.20 ADS mode livelocks after the last L7 listener drains (cilium/cilium#47624,
+# Gateways all 403) — stay on split xDS for the whole 1.20 line.
+envoy:
+  xdsMode: split
+
 # Gateway API Support
 gatewayAPI:
   enabled: true
@@ -132,12 +137,6 @@ gatewayAPI:
   # Enable session affinity for consistent routing
   sessionAffinity: true
   sessionAffinityTimeoutSeconds: 10800 # 3 hours
-
-# Cilium 1.20.0 ADS can livelock after its last L7 listener drains, publishing
-# an empty policy snapshot that makes every Gateway return 403 "Access denied".
-# Split xDS is unaffected; keep it until cilium/cilium#47624 ships in a release.
-envoy:
-  xdsMode: split
 
 # Cilium agent resources (VPA-optimized 2026-02-28; mem limit raised 2026-05-04)
 # Capacity baseline 2026-05-04 showed cilium-* daemonset pods observed


### PR DESCRIPTION
## Incident

`hp-workers-gkfrw8` had no working CNI for 25+ hours. The chain:

```
Cilium 1.20.0 (split xDS) replays stale NetworkPolicy resources on new Envoy streams
  └─> Envoy NACK: "duplicate resource key '10.244.5.33' on a new stream" — two cached
      policy resources claim one reused pod IP; BOTH endpoints are dead (verified absent
      from cilium-dbg endpoint list — pure phantoms in the agent's xDS cache)
       └─> one NACK poisons the node's shared policy stream: every endpoint regeneration
           fails (5,140 NACKs / 2h, 18 endpoints stuck — only on hp; 4 other nodes: zero)
            └─> agent API times out → cilium-cni can create no pod sandbox
                 └─> longhorn-manager down 25h (1,018 sandbox failures) → Longhorn node
                     Ready=False (allowScheduling stayed true)
                      └─> strict-local kopiur staging volumes unattachable
                           └─> 12 backup Jobs wedged in ContainerCreating up to 31h
```

## Why rc.0 and not forward or back

**Both** 1.20.0 xDS modes are broken:
- **ADS** livelocks after the last L7 listener drains ([cilium/cilium#47624](https://github.com/cilium/cilium/issues/47624), 1.20.1 release blocker) — hit here 2026-08-11 as Gateway-wide 403s, worked around with `xdsMode: split` (#1925)
- **split** has the stale-cache NACK above — unreported upstream, and **1.20.1 does not exist yet**

So there is no forward fix. Pinning `1.20.0-rc.0`: the coalesced-updates NACK fix ([#46938](https://github.com/cilium/cilium/releases/tag/v1.20.0-rc.0)) is in rc.0, and the bet is that the split regression landed between rc.0 and final. `xdsMode: split` stays (the ADS livelock spans the 1.20 line). **Fallback if hp wedges again on rc.0: 1.19.6**, the previously stable release.

## Renovate guard

`1.20.0` walked in as an unreviewed minor automerge on 2026-08-06. New rule: cilium `allowedVersions: '<1.20.0'` + `automerge: false`. Semver orders `1.20.0-rc.0 < 1.20.0`, so the pin satisfies the rule while final stays blocked. Lift only after a 1.20.x release fixes **both** bugs.

## Merging is the fix for the live incident

The rollout restarts every cilium agent; a restarted agent rebuilds its NetworkPolicy cache from live endpoints only — the phantoms have no endpoint state and cannot return. Expected recovery order on hp: CNI unwedges → longhorn-manager starts (kubelet is already retrying) → Longhorn node Ready → the 12 stuck backup Jobs attach and drain. No node reboots.

Validated: `kustomize build --enable-helm` renders agent+operator at `v1.20.0-rc.0`, `envoy-xds-mode: split` present in the ConfigMap, `api-rate-limit` tuning carried over, renovate.json5 parses (22 rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)