### PR TITLE
docs: refresh the AI/GPU docs for the single-3090 vLLM backend

### DIFF
--- a/docs/domains/ai-gpu/3090-llm-optimization.md
+++ b/docs/domains/ai-gpu/3090-llm-optimization.md
@@ -7,11 +7,14 @@
 >
 > Last updated: 2026-07-04.
 >
-> ⚠️ **2026-06/07 update:** the "llama.cpp single-card is the steady state"
-> framing below is superseded — **vLLM TP=2 (both 3090s, `qwen3.6-27b` AWQ,
-> 262K) is the live default backend** (see `my-apps/ai/vllm/deployment.yaml`
-> and the model catalog's "Who points at what"). llama-cpp and ComfyUI are
-> scaled to 0. The engine analysis below remains correct per-configuration;
+> ⚠️ **Superseded topology:** the live backend is **vLLM serving
+> `qwen3.8-27b` on a SINGLE 3090** (TP=1, W4A16 + INT8 `lm_head`, 200,826-token
+> measured pool, text-only). Both the "llama.cpp single-card steady state"
+> framing and any `TP=2` / `qwen3.6-27b` / `262K` reference below are stale —
+> see [`model-catalog.md`](model-catalog.md) and
+> [`single-vs-dual-3090.md`](single-vs-dual-3090.md). llama-cpp and the
+> image-gen apps are scaled to 0. The engine analysis below remains correct
+> per-configuration;
 > the MTP "skip" verdict applied to single-card llama.cpp only — under the
 > now-live vLLM TP=2 it IS the documented win (149 → 179 narr / 264 code TPS
 > with MTP-3; club-3090's default dual recipe is AutoRound INT4 + MTP n=3).

--- a/docs/domains/ai-gpu/gpu-scale-swap.md
+++ b/docs/domains/ai-gpu/gpu-scale-swap.md
@@ -26,15 +26,21 @@ Two things make this safe by construction:
 
 | App | Cards | `replicas` in git (current) | File |
 |---|---|---|---|
-| **vLLM** (Qwen 3.6 AWQ, parked during evaluation) | **2** | `0` | `my-apps/ai/vllm/deployment.yaml` |
-| **llama-cpp** (Qwen 3.8 GGUF evaluation) | 1 | `1` | `my-apps/ai/llama-cpp/deployment.yaml` |
+| **vLLM** (Qwen 3.8 W4A16, active) | **1** | `1` | `my-apps/ai/vllm/deployment.yaml` |
+| **llama-cpp** (Qwen 3.8 GGUF, parked) | 1 | `0` | `my-apps/ai/llama-cpp/deployment.yaml` |
 | **ComfyUI** (image gen — see note below) | 1 | `0` | `my-apps/ai/comfyui/deployment.yaml` |
 | **SwarmUI** (image gen — see note below) | 1 | `0` | `my-apps/ai/swarmui/deployment.yaml` |
 | llmfit (batch benchmark **Jobs**, not always-on) | 1 or 2 | n/a | `my-apps/ai/llmfit/` |
 
 A valid target state is any set of `replicas: 1` rows whose **card total ≤ 2**.
-Working combos: vLLM alone (2 cards) · llama-cpp + one image-gen app (1+1) ·
-llama-cpp alone · one image-gen app alone.
+Working combos: vLLM (1 card) + one other single-card app · vLLM alone ·
+llama-cpp + one image-gen app (1+1) · llama-cpp alone · one image-gen app alone.
+
+vLLM currently requests **one** card, so a second single-card workload fits
+alongside it without a swap. Restoring the two-card vLLM configuration
+(`--tensor-parallel-size 2`, `nvidia.com/gpu: 2`) requires every other GPU app
+to be at `replicas: 0` first — see
+[`single-vs-dual-3090.md`](single-vs-dual-3090.md).
 
 > **Image gen: ComfyUI vs SwarmUI — decision pending.** ComfyUI's manifest is
 > marked *retired, replaced by SwarmUI* (SwarmUI self-starts its own ComfyUI),
@@ -73,9 +79,9 @@ curl -s http://vllm-service.vllm.svc.cluster.local:8080/v1/models
 
 - **Scaling llama-cpp to 0** → the external route `llama.vanillax.me` returns
   "no healthy upstream" until it's scaled back up. Expected, not an outage.
-- **Scaling vLLM to 0** → OpenWebUI, Perplexica, Project NOMAD, and Karakeep
-  lose their inference backend (they all point at vLLM / `qwen3.6-27b`).
-  Treat vLLM-down as "apps degraded" and keep the window short.
+- **Scaling vLLM to 0** → every app pointing at `vllm-service` loses its
+  inference backend, including Open WebUI, Perplexica and Deal Scout. Treat
+  vLLM-down as "apps degraded" and keep the window short.
 - **ComfyUI's vision→image workflow needs llama-cpp too** — it calls the
   llama-cpp multimodal endpoint for vision. Bringing up ComfyUI alone leaves
   its vision/caption nodes failing against a dead service. That combo is a

--- a/docs/domains/ai-gpu/model-catalog.md
+++ b/docs/domains/ai-gpu/model-catalog.md
@@ -1,78 +1,87 @@
 # AI model catalog
 
-Current model inventory, runtime ownership, and app wiring for the two local
+Current model inventory, runtime ownership, and app wiring for the local
 chat-model paths. The GPU swap procedure lives in
-[`gpu-scale-swap.md`](gpu-scale-swap.md).
+[`gpu-scale-swap.md`](gpu-scale-swap.md); the single-card capacity result lives
+in [`single-vs-dual-3090.md`](single-vs-dual-3090.md).
 
-## Current evaluation state
+## Current state
 
-| Backend | Replicas | Stored model | Runtime status |
-|---|---:|---|---|
-| vLLM | `0` | Qwen 3.6-27B AWQ BF16-INT4 | Parked and unchanged |
-| llama.cpp | `1` | Qwen 3.8-27B UD-Q4_K_XL GGUF | Active OpenWebUI backend |
-| ComfyUI / SwarmUI | `0` | Image-generation models on SMB | Parked |
+| Backend | Replicas | Cards | Served model | Status |
+|---|---:|---:|---|---|
+| vLLM | `1` | **1** | `qwen3.8-27b` | Active backend for every app |
+| llama.cpp | `0` | 1 | Qwen 3.8-27B GGUF | Parked |
+| ComfyUI / SwarmUI | `0` | 1 | Image-generation models on SMB | Parked |
 
-Qwen 3.8 does not yet have the AWQ quant needed by this cluster's Ampere vLLM
-path. The evaluation therefore uses the existing GGUF on llama.cpp while the
-proven Qwen 3.6 vLLM deployment remains available to restore later.
+vLLM holds **one** RTX 3090. The second card is unallocated and available for
+another whole-card workload.
+
+## vLLM
+
+Serves a single canonical model id, `qwen3.8-27b`, from
+`Qwen3.8-27B-W4A16-AutoRound-3090-int8lmhead` on the read-only
+`192.168.10.133:/mnt/ai-pool/vllm` share at `/models`.
+
+The checkpoint is W4A16 AutoRound with `lm_head` requantized to INT8 group-128
+and `embed_tokens` left BF16. That combination loads on **stock** vLLM:
+`qwen3_5.py` already passes `quant_config` to `ParallelLMHead`, and
+`ParallelLMHead` is routed to the linear WNA16 path, which supports 8 bits.
+Only quantizing `embed_tokens` would require a patched image.
+
+Text-only. The deployment runs `--language-model-only`, so the vision tower is
+not loaded and image input is unavailable.
+
+> A patched image that also wires the quantized-embedding path exists at
+> `ghcr.io/mitchross/vllm-qwen38` and is **parked**. It buys roughly 7K more
+> cache tokens. Use it only if a workload demonstrably needs that margin.
 
 ## Storage boundaries
 
 The model stores are intentionally separate:
 
-- vLLM mounts `192.168.10.133:/mnt/ai-pool/vllm` read-only at `/models`.
-  Its selected directory is `Qwen3.6-27B-AWQ-BF16-INT4`.
+- vLLM mounts `192.168.10.133:/mnt/ai-pool/vllm` **read-only** at `/models`.
+  Writing to it requires a separate read-write mount; the share is exported to
+  the cluster subnet.
 - llama.cpp mounts `192.168.10.133:/mnt/ai-pool/llama-cpp` at `/models`.
-  The active files are `Qwen3.8-27B-UD-Q4_K_XL.gguf` and
-  `mmproj-qwen3.8-BF16.gguf`.
-- SMB `//192.168.10.133/comfyui` is ComfyUI/image-generation storage. Qwen
-  image models or helper LLMs there are unrelated to OpenWebUI's chat-model
-  catalog.
+- SMB `//192.168.10.133/comfyui` is image-generation storage, unrelated to the
+  chat-model catalog.
 
-Do not delete unused NAS files as part of API-catalog cleanup. A model is
-selectable only when it has a preset in `my-apps/ai/llama-cpp/presets.ini`.
+Do not delete unused NAS files as part of API-catalog cleanup. A llama.cpp model
+is selectable only when it has a preset in `my-apps/ai/llama-cpp/presets.ini`.
 
-## llama.cpp API catalog
+## llama.cpp API catalog (parked)
 
-llama.cpp advertises exactly two presets over one GGUF and projector:
+When scaled up, llama.cpp advertises two presets over one GGUF and projector:
 
-| API model | Thinking | Sampling | Consumer |
+| API model | Thinking | Sampling | Use |
 |---|---|---|---|
-| `qwen3.8` | Enabled | `temp=1.0`, `top_p=0.95`, `top_k=20` | OpenWebUI chat and vision |
-| `qwen3.8-nothink` | Disabled | `temp=0.7`, `top_p=0.8`, `top_k=20`, `presence_penalty=1.5` | OpenWebUI title/tag tasks |
+| `qwen3.8` | Enabled | `temp=1.0`, `top_p=0.95`, `top_k=20` | Chat and vision |
+| `qwen3.8-nothink` | Disabled | `temp=0.7`, `top_p=0.8`, `top_k=20`, `presence_penalty=1.5` | Title/tag tasks |
 
-`--models-max 1` means only one preset process is resident. Switching between
-the two can reload the same weights even though both point at one file, so keep
-interactive traffic on `qwen3.8` and reserve `qwen3.8-nothink` for short
-background work.
+`--models-max 1` keeps one preset process resident. Switching between the two
+can reload the same weights even though both point at one file, so keep
+interactive traffic on `qwen3.8`.
 
-## OpenWebUI wiring
+## App wiring
 
-`my-apps/ai/open-webui/open-webui-configmap.env` is authoritative:
+`my-apps/ai/open-webui/open-webui-configmap.env` is authoritative for Open WebUI
+and points at `vllm-service` with `qwen3.8-27b` for default, vision and task
+models. `ENABLE_PERSISTENT_CONFIG=False` prevents stale database settings from
+overriding GitOps configuration.
 
-- `OPENAI_API_BASE_URL(S)` → llama.cpp service
-- `DEFAULT_MODELS=qwen3.8`
-- `VISION_MODELS=qwen3.8`
-- `TASK_MODEL=qwen3.8-nothink`
-- `TASK_MODEL_EXTERNAL=qwen3.8-nothink`
-- `CONTEXT_WINDOW=65536`
-- `ENABLE_PERSISTENT_CONFIG=False`, preventing stale database settings from
-  overriding GitOps configuration
+Because vLLM is text-only in the current configuration, `VISION_MODELS` will not
+produce image understanding until either the vision tower is re-enabled or
+llama.cpp is scaled up for that purpose.
 
-OpenWebUI is the only app moved to llama.cpp for this evaluation. Perplexica,
-Project NOMAD, Karakeep, LiteLLM, Presenton, and other normal consumers remain
-wired to `vllm-service` / `qwen3.6-27b`; they are unavailable while vLLM is at
-zero replicas.
+> **Known gap:** several consumers still request the retired id `qwen3.6-27b`
+> and will 404 — including LiteLLM, Presenton, Hindsight, WorldMonitor,
+> Karakeep, Project NOMAD, the news-reader Temporal worker, and some n8n
+> workflows. Grep for `qwen3.6-27b` under `my-apps/` before assuming an app
+> works. Rolling these to `qwen3.8-27b` is outstanding.
 
-## Ending the evaluation
+## Changing the served model
 
-Restore the normal backend in one GitOps change:
-
-1. Set llama.cpp to `replicas: 0` and vLLM to `replicas: 1`.
-2. Point OpenWebUI's base URL back to vLLM.
-3. Restore its default/vision/task model IDs to `qwen3.6-27b` and the validated
-   Qwen 3.6 sampling values.
-4. Verify `/v1/models` before relying on dependent applications.
-
-Never scale vLLM up while llama.cpp plus another GPU workload would make the
-requested card total exceed two.
+The served id is `--served-model-name` in `my-apps/ai/vllm/deployment.yaml`.
+Keep it to a single canonical id so model selectors are not cluttered with
+aliases, and roll every consumer in the same change — a renamed id silently
+404s for anything left behind.

--- a/docs/domains/ai-gpu/pi-agent-local-dev.md
+++ b/docs/domains/ai-gpu/pi-agent-local-dev.md
@@ -1,5 +1,14 @@
 # Pi Agent — Claude-Code-Grade Local Dev on the Dual-3090 Backend
 
+> ⚠️ **Model id and topology below are out of date.** The live backend is
+> **`qwen3.8-27b`** on a **single** RTX 3090 (TP=1), W4A16 + INT8 `lm_head`,
+> a measured **200,826-token** KV pool with a 180000 ceiling, and
+> **text-only** (`--language-model-only`, no vision). Every `qwen3.6-27b`,
+> `TP=2` and `262K` reference on this page is stale — substitute the current
+> values. See [`model-catalog.md`](model-catalog.md) and
+> [`single-vs-dual-3090.md`](single-vs-dual-3090.md); the surrounding technique
+> is still sound.
+
 > Goal: fully local coding agents that match the Claude Code *capability set*
 > — tools, repo context, skills, research — without using Claude Code. The
 > toolchain is **[pi](https://github.com/badlogic/pi-mono) (primary) +

--- a/docs/domains/ai-gpu/single-vs-dual-3090.md
+++ b/docs/domains/ai-gpu/single-vs-dual-3090.md
@@ -1,0 +1,113 @@
+# One 3090 vs two for Qwen3.8-27B
+
+vLLM serves Qwen3.8-27B on a **single RTX 3090**. The second card is free.
+This page records what that costs, what it does not cost, and the rules that
+follow.
+
+The swap procedure lives in [`gpu-scale-swap.md`](gpu-scale-swap.md); model
+inventory and app wiring live in [`model-catalog.md`](model-catalog.md).
+
+## The result
+
+A single card was measured against the two-card configuration using the same
+two real workloads (a Perplexica research query and an agentic coding session
+over a real repository), with identical verbatim prompts.
+
+| | 2× RTX 3090, TP=2 | **1× RTX 3090, TP=1** |
+|---|---:|---:|
+| KV cache pool | 313,367 tok | **200,826 tok** |
+| Peak resident context | 160,468 (51.2%) | **152,867 (76.1%)** |
+| Preemptions | 0 | **0** |
+| Prefix-cache hit rate | 97.5% | **96.3%** |
+| Truncation / abort / error | 0 / 0 / 0 | **0 / 0 / 0** |
+| TTFT mean | 3.808 s | 4.564 s |
+| Prefill mean | 3.012 s | 4.242 s |
+| Decode (TPOT) mean | 0.036 s | 0.038 s |
+| Power, mean | ~236 W total | **196 W** |
+
+**The penalty is prefill and TTFT latency, not usable context.** Dropping a card
+removes 36% of the KV pool but the workload still fits, because the pool is only
+ever ~76% full at peak. Decode barely moves; generation was never the bottleneck.
+
+## Why the pool is large enough
+
+Qwen3.8 is a hybrid-attention model. `full_attention_interval: 4` means only
+**16 of its 64 layers** build a real KV cache; the other 48 are Gated DeltaNet
+with a fixed-size recurrent state per sequence, not per token. KV therefore
+costs roughly **32 KiB/token**, which is why 200K+ tokens fit in 6.5 GiB.
+
+Two consequences worth internalising:
+
+- Raising `--max-model-len` does **not** add capacity. The pool is one shared
+  token budget; the flag only raises the per-request ceiling.
+- Each `--max-num-seqs` slot reserves a GDN recurrent-state set out of that same
+  pool, which must still admit one full-length request.
+
+## Rules
+
+**Read the pool from the engine, never predict it.** The boot log line
+`GPU KV cache size: N tokens` is the only trustworthy source. Capacity does not
+scale the way arithmetic suggests — the same card reported 198,529 tokens at
+`--max-model-len 150000` and 200,826 at `180000`, with identical KV bytes.
+
+**Boot small, then set the ceiling.** To discover capacity on a new
+quantization or card layout, boot deliberately low (150000 works), read the
+pool, then set the real ceiling. `--max-model-len` acts as an assertion: if the
+pool cannot admit one full-length request the engine refuses to start with an
+explicit `ValueError` rather than serving a silently degraded cache.
+
+**Keep `--max-num-batched-tokens` at 2048 on a single card.** Larger prefill
+chunks inflate the profiled activation peak, which shrinks the cache pool. 8192
+measurably costs capacity here.
+
+**`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` is not optional** above
+~0.975 utilisation. The DeltaNet prefill kernels allocate transient workspace
+and fragment the allocator without it. Do not also set `max_split_size_mb`;
+it works against expandable segments.
+
+**Never drop `--enable-auto-tool-choice` or `--tool-call-parser qwen3_coder`.**
+Perplexica sends `tool_choice=auto` and fails silently without them.
+
+**Watch prefix-cache hit rate, not just peak context.** Cache retention is what
+keeps TTFT low on 100K+ prompts — the vast majority of prompt tokens are served
+from cache rather than re-prefilled. A capacity change that preserves peak
+context but collapses the hit rate is a regression, and it will present as
+multi-minute stalls rather than a gentle slowdown.
+
+## Scope of the result
+
+The measurement covers **two concurrent text workloads** at `--max-num-seqs 3`.
+It does not cover:
+
+- **Vision.** The single-card configuration runs `--language-model-only`, which
+  drops the vision tower (~2.7 GB). Image input is unavailable in this mode.
+- **Sustained peaks above ~76% pool utilisation.** The agent workload converged
+  around 146K tokens of context; behaviour nearer the 180,000 ceiling is
+  extrapolated, not measured.
+- **Higher concurrency.** Three sequence slots were enough for the apps in this
+  cluster; more consumers would need re-measuring.
+
+## Restoring two cards
+
+Revert the vLLM Deployment to `--tensor-parallel-size 2`, `nvidia.com/gpu: 2`,
+the FP8 checkpoint and `--max-model-len 262144`. Both configurations run the
+same stock digest-pinned image, and the FP8 checkpoint stays on the read-only
+model share, so no data moves and no image changes. Expect ~3 minutes for the
+pod to reload weights.
+
+## Reproducing
+
+The harness lives in `benchmarks/ai-realworld-load/`. Its README holds the
+verbatim workload prompts, which must be reused unchanged for any comparison to
+be valid. `tools/collect.sh` reads cluster telemetry only and deploys nothing.
+
+Two things to get right when re-running:
+
+- **Restart vLLM first and verify the cache is genuinely cold**
+  (`prefix_cache_queries_total` and `hits` both zero). A warm cache invalidates
+  exactly the metric under test.
+- **Drive long-running HTTP workloads from inside the cluster.** The external
+  gateway terminates connections at 300 s, which kills a research query
+  mid-flight. `kubectl port-forward` does not work for Perplexica — it binds the
+  pod IP, so forwarding to localhost is refused. A detached Job that calls the
+  service DNS is immune to both.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ reconstructs protected data. [Open the full-size platform map](assets/platform-o
 - **Database**: plain Postgres Deployments backed up by kopiur — hourly snapshots, restore-before-bind (CNPG retired 2026-08-13)
 - **Secrets**: 1Password Connect + External Secrets Operator
 - **Observability**: kube-prometheus-stack, Loki, Tempo, OpenTelemetry
-- **AI**: vLLM (Qwen3.6-27B, default app inference) + llama-cpp (Qwen3.6-35B multimodal — vision→image + preset playground) on mutually-exclusive whole-card GPUs ([scale-swap runbook](domains/ai-gpu/gpu-scale-swap.md))
+- **AI**: vLLM serving Qwen3.8-27B (`qwen3.8-27b`, W4A16 + INT8 lm_head) on a **single** RTX 3090; the second card is free. llama-cpp and the image-gen apps are parked ([scale-swap runbook](domains/ai-gpu/gpu-scale-swap.md) · [one vs two 3090s](domains/ai-gpu/single-vs-dual-3090.md))
 
 ## Documentation
 
@@ -101,7 +101,7 @@ Backups are **kopiur** (Kopia-native operator).
 - **Observability**: [radar-ng](domains/observability/radar-ng.md)
 - **Scheduling**: [VPA policy ownership and topology](domains/scheduling/vpa-and-topology.md)
 - **Apps**: [Self-hosting PostHog on Kubernetes](posthog-self-host-k8s.md) — the full recipe (topology, single-node ClickHouse, routing, upgrade checklist), portable to any cluster
-- **AI / GPU**: [model catalog](domains/ai-gpu/model-catalog.md) · [3090 LLM optimization](domains/ai-gpu/3090-llm-optimization.md) · [pi agent local-dev guide](domains/ai-gpu/pi-agent-local-dev.md)
+- **AI / GPU**: [model catalog](domains/ai-gpu/model-catalog.md) · [one vs two 3090s](domains/ai-gpu/single-vs-dual-3090.md) · [3090 LLM optimization](domains/ai-gpu/3090-llm-optimization.md) · [pi agent local-dev guide](domains/ai-gpu/pi-agent-local-dev.md)
 
 ## Adopting any of this
 

--- a/my-apps/ai/CLAUDE.md
+++ b/my-apps/ai/CLAUDE.md
@@ -2,39 +2,43 @@
 
 ## LLM Backend
 
-Two OpenAI-compatible local backends, **NEITHER is ollama**:
+One OpenAI-compatible local backend, **NOT ollama**:
 
-### vLLM — normal app backend, temporarily parked
+### vLLM — active, single card
 - Endpoint: `http://vllm-service.vllm.svc.cluster.local:8080/v1`
-- Served model: **`qwen3.6-27b`** (Qwen3.6-27B dense AWQ, multimodal/vision)
-- `replicas: 0` during the Qwen 3.8 GGUF evaluation; do not scale or reconfigure it unless ending the evaluation.
-- Perplexica, Project NOMAD, Karakeep, and the other normal consumers still point here and are unavailable while it is parked.
-- **Use vLLM / `qwen3.6-27b` when wiring an in-cluster app to chat/vision inference.**
+- Served model: **`qwen3.8-27b`** — Qwen3.8-27B W4A16 AutoRound with INT8
+  group-128 `lm_head`, BF16 `embed_tokens`, FP8 KV, on **one** RTX 3090 (TP=1).
+- **Text-only**: runs `--language-model-only`, so the vision tower is not
+  loaded. Do not wire image input to this endpoint.
+- **Use vLLM / `qwen3.8-27b` when wiring an in-cluster app to chat inference.**
 
-### llama-cpp — current Qwen 3.8 evaluation backend
-- Endpoint: `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`
-- Serves **Qwen3.8-27B** `UD-Q4_K_XL.gguf` plus its BF16 vision projector.
-- Advertises only `qwen3.8` and `qwen3.8-nothink`; both use the same weights.
-- OpenWebUI points here during the evaluation. Chat/vision use `qwen3.8`; strict
-  title/tag tasks use `qwen3.8-nothink`.
-- **Models swap natively** via `llama-server --models-preset` — no external
-  `llama-swap` needed. `--models-max 1` = one resident at a time.
+### llama-cpp — parked
+- `replicas: 0`. Endpoint `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`.
+- Serves Qwen3.8-27B GGUF plus a vision projector when scaled up; advertises
+  `qwen3.8` and `qwen3.8-nothink`. Scale it up only if vision is needed, and
+  only via the swap procedure.
 
-**App→backend wiring table + what each model is / when to use it:
-[`docs/domains/ai-gpu/model-catalog.md`](../../docs/domains/ai-gpu/model-catalog.md).**
+**Several apps still request the retired `qwen3.6-27b` and will 404** (LiteLLM,
+Presenton, Hindsight, WorldMonitor, Karakeep, Project NOMAD, the news-reader
+Temporal worker, some n8n workflows). Grep for it before assuming an app works.
+
+**App→backend wiring + capacity rules:
+[`model-catalog.md`](../../docs/domains/ai-gpu/model-catalog.md) ·
+[`single-vs-dual-3090.md`](../../docs/domains/ai-gpu/single-vs-dual-3090.md).**
 
 ### Gotchas (see `docs/domains/ai-gpu/3090-llm-optimization.md` for full rationale)
 - **KV cache must be SYMMETRIC** — `q8_0/q8_0` or `q4_0/q4_0`, never mixed.
   Asymmetric KV falls to CPU, 44x slower ([llama.cpp #20866]). Overrides the
   Qwen3-Coder docs' q8-K/q4-V suggestion.
-- **Context limit = `min(model max, VRAM-affordable KV)`.** Qwen3.8 model max is
-  256K; a single 3090 only *affords* ~64K of KV after weights. Pool both 3090s
-  (48GB) for resident 256K. CPU expert-offload is a last resort on this
-  Broadwell/DDR4 node (memory-bandwidth-bound, ~8-12 TPS).
+- **Context limit = `min(model max, VRAM-affordable KV)`.** Measured on one
+  3090 with the W4A16 + INT8-lm_head checkpoint: a **200,826-token** pool, set
+  to a 180000 ceiling. Read `GPU KV cache size` from the boot log; never predict
+  it. Details in
+  [`single-vs-dual-3090.md`](../../docs/domains/ai-gpu/single-vs-dual-3090.md).
 - **Local = unlimited token *volume* (free), not an infinite *window* per request.**
-- **Engine tradeoff:** Qwen 3.8 has no Ampere-usable vLLM AWQ quant yet, so the
-  evaluation uses llama.cpp GGUF. Keep the proven Qwen 3.6 AWQ vLLM deployment
-  parked and unchanged so it can be restored after the evaluation.
+- **Engine choice:** Qwen 3.8 runs on vLLM via W4A16 AutoRound with an INT8
+  `lm_head`, which stock vLLM loads unpatched. llama.cpp GGUF is the fallback
+  when vision is required.
 - **MTP/spec-decode gives NO net speedup** on Ampere + 35B-A3B under llama.cpp
   (same-hw benchmark) — only helps under vLLM TP=2. Don't bother on single-card.
 - **TurboQuant `turbo3` KV** (≈5x smaller) is coming to mainline llama.cpp
@@ -53,7 +57,8 @@ The production AI workloads are pinned to the existing `gpu-worker=true`
 label. The Wi-Fi Dell worker is CPU-only and deliberately does not carry that
 label, so it cannot receive these 24/48-GiB model workloads.
 
-- **Current state:** vLLM `replicas: 0`; llama-cpp `1`; ComfyUI and SwarmUI `0`.
+- **Current state:** vLLM `replicas: 1` holding **one** card; llama-cpp,
+  ComfyUI and SwarmUI `0`. One 3090 is free for a second single-card workload.
   (Current, not permanent — flip the committed replica counts to swap which
   workload owns the cards. Full procedure + card truth table:
   [`docs/domains/ai-gpu/gpu-scale-swap.md`](../../docs/domains/ai-gpu/gpu-scale-swap.md).)


### PR DESCRIPTION
The AI/GPU docs still described a **finished evaluation**: vLLM parked at `replicas: 0` serving Qwen3.6 across both cards, llama-cpp active on a Qwen3.8 GGUF.

Reality is the inverse — vLLM is the only active backend, holds **one** 3090, and serves `qwen3.8-27b`. An agent or operator reading these would have reached for the wrong endpoint, the wrong model id and the wrong card budget.

## New

**`docs/domains/ai-gpu/single-vs-dual-3090.md`** — the measured one-card result, and more usefully the rules that follow from it:

| | 2× 3090 | **1× 3090** |
|---|---:|---:|
| KV pool | 313,367 | **200,826** |
| Peak resident | 160,468 (51.2%) | **152,867 (76.1%)** |
| Preemptions | 0 | **0** |
| Prefix-cache hit | 97.5% | **96.3%** |
| TTFT / prefill mean | 3.808 / 3.012 s | 4.564 / 4.242 s |

The penalty is prefill and TTFT latency, **not usable context**.

Rules recorded: read the pool from the engine's own `GPU KV cache size` line rather than predicting it (the same card reports 198,529 at `--max-model-len 150000` and 200,826 at `180000`, with identical KV bytes); boot small then set the ceiling; keep `--max-num-batched-tokens` at 2048 because larger prefill chunks inflate the activation peak and shrink the pool; `expandable_segments` is not optional above ~0.975 util; never drop `--enable-auto-tool-choice`, because Perplexica sends `tool_choice=auto` and fails silently without it.

It also states the **limits** of the result: text-only, two workloads, and untested above ~76% pool utilisation.

## Corrected in place

- **`model-catalog.md`** — current state, storage boundaries, app wiring
- **`gpu-scale-swap.md`** — card truth table (vLLM is 1 card now, so a second single-card workload fits without a swap)
- **`docs/index.md`** — the AI one-liner
- **`my-apps/ai/CLAUDE.md`** — the file agents actually load; its backend section was fully inverted

## Deliberately not done here

The two large guides (`pi-agent-local-dev.md`, `3090-llm-optimization.md`) keep their content but gain an explicit staleness banner naming exactly what changed. Their config snippets, mermaid diagrams and checklists carry ~18 stale references; rewriting 70 KB of guide is follow-up work, and a banner beats being silently wrong in a setup you'd copy-paste.

**Recorded as a known gap, not fixed:** LiteLLM, Presenton, Hindsight, WorldMonitor, Karakeep, Project NOMAD, the news-reader Temporal worker and several n8n workflows still request the retired `qwen3.6-27b` and **404**. That is an app-config change touching 12+ files, not a docs change.

Docs only — no manifests, no behaviour change. All relative links verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r9VGfUmjAinBBJSEy5s2y
