### PR TITLE
benchmarks: make report.py baseline-agnostic, record the Baseline B result

### DIFF
--- a/benchmarks/ai-realworld-load/README.md
+++ b/benchmarks/ai-realworld-load/README.md
@@ -1,8 +1,12 @@
 # Real-world AI load baseline (dual vs single RTX 3090)
 
-Answers one question: **can ONE RTX 3090 serve Perplexica + Pi + Deal Scout
-without materially losing usable context?** Context capacity is the criterion,
-not tokens/sec.
+Answered one question: **can ONE RTX 3090 serve the real workload without
+materially losing usable context?** Context capacity was the criterion, not
+tokens/sec. **It can** — see Results below.
+
+The Deal Scout digest is excluded from both baselines: it 500s on an
+application bug, so it contributed no load and would have made the comparison
+uneven.
 
 Not ArgoCD-managed — `benchmarks/` sits outside every AppSet glob. Nothing here
 deploys; the collector only reads. Runs land in `runs/` (git-ignored).
@@ -11,10 +15,49 @@ deploys; the collector only reads. Runs land in `runs/` (git-ignored).
 
 | | Hardware | Model | Status |
 |---|---|---|---|
-| **A** | 2x RTX 3090, TP=2, PCIe/no NVLink | Qwen3.8-27B-**FP8** (Marlin weight-only) | this doc |
-| **B** | 1x RTX 3090, TP=1 | Qwen3.8-27B W4A16 AutoRound (INT8 `lm_head`/`embed_tokens`, ~14.26 GiB) | later |
+| **A** | 2x RTX 3090, TP=2, PCIe/no NVLink | Qwen3.8-27B-**FP8** (Marlin weight-only) | measured |
+| **B** | 1x RTX 3090, TP=1 | Qwen3.8-27B W4A16 AutoRound, INT8 `lm_head`, BF16 `embed_tokens` | measured |
 
-B must reuse the **verbatim prompts in this file** or the comparison is void.
+Both used the **verbatim prompts in this file**. Any re-run must too, or the
+comparison is void.
+
+## Results
+
+| | A — 2x3090 | **B — 1x3090** |
+|---|---:|---:|
+| KV pool | 313,367 | **200,826** |
+| Peak resident context | 160,468 (51.2%) | **152,867 (76.1%)** |
+| Preemptions | 0 | **0** |
+| Prefix-cache hit rate | 97.5% | **96.3%** |
+| Truncation / abort / error | 0 / 0 / 0 | **0 / 0 / 0** |
+| TTFT mean | 3.808s | 4.564s |
+| Prefill mean | 3.012s | 4.242s |
+| TPOT mean | 0.036s | 0.038s |
+| Completed requests | 122 | 141 |
+
+**One 3090 is sufficient for this workload.** The penalty is prefill and TTFT
+latency, not usable context. Full analysis and the rules that follow:
+[`docs/domains/ai-gpu/single-vs-dual-3090.md`](../../docs/domains/ai-gpu/single-vs-dual-3090.md).
+
+Caveat kept deliberately: the agent workload converged near 146K tokens of
+context in B, so the pool was measured to ~76% utilisation. Behaviour nearer the
+ceiling is extrapolated.
+
+### Baseline B configuration
+
+```
+vLLM 0.27.1 (STOCK image) · Qwen3.8-27B W4A16 + INT8 g128 lm_head · TP=1 · 1 card
+--max-model-len 180000        --gpu-memory-utilization 0.972
+--max-num-seqs 3              --max-num-batched-tokens 2048
+--kv-cache-dtype fp8_e4m3     --language-model-only  (text-only, no vision)
+--async-scheduling            max_cudagraph_capture_size 4
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+200W/card power limit
+
+KV capacity ceiling : 200,826 tokens   <- read from the boot log, never predicted
+Max concurrency     : 1.12x @ 180,000
+Weights             : 15.43 GiB   activation: 0.75  CUDA graphs: 0.45  KV: 6.50 GiB
+```
 
 ### Baseline A configuration (measured at boot, not assumed)
 
@@ -78,6 +121,17 @@ behaviour) — both out of scope. Per-request counts are never invented from
 aggregate counters.
 
 ## Run sequence
+
+Two traps that invalidate a run, both hit in practice:
+
+- **Restart vLLM first and verify the prefix cache is cold**
+  (`prefix_cache_queries_total` and `hits` both 0). A warm cache contaminates
+  exactly the metric under test.
+- **Drive long HTTP workloads from inside the cluster.** The external gateway
+  terminates connections at 300s, killing a research query mid-flight.
+  `kubectl port-forward` does not work for Perplexica — it binds the pod IP, so
+  forwarding to localhost is refused. A detached Job calling the service DNS is
+  immune to both.
 
 ```bash
 cd benchmarks/ai-realworld-load

--- a/benchmarks/ai-realworld-load/tools/report.py
+++ b/benchmarks/ai-realworld-load/tools/report.py
@@ -118,7 +118,7 @@ def main():
         print("no metric ticks captured — was the collector running?")
         sys.exit(1)
 
-    print(f"BASELINE A — {os.path.basename(run)}")
+    print(f"{ctx.get('label', 'run').upper()} — {os.path.basename(run)}")
     print(f"pod={ctx.get('pod','?')}  node={ctx.get('node','?')}")
     print(f"window={ctx.get('run_started_utc','?')} .. {ctx.get('run_ended_utc','in progress')}")
     print(f"KV capacity ceiling = {cap:,} tokens   [{M}, from engine cache_config_info]")
@@ -138,7 +138,7 @@ def main():
 
     print(f"\n4. PEAK SIMULTANEOUS RESIDENT CONTEXT : {fmt(peak_res)} tokens   [{D}]")
     print(f"   formula: max(vllm:kv_cache_usage_perc) x {cap:,}")
-    print(f"   = {peak_res/cap*100:.1f}% of the dual-3090 pool" if cap else "")
+    print(f"   = {peak_res/cap*100:.1f}% of the measured KV pool" if cap else "")
     print(f"   NOTE: KV occupancy includes blocks retained by the prefix cache,")
     print(f"         so this is an upper bound on live request context.")
 
@@ -190,11 +190,12 @@ def main():
     total_pre = (pre[-1][1] - pre[0][1]) if pre else 0
     print(f"preemptions during run           : {int(total_pre):>4}   [{M}]")
 
-    ever3 = sum(1 for _, v in runq if v >= 3)
-    print(f"ticks with all 3 running         : {ever3:>4} of {len(ticks)}   [{M}]")
-    if ever3 == 0:
-        print("  !! the three workloads never genuinely overlapped — the run does not")
-        print("     test concurrency. Re-run with tighter launch spacing.")
+    peak_conc = int(max((v for _, v in runq), default=0))
+    overlapped = sum(1 for _, v in runq if v >= 2)
+    print(f"ticks with >=2 running           : {overlapped:>4} of {len(ticks)}   [{M}]")
+    if peak_conc < 2:
+        print("  !! the workloads never overlapped — the run does not test concurrency.")
+        print("     Re-run with tighter launch spacing.")
 
     if total_pre > 0:
         print("\n  PREEMPTION FORENSICS (recompute restarts prefill from token 0):")
@@ -271,8 +272,11 @@ def main():
         a, b = sum(per[0]["util"])/len(per[0]["util"]), sum(per[1]["util"])/len(per[1]["util"])
         if max(a, b) > 0:
             print(f"\nutilisation imbalance: {abs(a-b)/max(a,b)*100:.1f}%   [{D}]")
-            print("  TP=2 over PCIe with no NVLink — large sustained imbalance would")
-            print("  point at NCCL/PCIe stalls rather than genuine idle.")
+            if min(a, b) < 1.0:
+                print("  One card is idle — single-card run, so 100% imbalance is expected.")
+            else:
+                print("  TP over PCIe with no NVLink — large sustained imbalance would")
+                print("  point at NCCL/PCIe stalls rather than genuine idle.")
 
     # ---------------- health -------------------------------------------------
     section("POD HEALTH")


### PR DESCRIPTION
> **Merge after #2014.** The README cross-references `docs/domains/ai-gpu/single-vs-dual-3090.md`, which lands in that PR.

## report.py was hardcoded to Baseline A

It was written when Baseline A was the only run, and carried three assumptions that were wrong for any other configuration:

| Symptom | Reality |
|---|---|
| Header printed `BASELINE A` for every run | Even when passed `…_baseline-b-official` |
| Peak context reported as "% of the **dual-3090** pool" | Baseline B has one card |
| `!! the three workloads never genuinely overlapped — the run does not test concurrency` | Baseline B deliberately runs **two** workloads |
| Imbalance explained as a `TP=2`/NCCL stall symptom | On one card, 100% imbalance is arithmetic, not a fault |

The third one mattered most: it told a perfectly valid run it had failed. The Deal Scout digest is excluded from both baselines because it 500s on an application bug, so the protocol is two workloads by design — but the script demanded three concurrent requests before it would believe concurrency had been tested.

## Fixes

- header takes the label from `context.env` → `BASELINE-A` / `BASELINE-B-OFFICIAL`
- pool described as **measured**, not dual-card
- overlap reported as `ticks with >=2 running`, warning only when peak concurrency `< 2`
- imbalance note distinguishes an idle second card from a real TP stall

**Verified against both stored runs**, not just re-read:

```
BASELINE-A — 20260816T222409Z_baseline-a
   = 51.2% of the measured KV pool
  ticks with >=2 running           :  151 of 2170
  utilisation imbalance: 0.0%
    TP over PCIe with no NVLink — large sustained imbalance would …

BASELINE-B-OFFICIAL — 20260818T142144Z_baseline-b-official
   = 76.1% of the measured KV pool
  ticks with >=2 running           :   96 of 1731
  utilisation imbalance: 100.0%
    One card is idle — single-card run, so 100% imbalance is expected.
```

Neither triggers a false warning now.

## README

Records the measured result — one 3090 sustained **152,867** resident tokens on a **200,826** pool with **0 preemptions**, **96.3%** cache hits and **0 truncations**, against two cards' 160,468 / 313,367 / 0 / 97.5% — plus the Baseline B configuration block.

Also documents the two operational traps that invalidated an earlier attempt, because both cost a full run:

- **a warm prefix cache contaminates exactly the metric under test** — restart vLLM and verify `prefix_cache_queries_total` and `hits` are both 0
- **the external gateway kills long HTTP workloads at 300 s**, and `kubectl port-forward` is *not* a workaround: Perplexica binds the pod IP, so forwarding to localhost is refused. A detached Job calling the service DNS is immune to both.

No behaviour change to the collector; `runs/` stays git-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r9VGfUmjAinBBJSEy5s2y
