### PR TITLE
Fix tok/s math under vLLM continuous usage + real v0.27.1 metric names

### DIFF
--- a/monitoring/prometheus-stack/vllm-dashboard.yaml
+++ b/monitoring/prometheus-stack/vllm-dashboard.yaml
@@ -77,11 +77,11 @@ data:
           "fieldConfig":{"defaults":{"unit":"none","decimals":1,"min":0}}
         },
 
-        { "type": "timeseries", "id": 11, "title": "Single-stream decode speed (1 / mean time-per-output-token)",
+        { "type": "timeseries", "id": 11, "title": "Single-stream decode speed (1 / mean inter-token latency)",
           "gridPos": {"x":12,"y":6,"w":12,"h":8},
           "datasource": {"type":"prometheus","uid":"prometheus"},
           "targets": [
-            {"expr":"1 / (sum(rate(vllm:time_per_output_token_seconds_sum[$__rate_interval])) / sum(rate(vllm:time_per_output_token_seconds_count[$__rate_interval])))","legendFormat":"tok/s per stream","refId":"A"}
+            {"expr":"1 / (sum(rate(vllm:inter_token_latency_seconds_sum[$__rate_interval])) / sum(rate(vllm:inter_token_latency_seconds_count[$__rate_interval])))","legendFormat":"tok/s per stream","refId":"A"}
           ],
           "fieldConfig":{"defaults":{"unit":"none","decimals":1,"min":0}}
         },
@@ -113,7 +113,7 @@ data:
         { "type": "timeseries", "id": 30, "title": "KV cache usage",
           "gridPos": {"x":0,"y":24,"w":12,"h":8},
           "datasource": {"type":"prometheus","uid":"prometheus"},
-          "targets": [{"expr":"sum(vllm:gpu_cache_usage_perc) * 100","legendFormat":"KV cache used %","refId":"A"}],
+          "targets": [{"expr":"sum(vllm:kv_cache_usage_perc) * 100","legendFormat":"KV cache used %","refId":"A"}],
           "fieldConfig":{"defaults":{"unit":"percent","min":0,"max":100,"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"yellow","value":80},{"color":"red","value":95}]}}}
         },
 
@@ -121,7 +121,7 @@ data:
           "gridPos": {"x":12,"y":24,"w":12,"h":8},
           "datasource": {"type":"prometheus","uid":"prometheus"},
           "targets": [
-            {"expr":"100 * sum(rate(vllm:gpu_prefix_cache_hits_total[$__rate_interval])) / sum(rate(vllm:gpu_prefix_cache_queries_total[$__rate_interval]))","legendFormat":"hit %","refId":"A"}
+            {"expr":"100 * sum(rate(vllm:prefix_cache_hits_total[$__rate_interval])) / sum(rate(vllm:prefix_cache_queries_total[$__rate_interval]))","legendFormat":"hit %","refId":"A"}
           ],
           "fieldConfig":{"defaults":{"unit":"percent","min":0,"max":100}}
         },

--- a/my-apps/ai/open-webui/tokens-per-second-function.py
+++ b/my-apps/ai/open-webui/tokens-per-second-function.py
@@ -1,7 +1,7 @@
 """
 title: Tokens Per Second
 author: vanillax
-version: 1.0.0
+version: 1.1.0
 description: Injects response_token/s + prompt_token/s into streamed usage stats (vLLM sends only token counts).
 """
 
@@ -43,17 +43,26 @@ class Filter:
             self._t_first[mid] = now
 
         usage = event.get("usage")
-        completion = (usage or {}).get("completion_tokens") or 0
-        if usage and completion:
-            t_first = self._t_first.pop(mid, None)
-            t_start = self._t_start.get(mid)
-            # first chunk arrives after prefill, so first->last spans the decode phase
-            if t_first and now > t_first:
-                usage["response_token/s"] = round(completion / (now - t_first), 2)
-            prompt = usage.get("prompt_tokens") or 0
-            if prompt and t_start and t_first and t_first > t_start:
-                usage["prompt_token/s"] = round(prompt / (t_first - t_start), 2)
-            if t_start:
-                s = int(now - t_start)
-                usage["approximate_total"] = f"{s // 3600}h{(s % 3600) // 60}m{s % 60}s"
+        if not usage:
+            return event
+
+        # vLLM --enable-force-include-usage puts RUNNING usage on every delta
+        # chunk; Open WebUI's merge_usage sums those. Keep only the final
+        # usage-only chunk (empty choices) and drop the rest.
+        if event.get("choices"):
+            event.pop("usage", None)
+            return event
+
+        completion = usage.get("completion_tokens") or 0
+        t_first = self._t_first.pop(mid, None)
+        t_start = self._t_start.get(mid)
+        # first chunk arrives after prefill, so first->last spans the decode phase
+        if completion and t_first and now > t_first:
+            usage["response_token/s"] = round(completion / (now - t_first), 2)
+        prompt = usage.get("prompt_tokens") or 0
+        if prompt and t_start and t_first and t_first > t_start:
+            usage["prompt_token/s"] = round(prompt / (t_first - t_start), 2)
+        if t_start:
+            s = int(now - t_start)
+            usage["approximate_total"] = f"{s // 3600}h{(s % 3600) // 60}m{s % 60}s"
         return event


### PR DESCRIPTION
Follow-ups to #2018, both found in live verification:

**1. Filter math / inflated tooltip totals.** `--enable-force-include-usage` in vLLM v0.27.1 hard-enables *continuous* usage — running totals on every delta chunk (`should_include_usage` → `True, True`, confirmed in the deployed image). Open WebUI's `merge_usage` **sums** `input_tokens`/`output_tokens`/`total_tokens` across chunks, so the tooltip showed `input_tokens: 1,371,738` (= 6179 × 222 chunks), and the filter computed tok/s against the last chunk-gap (2444 tok/s on a 3090). The filter (v1.1.0) now strips usage from delta chunks — which also fixes Open WebUI's inflated totals — and computes `response_token/s` / `prompt_token/s` on the final usage-only chunk. Verified with a simulated continuous-usage stream (expected ≈10 tok/s → got 9.99).

**2. Dashboard metric names.** v0.27.1's `/metrics` exposes `vllm:kv_cache_usage_perc`, `vllm:prefix_cache_{hits,queries}_total`, and `vllm:inter_token_latency_seconds_*` — not the `gpu_*`/`time_per_output_token` names the dashboard shipped with (verified against the live endpoint). Without this the KV-cache, prefix-cache, and decode-speed panels are empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)