### PR TITLE
ninfer: fix download-hook sync-wave deadlock

### DIFF
--- a/my-apps/ai/ninfer/deployment.yaml
+++ b/my-apps/ai/ninfer/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: ninfer
   labels:
     app: ninfer-server
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"   # after the wave-0 download hook completes
 spec:
   # Experimental candidate backend (side-by-side vs the vLLM control). Consumes
   # the second, currently free 3090; delete/revert this app to roll back.

--- a/my-apps/ai/ninfer/download-model-job.yaml
+++ b/my-apps/ai/ninfer/download-model-job.yaml
@@ -6,7 +6,9 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-    argocd.argoproj.io/sync-wave: "-1"    # artifact must exist before the server pod starts
+    # Wave 0 WITH the PV/PVC (a -1 hook deadlocks: it runs before the PVC exists).
+    # The server Deployment sits at wave 1, so the artifact still lands first.
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 4


### PR DESCRIPTION
The wave `-1` Sync hook ran before any wave-0 resource was applied, so its pod sat Pending on the not-yet-created `ninfer-models-pvc` while the sync waited on the hook — a deadlock (observed 30 min). Hook → wave 0 (applied together with the PV/PVC), server Deployment → wave 1 so the artifact still downloads before the server starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)