### PR TITLE
Tokens/s in Open WebUI + vLLM Grafana dashboard (and fix the single-3090 boot OOM)

### DIFF
--- a/monitoring/prometheus-stack/kustomization.yaml
+++ b/monitoring/prometheus-stack/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - app-performance-dashboard.yaml # Two-selector workload investigation with correlated Loki errors
   - posthog-performance-dashboard.yaml # PostHog web/Postgres/Kafka/ClickHouse root-cause decoder
   - gpu-dashboard.yaml # Grafana dashboard
+  - vllm-dashboard.yaml # vLLM tokens/s + latency + KV cache + MTP acceptance
   - vpa-recommendations-dashboard.yaml # Active VPA policy and recommendation dashboard
   - trivy-dashboard.yaml # Trivy Operator vulnerability dashboard (Grafana 17813; pairs with monitoring/trivy-operator)
   - trivy-alerts.yaml # Trivy critical-vuln alerting (high per-image critical count)

--- a/monitoring/prometheus-stack/vllm-dashboard.yaml
+++ b/monitoring/prometheus-stack/vllm-dashboard.yaml
@@ -1,0 +1,150 @@
+# vLLM Inference Dashboard (Grafana)
+#
+# Grafana auto-discovers this ConfigMap via the sidecar (grafana_dashboard: "1" label).
+# Data source: Prometheus scraping vLLM's native /metrics (my-apps/ai/vllm/servicemonitor.yaml).
+#
+# Layout answers "how fast is the model serving right now?" in five rows:
+#   Row 1 - At-a-glance stats: gen tok/s, prompt tok/s, running, waiting
+#   Row 2 - Tokens/s over time: aggregate throughput + single-stream decode speed
+#   Row 3 - Latency: TTFT + end-to-end quantiles
+#   Row 4 - KV / prefix cache utilization and hit rate
+#   Row 5 - Speculative decoding (MTP-2): acceptance rate, draft vs accepted
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vllm-dashboard
+  namespace: prometheus-stack
+  labels:
+    grafana_dashboard: "1"
+    app.kubernetes.io/name: grafana-dashboards
+data:
+  vllm-inference.json: |
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "graphTooltip": 1,
+      "schemaVersion": 39,
+      "title": "vLLM Inference",
+      "uid": "vllm-inference",
+      "tags": ["vllm", "llm", "ai"],
+      "time": { "from": "now-3h", "to": "now" },
+      "refresh": "30s",
+      "templating": { "list": [] },
+      "panels": [
+        { "type": "row", "id": 100, "title": "At a glance", "gridPos": {"x":0,"y":0,"w":24,"h":1}, "collapsed": false },
+
+        { "type": "stat", "id": 1, "title": "Generation tok/s",
+          "gridPos": {"x":0,"y":1,"w":6,"h":4},
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "targets": [{"expr":"sum(rate(vllm:generation_tokens_total[$__rate_interval]))","refId":"A"}],
+          "options": {"reduceOptions":{"calcs":["lastNotNull"]},"colorMode":"value","graphMode":"area"},
+          "fieldConfig":{"defaults":{"unit":"none","decimals":1,"color":{"mode":"thresholds"},"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null}]}}}
+        },
+
+        { "type": "stat", "id": 2, "title": "Prompt (prefill) tok/s",
+          "gridPos": {"x":6,"y":1,"w":6,"h":4},
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "targets": [{"expr":"sum(rate(vllm:prompt_tokens_total[$__rate_interval]))","refId":"A"}],
+          "options": {"reduceOptions":{"calcs":["lastNotNull"]},"colorMode":"value","graphMode":"area"},
+          "fieldConfig":{"defaults":{"unit":"none","decimals":1,"color":{"mode":"thresholds"},"thresholds":{"mode":"absolute","steps":[{"color":"blue","value":null}]}}}
+        },
+
+        { "type": "stat", "id": 3, "title": "Requests running",
+          "gridPos": {"x":12,"y":1,"w":6,"h":4},
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "targets": [{"expr":"sum(vllm:num_requests_running)","refId":"A"}],
+          "options": {"reduceOptions":{"calcs":["lastNotNull"]},"colorMode":"value","graphMode":"area"},
+          "fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"yellow","value":3}]}}}
+        },
+
+        { "type": "stat", "id": 4, "title": "Requests waiting",
+          "gridPos": {"x":18,"y":1,"w":6,"h":4},
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "targets": [{"expr":"sum(vllm:num_requests_waiting)","refId":"A"}],
+          "options": {"reduceOptions":{"calcs":["lastNotNull"]},"colorMode":"value","graphMode":"area"},
+          "fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"yellow","value":1},{"color":"red","value":3}]}}}
+        },
+
+        { "type": "row", "id": 101, "title": "Tokens per second", "gridPos": {"x":0,"y":5,"w":24,"h":1}, "collapsed": false },
+
+        { "type": "timeseries", "id": 10, "title": "Throughput (all requests)",
+          "gridPos": {"x":0,"y":6,"w":12,"h":8},
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "targets": [
+            {"expr":"sum(rate(vllm:generation_tokens_total[$__rate_interval]))","legendFormat":"generation tok/s","refId":"A"},
+            {"expr":"sum(rate(vllm:prompt_tokens_total[$__rate_interval]))","legendFormat":"prompt tok/s","refId":"B"}
+          ],
+          "fieldConfig":{"defaults":{"unit":"none","decimals":1,"min":0}}
+        },
+
+        { "type": "timeseries", "id": 11, "title": "Single-stream decode speed (1 / mean time-per-output-token)",
+          "gridPos": {"x":12,"y":6,"w":12,"h":8},
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "targets": [
+            {"expr":"1 / (sum(rate(vllm:time_per_output_token_seconds_sum[$__rate_interval])) / sum(rate(vllm:time_per_output_token_seconds_count[$__rate_interval])))","legendFormat":"tok/s per stream","refId":"A"}
+          ],
+          "fieldConfig":{"defaults":{"unit":"none","decimals":1,"min":0}}
+        },
+
+        { "type": "row", "id": 102, "title": "Latency", "gridPos": {"x":0,"y":14,"w":24,"h":1}, "collapsed": false },
+
+        { "type": "timeseries", "id": 20, "title": "Time to first token",
+          "gridPos": {"x":0,"y":15,"w":12,"h":8},
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "targets": [
+            {"expr":"histogram_quantile(0.50, sum(rate(vllm:time_to_first_token_seconds_bucket[$__rate_interval])) by (le))","legendFormat":"p50","refId":"A"},
+            {"expr":"histogram_quantile(0.95, sum(rate(vllm:time_to_first_token_seconds_bucket[$__rate_interval])) by (le))","legendFormat":"p95","refId":"B"}
+          ],
+          "fieldConfig":{"defaults":{"unit":"s","min":0}}
+        },
+
+        { "type": "timeseries", "id": 21, "title": "End-to-end request latency",
+          "gridPos": {"x":12,"y":15,"w":12,"h":8},
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "targets": [
+            {"expr":"histogram_quantile(0.50, sum(rate(vllm:e2e_request_latency_seconds_bucket[$__rate_interval])) by (le))","legendFormat":"p50","refId":"A"},
+            {"expr":"histogram_quantile(0.95, sum(rate(vllm:e2e_request_latency_seconds_bucket[$__rate_interval])) by (le))","legendFormat":"p95","refId":"B"}
+          ],
+          "fieldConfig":{"defaults":{"unit":"s","min":0}}
+        },
+
+        { "type": "row", "id": 103, "title": "KV / prefix cache", "gridPos": {"x":0,"y":23,"w":24,"h":1}, "collapsed": false },
+
+        { "type": "timeseries", "id": 30, "title": "KV cache usage",
+          "gridPos": {"x":0,"y":24,"w":12,"h":8},
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "targets": [{"expr":"sum(vllm:gpu_cache_usage_perc) * 100","legendFormat":"KV cache used %","refId":"A"}],
+          "fieldConfig":{"defaults":{"unit":"percent","min":0,"max":100,"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"yellow","value":80},{"color":"red","value":95}]}}}
+        },
+
+        { "type": "timeseries", "id": 31, "title": "Prefix cache hit rate",
+          "gridPos": {"x":12,"y":24,"w":12,"h":8},
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "targets": [
+            {"expr":"100 * sum(rate(vllm:gpu_prefix_cache_hits_total[$__rate_interval])) / sum(rate(vllm:gpu_prefix_cache_queries_total[$__rate_interval]))","legendFormat":"hit %","refId":"A"}
+          ],
+          "fieldConfig":{"defaults":{"unit":"percent","min":0,"max":100}}
+        },
+
+        { "type": "row", "id": 104, "title": "Speculative decoding (MTP)", "gridPos": {"x":0,"y":32,"w":24,"h":1}, "collapsed": false },
+
+        { "type": "timeseries", "id": 40, "title": "Draft token acceptance rate",
+          "gridPos": {"x":0,"y":33,"w":12,"h":8},
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "targets": [
+            {"expr":"100 * sum(rate(vllm:spec_decode_num_accepted_tokens_total[$__rate_interval])) / sum(rate(vllm:spec_decode_num_draft_tokens_total[$__rate_interval]))","legendFormat":"accepted %","refId":"A"}
+          ],
+          "fieldConfig":{"defaults":{"unit":"percent","min":0,"max":100}}
+        },
+
+        { "type": "timeseries", "id": 41, "title": "Draft vs accepted tok/s",
+          "gridPos": {"x":12,"y":33,"w":12,"h":8},
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "targets": [
+            {"expr":"sum(rate(vllm:spec_decode_num_draft_tokens_total[$__rate_interval]))","legendFormat":"drafted","refId":"A"},
+            {"expr":"sum(rate(vllm:spec_decode_num_accepted_tokens_total[$__rate_interval]))","legendFormat":"accepted","refId":"B"}
+          ],
+          "fieldConfig":{"defaults":{"unit":"none","decimals":1,"min":0}}
+        }
+      ]
+    }

--- a/my-apps/ai/open-webui/function-loader-job.yaml
+++ b/my-apps/ai/open-webui/function-loader-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: load-har-analyzer-v6
+  name: load-functions-v7
   namespace: open-webui
   annotations:
     argocd.argoproj.io/hook: PostSync
@@ -38,8 +38,20 @@ spec:
           sys.path.insert(0, "/app/backend")
           os.environ.setdefault("DATA_DIR", "/app/backend/data")
 
-          with open("/functions/har-analyzer-function.py") as f:
-              code = f.read()
+          FUNCTIONS = [
+              {
+                  "id": "har_forensics_analyzer",
+                  "name": "HAR Forensics Analyzer",
+                  "path": "/functions/har-analyzer-function.py",
+                  "description": "Filter: preprocesses uploaded .har files into forensic reports for LLM analysis",
+              },
+              {
+                  "id": "tokens_per_second",
+                  "name": "Tokens Per Second",
+                  "path": "/functions/tokens-per-second-function.py",
+                  "description": "Filter: injects response_token/s + prompt_token/s into streamed usage stats",
+              },
+          ]
 
           from open_webui.models.functions import Functions, FunctionForm, FunctionMeta
           from open_webui.models.users import Users
@@ -71,6 +83,60 @@ spec:
               return []
 
 
+          async def load_function(admin_id, spec):
+              with open(spec["path"]) as f:
+                  code = f.read()
+
+              existing = await _maybe_await(Functions.get_function_by_id(spec["id"]))
+
+              if existing:
+                  result = await _maybe_await(
+                      Functions.update_function_by_id(
+                          spec["id"],
+                          {
+                              "name": spec["name"],
+                              "type": "filter",
+                              "content": code,
+                              "meta": {"description": spec["description"]},
+                              "is_active": True,
+                              "is_global": True,
+                          },
+                      )
+                  )
+                  if result is None:
+                      print(f"ERROR: Failed to update function {spec['id']}")
+                      sys.exit(1)
+                  print(f"Updated function: {result.id}")
+              else:
+                  form = FunctionForm(
+                      id=spec["id"],
+                      name=spec["name"],
+                      type="filter",
+                      content=code,
+                      meta=FunctionMeta(description=spec["description"]),
+                  )
+                  result = await _maybe_await(
+                      Functions.insert_new_function(admin_id, "filter", form)
+                  )
+                  if result is None:
+                      print(f"ERROR: Failed to create function {spec['id']}")
+                      sys.exit(1)
+                  await _maybe_await(
+                      Functions.update_function_by_id(
+                          spec["id"], {"is_active": True, "is_global": True}
+                      )
+                  )
+                  print(f"Created function: {result.id}")
+
+              # Re-read to confirm the active/global flags actually stuck.
+              final = await _maybe_await(Functions.get_function_by_id(spec["id"]))
+              if final is not None:
+                  print(
+                      f"{spec['id']} Active: {getattr(final, 'is_active', '?')}, "
+                      f"Global: {getattr(final, 'is_global', '?')}"
+                  )
+
+
           async def main():
               # Find first admin user
               users_data = await _maybe_await(Users.get_users())
@@ -84,64 +150,9 @@ spec:
                   print("WARNING: No admin user found, using placeholder ID")
                   admin_id = "system"
 
-              form = FunctionForm(
-                  id="har_forensics_analyzer",
-                  name="HAR Forensics Analyzer",
-                  type="filter",
-                  content=code,
-                  meta=FunctionMeta(
-                      description="Filter: preprocesses uploaded .har files into forensic reports for LLM analysis"
-                  ),
-              )
+              for spec in FUNCTIONS:
+                  await load_function(admin_id, spec)
 
-              existing = await _maybe_await(
-                  Functions.get_function_by_id("har_forensics_analyzer")
-              )
-
-              if existing:
-                  result = await _maybe_await(
-                      Functions.update_function_by_id(
-                          "har_forensics_analyzer",
-                          {
-                              "name": "HAR Forensics Analyzer",
-                              "type": "filter",
-                              "content": code,
-                              "meta": {
-                                  "description": "Filter: preprocesses uploaded .har files into forensic reports for LLM analysis"
-                              },
-                              "is_active": True,
-                              "is_global": True,
-                          },
-                      )
-                  )
-                  if result is None:
-                      print("ERROR: Failed to update function")
-                      sys.exit(1)
-                  print(f"Updated function: {result.id}")
-              else:
-                  result = await _maybe_await(
-                      Functions.insert_new_function(admin_id, "filter", form)
-                  )
-                  if result is None:
-                      print("ERROR: Failed to create function")
-                      sys.exit(1)
-                  await _maybe_await(
-                      Functions.update_function_by_id(
-                          "har_forensics_analyzer",
-                          {"is_active": True, "is_global": True},
-                      )
-                  )
-                  print(f"Created function: {result.id}")
-
-              # Re-read to confirm the active/global flags actually stuck.
-              final = await _maybe_await(
-                  Functions.get_function_by_id("har_forensics_analyzer")
-              )
-              if final is not None:
-                  print(
-                      f"Active: {getattr(final, 'is_active', '?')}, "
-                      f"Global: {getattr(final, 'is_global', '?')}"
-                  )
               print("Done!")
 
 
@@ -150,14 +161,21 @@ spec:
         - configMapRef:
             name: open-webui-configmap
         volumeMounts:
-        - name: functions
-          mountPath: /functions
+        - name: har-function
+          mountPath: /functions/har-analyzer-function.py
+          subPath: har-analyzer-function.py
+        - name: tps-function
+          mountPath: /functions/tokens-per-second-function.py
+          subPath: tokens-per-second-function.py
         - name: data
           mountPath: /app/backend/data
       volumes:
-      - name: functions
+      - name: har-function
         configMap:
           name: har-analyzer-function
+      - name: tps-function
+        configMap:
+          name: tokens-per-second-function
       - name: data
         persistentVolumeClaim:
           claimName: storage

--- a/my-apps/ai/open-webui/kustomization.yaml
+++ b/my-apps/ai/open-webui/kustomization.yaml
@@ -24,6 +24,11 @@ configMapGenerator:
   - har-analyzer-function.py
   options:
     disableNameSuffixHash: true
+- name: tokens-per-second-function
+  files:
+  - tokens-per-second-function.py
+  options:
+    disableNameSuffixHash: true
 - name: open-webui-configmap
   envs:
   - open-webui-configmap.env

--- a/my-apps/ai/open-webui/tokens-per-second-function.py
+++ b/my-apps/ai/open-webui/tokens-per-second-function.py
@@ -1,0 +1,59 @@
+"""
+title: Tokens Per Second
+author: vanillax
+version: 1.0.0
+description: Injects response_token/s + prompt_token/s into streamed usage stats (vLLM sends only token counts).
+"""
+
+import time
+
+from pydantic import BaseModel, Field
+
+
+class Filter:
+    class Valves(BaseModel):
+        priority: int = Field(default=0, description="Filter processing order")
+
+    def __init__(self):
+        self.valves = self.Valves()
+        self._t_start = {}  # message_id -> inlet (request start) time
+        self._t_first = {}  # message_id -> first stream chunk time
+
+    def _prune(self, now):
+        # Aborted/errored streams never hit the usage chunk; drop stale entries.
+        for d in (self._t_start, self._t_first):
+            for k in [k for k, t in d.items() if now - t > 3600]:
+                d.pop(k, None)
+
+    def inlet(self, body: dict, __metadata__=None) -> dict:
+        now = time.time()
+        self._prune(now)
+        mid = (__metadata__ or {}).get("message_id")
+        if mid:
+            self._t_start[mid] = now
+            self._t_first.pop(mid, None)
+        return body
+
+    def stream(self, event: dict, __metadata__=None) -> dict:
+        if not isinstance(event, dict):
+            return event
+        now = time.time()
+        mid = (__metadata__ or {}).get("message_id") or event.get("id")
+        if mid and mid not in self._t_first:
+            self._t_first[mid] = now
+
+        usage = event.get("usage")
+        completion = (usage or {}).get("completion_tokens") or 0
+        if usage and completion:
+            t_first = self._t_first.pop(mid, None)
+            t_start = self._t_start.get(mid)
+            # first chunk arrives after prefill, so first->last spans the decode phase
+            if t_first and now > t_first:
+                usage["response_token/s"] = round(completion / (now - t_first), 2)
+            prompt = usage.get("prompt_tokens") or 0
+            if prompt and t_start and t_first and t_first > t_start:
+                usage["prompt_token/s"] = round(prompt / (t_first - t_start), 2)
+            if t_start:
+                s = int(now - t_start)
+                usage["approximate_total"] = f"{s // 3600}h{(s % 3600) // 60}m{s % 60}s"
+        return event

--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - "--served-model-name"
             - "qwen3.8-27b"
             - "--gpu-memory-utilization"
-            - "0.90"                                   # MTP needs headroom for DeltaNet decode workspace
+            - "0.93"                                   # 0.90 left only 1.9 GiB KV (2.45 needed for 65536) — boot-verified floor; keep ≥1 GiB free for DeltaNet workspace
             - "--max-model-len"
             - "65536"                                  # vision tower trades context for image understanding on 24 GiB
             - "--max-num-seqs"
@@ -84,6 +84,7 @@ spec:
             - '{"method":"mtp","num_speculative_tokens":2}'
             - "--override-generation-config"
             - '{"temperature":0.7,"top_p":0.8,"top_k":20,"presence_penalty":1.5}'
+            - "--enable-force-include-usage"             # usage on every stream chunk final — Open WebUI shows token stats without per-model DB config
             - "--host"
             - "0.0.0.0"
             - "--port"


### PR DESCRIPTION
## What

**1. vLLM boot fix (crash-loop since #2017):** at `--gpu-memory-utilization 0.90` the profiler leaves **1.9 GiB** for KV cache but the 65536 max-model-len needs **2.45 GiB**, so the engine failed startup validation on every boot (`ValueError` in `gpu_worker`; verified against a clean card — 4 MiB used between restarts). Raised to **0.93** (+0.71 GiB): keeps 65536 + vision + MTP-2, leaves ~1.2 GiB free VRAM for the DeltaNet decode workspace. The node outage had been masking this.

**2. Tokens/s in Open WebUI:**
- `--enable-force-include-usage` on vLLM → every streamed response carries a `usage` block; Open WebUI captures chunk usage unconditionally (`middleware.py`), so token stats show with zero per-model DB config.
- New `tokens_per_second` filter (loaded by the generalized function-loader Job) times request → first chunk → final usage chunk and injects `response_token/s` / `prompt_token/s` / total duration into the usage dict — Open WebUI only computes rates natively for Ollama backends. Shows in the message ⓘ tooltip and feeds Analytics.

**3. Grafana:** new `vllm-inference` dashboard — generation/prompt tok/s, single-stream decode speed (1/mean TPOT), TTFT + e2e p50/p95, KV cache usage, prefix cache hit rate, MTP draft acceptance rate.

## Verification
- `kustomize build` passes for all three apps; dashboard JSON validated; filter syntax-checked.
- Filter hook shapes verified against the deployed Open WebUI image source (`stream(event)` invocation, `merge_usage` passthrough of custom keys).
- `--enable-force-include-usage` confirmed present in vLLM v0.27.1 cli_args.
- Post-merge I'll confirm the boot log KV pool and spot-check the two cache metric names (`vllm:gpu_cache_usage_perc`, `vllm:gpu_prefix_cache_*`) against live `/metrics`, and follow up if v0.27.1 renamed them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)