### PR TITLE
ninfer: fix download Job OOM — NFS page cache needs headroom

### DIFF
--- a/my-apps/ai/ninfer/download-model-job.yaml
+++ b/my-apps/ai/ninfer/download-model-job.yaml
@@ -43,9 +43,11 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 128Mi
+            memory: 256Mi
           limits:
-            memory: 512Mi
+            # NFS page cache counts against the cgroup: at 512Mi the container was
+            # repeatedly killed mid-download (~2-3 GiB per attempt, resume proved it).
+            memory: 4Gi
         volumeMounts:
         - name: models
           mountPath: /models


### PR DESCRIPTION
The 512Mi memory limit killed the download container every ~2–3 GiB of the 17 GiB NFS write (dirty page cache is charged to the cgroup). curl's `-C -` resume kept making progress across restarts — the artifact reached 47% — until `backoffLimit` failed the Job. Raising the limit to 4Gi lets per-cgroup dirty throttling do its job. Probable-cause diagnosis: no OOM event was retained, but the progress-per-attempt pattern and an unlimited debug pod downloading without issue both point at the limit.

The remaining bytes are currently finishing in a temporary debug pod so the next sync's hook verifies-and-skips; this fix is what makes the Job reproducible on a fresh cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)