### PR TITLE
kopiur: drop strict-local from the staging class

### DIFF
--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -7,8 +7,8 @@ kind: Kustomization
 
 resources:
   # Kopiur does not currently expose mover node affinity. Restrict staged-PVC
-  # movers to the two workers that actually have Longhorn disks so the
-  # strict-local WFFC staging class cannot select the compute-only worker.
+  # movers to the workers that actually have Longhorn disks so the WFFC
+  # staging class cannot hint the compute-only worker.
   - mover-storage-node-policy.yaml
   # Longhorn creates its CSI sidecar Deployments dynamically, outside this
   # repository's rendered manifests. Mutate new attacher pods at admission so

--- a/infrastructure/controllers/kopiur-operator/mover-storage-node-policy.yaml
+++ b/infrastructure/controllers/kopiur-operator/mover-storage-node-policy.yaml
@@ -1,8 +1,8 @@
 # Kopiur 0.10.2 exposes mover security/resource overrides but no scheduling
 # affinity. Its snapshot movers consume short-lived `*-src` Longhorn PVCs, so
 # place those pods only on workers that declare Longhorn disk configuration.
-# Together with the strict-local WFFC staging class, this keeps each mover,
-# clone engine, and clone replica on one storage-capable node.
+# Together with the WFFC staging class, this steers mover, clone engine, and
+# clone replica toward one storage-capable node (best effort; see the class).
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:

--- a/infrastructure/storage/longhorn/storageclass-kopiur-staging.yaml
+++ b/infrastructure/storage/longhorn/storageclass-kopiur-staging.yaml
@@ -1,24 +1,13 @@
-# Temporary snapshot clones mounted by kopiur backup movers.
-#
-# Longhorn's default `longhorn` class binds immediately. For a CSI snapshot
-# clone that means Longhorn chooses the clone location before Kubernetes knows
-# where the consuming mover pod will run. Longhorn V1 can then spend minutes
-# handing the completed clone from one node to another (longhorn/longhorn
-# #13335), and a disrupted handoff can leave the backup Job wedged.
-#
-# WaitForFirstConsumer reverses that order: schedule the mover first, then pass
-# its node to Longhorn. The kopiur-operator application installs an admission
-# policy that restricts mover pods to nodes carrying
-# `node.longhorn.io/create-default-disk=config`, so strict-local can safely put
-# the temporary one-replica clone on the mover's storage-capable node. If no
-# such node can host it, fail closed instead of falling back to a cross-node
-# clone/attachment handoff.
+# Temporary snapshot clones mounted by kopiur backup movers. WFFC schedules the
+# mover first so its node becomes Longhorn's placement hint.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: longhorn-kopiur-staging-local
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
+    # Longhorn SC parameters are immutable — Replace lets ArgoCD swap the object.
+    argocd.argoproj.io/sync-options: Replace=true
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete
@@ -28,6 +17,8 @@ parameters:
   staleReplicaTimeout: "30"
   fsType: "ext4"
   dataEngine: "v1"
-  dataLocality: "strict-local"
+  # NEVER strict-local: clone provisioning can ignore the WFFC hint (longhorn#12792)
+  # and strict-local turns that into a permanent attach deadlock + Forbid backup stall.
+  dataLocality: "disabled"
   disableRevisionCounter: "true"
   unmapMarkSnapChainRemoved: "ignored"


### PR DESCRIPTION
## Problem

Longhorn clone provisioning sometimes ignores the WFFC `selected-node` hint ([longhorn/longhorn#12792](https://github.com/longhorn/longhorn/issues/12792), open, milestone v1.13): the staging clone's replica lands on whatever node scores best (in practice hp's 893G-free disk), while the mover pod and its attach ticket sit on the hinted node.

With `dataLocality: strict-local`, that mismatch is a **permanent attach deadlock**:

```
admission webhook "validator.longhorn.io" denied the request: data locality
strict-local requires the volume and replica to stay on the same node, but
ticket is on node dell-workers and replica is on node hp-workers
```

The mover never leaves `ContainerCreating`, and `concurrencyPolicy: Forbid` then blocks **every subsequent backup of that PVC** until the run is deleted by hand.

Observed 3× in 12h since hp's empty disk joined the cluster (temporal ×2, home-assistant ×1). home-assistant *succeeded* at 06:15 and *wedged* at 08:15 with identical topology — the placement is nondeterministic. `selected-node` annotation verified correct (`dell`) on every wedged PVC; Longhorn placed the replica on hp regardless.

## Fix

`dataLocality: disabled` — a misplaced replica becomes a cross-node attach: the backup runs slower instead of never. When Longhorn honors the hint (the common case), behavior is unchanged — mover, engine, and replica co-locate exactly as before via WFFC + the mover admission policy.

`best-effort` was deliberately not used: it triggers a local-replica rebuild that a read-once staging clone can't benefit from.

## Mechanics

- StorageClass parameters are immutable → the class gains `argocd.argoproj.io/sync-options: Replace=true` so ArgoCD swaps the object.
- In-flight staged PVCs keep old parameters; they're ephemeral — the next scheduled run picks up the new class.
- Two stale comment references to strict-local updated (kopiur-operator MAP + kustomization).

## Verification after merge

Watch the next temporal + home-assistant hourly runs (`kubectl get snapshot -n temporal -n home-assistant`) — they were the repeat offenders. A wedge-free 24h closes this out; the fix can be reverted to strict-local once Longhorn v1.13 ships #12792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)