### PR TITLE
ninfer: single-card scale-swap evaluation (no second 3090, ever)

### DIFF
--- a/benchmarks/ai-realworld-load/README.md
+++ b/benchmarks/ai-realworld-load/README.md
@@ -271,14 +271,19 @@ contributed no load.
 ## Engine A/B — vLLM control vs NInfer-3090 candidate
 
 The candidate is `my-apps/ai/ninfer/` (NInfer-3090 `v0.6.0-rtx3090`, commit
-`2ae51915225d`, official `qwen3_8_27b.ninfer` artifact, SHA-pinned) on the
-second 3090. The vLLM control and everything above this line is UNCHANGED —
-control runs still use `collect.sh` + `report.py` and the verbatim Workload A/B
-prompts. Workload C (Deal Scout digest) stays excluded while its application
-bug stands.
+`2ae51915225d`, official `qwen3_8_27b.ninfer` artifact, SHA-pinned). The
+chassis holds **one RTX 3090 — permanently** — so the engines are compared
+**sequentially on the identical card** by scale-swapping committed replicas
+(`vllm-server: 1/ninfer-server: 0` ↔ `0/1`, one commit each way — see
+`docs/domains/ai-gpu/gpu-scale-swap.md`). Same silicon, same 200 W cap, and
+every swap restarts the engine, so each window starts with a provably cold
+prefix cache. The vLLM control config and everything above this line is
+UNCHANGED — control runs still use `collect.sh` + `report.py` and the verbatim
+Workload A/B prompts. Workload C (Deal Scout digest) stays excluded while its
+application bug stands.
 
-Both cards are power-limited to 200 W by the powerlimit DaemonSet; do not
-change that during an A/B without recording it in `context.env`.
+The card is power-limited to 200 W by the powerlimit DaemonSet; do not change
+that between the two windows of an A/B without recording it in `context.env`.
 
 ### Candidate tooling (parallel, not replacing)
 
@@ -313,21 +318,28 @@ knob-for-knob identical.
 
 ### Order of operations
 
-1. **Smoke (correctness before speed):** `tools/smoke-ninfer.sh all <image.jpg>`
-   — text stream, thinking on/off, tools (`tool_choice=auto` is the
-   Perplexica-compatibility gate), vision (judge the description content),
-   16K-context needle. Vision must name details actually present in the image;
-   HTTP 200 is not a pass.
-2. **First controlled A/B:** start `collect.sh start ab-control` and
-   `collect-ninfer.sh start ab-candidate`, then `tools/ab-smallload.sh`
+Every candidate step below happens inside a **NInfer window** (committed swap:
+`ninfer-server: 1`, `vllm-server: 0`); control steps happen inside a **vLLM
+window** (the normal production state). One engine at a time, always.
+
+1. **Control window — baseline A/B half:** with production vLLM up,
+   `collect.sh start ab-control`, then `tools/ab-smallload.sh control`
    (6,055-token fixed prompt — counted by the live Qwen tokenizer — ~600-token
-   answer, cold then warm, C1, vision loaded on both servers). Stop both
-   collectors; run both reports.
-3. **Real workload on the candidate:** re-run Workload A (Perplexica: point its
-   custom-OpenAI provider at the NInfer endpoint in Perplexica's settings UI —
-   config-only, revert after) and Workload B (Pi: add a `vanillax-ninfer`
-   provider to `~/.pi/agent/models.json`, `pi --model qwen3.8-ninfer`) with the
-   VERBATIM prompts above. Restart the ninfer pod first for a cold prefix store.
+   answer, cold then warm, C1). Stop the collector. Note the printed `RUN=` dir.
+2. **Swap to NInfer** (one commit), then **smoke (correctness before speed):**
+   `tools/smoke-ninfer.sh all <image.jpg>` — text stream, thinking on/off,
+   tools (`tool_choice=auto` is the Perplexica-compatibility gate), vision
+   (judge the description content), 16K-context needle. Vision must name
+   details actually present in the image; HTTP 200 is not a pass.
+3. **Candidate A/B half, same window:** `collect-ninfer.sh start ab-candidate`,
+   then `AB_RUN=<dir-from-step-1> tools/ab-smallload.sh candidate`. Stop the
+   collector; run both reports. Then the **real workload**: Workload A
+   (Perplexica: point its custom-OpenAI provider at the NInfer endpoint in its
+   settings UI — config-only, revert after) and Workload B (Pi: add a
+   `vanillax-ninfer` provider to `~/.pi/agent/models.json`,
+   `pi --model qwen3.8-ninfer`) with the VERBATIM prompts above. Note that
+   in-cluster consumers (Open WebUI etc.) are down during a NInfer window —
+   that is inherent to single-card swap. Swap back to vLLM when done.
 4. **Long-context gate (only after 1–3 pass):** raise `--max-context`/
    `--kv-capacity` through git one step at a time — 65,536 → 131,072 → 153,600
    → 163,840 — and at each step run `tools/smoke-ninfer.sh context <N>` plus a

--- a/benchmarks/ai-realworld-load/tools/ab-smallload.sh
+++ b/benchmarks/ai-realworld-load/tools/ab-smallload.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # First controlled A/B: ~6K-token fixed prompt (workloads/ab-6k-prompt.txt,
 # 6,055 tokens by the live Qwen tokenizer), ~550-600 generated tokens, C1,
-# one GPU per engine, vision LOADED on both servers (request itself is text).
+# both engines on THE SAME single 3090 (sequential swap windows), vision
+# LOADED on both servers (the request itself is text).
 #
 # Per engine, two passes with the byte-identical prompt:
 #   cold  — unique run-id first line => prefix reuse CANNOT hit
@@ -21,10 +22,16 @@ CONTROL_MODEL="${CONTROL_MODEL:-qwen3.8-27b}"
 CANDIDATE_URL="${CANDIDATE_URL:-https://ninfer.vanillax.me/v1}"
 CANDIDATE_MODEL="${CANDIDATE_MODEL:-qwen3.8-ninfer}"
 
+# Single-card cluster: the engines are swapped, never co-resident, so run this
+# once per engine window: `ab-smallload.sh control` while vLLM holds the card,
+# `ab-smallload.sh candidate` while NInfer does. Pass an existing RUN dir as
+# AB_RUN=... for the second window so both engines land in one run dir.
+ENGINES="${1:-control candidate}"
+
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
-OUT="$ROOT/runs/${TS}_ab-smallload"
+OUT="${AB_RUN:-$ROOT/runs/${TS}_ab-smallload}"
 mkdir -p "$OUT"
-TAG="ab-$TS"
+TAG="ab-$(basename "$OUT")"
 
 run_pair() { # engine base_url model
   local engine="$1" url="$2" model="$3"
@@ -38,12 +45,18 @@ run_pair() { # engine base_url model
     > "$OUT/${engine}-warm.json" || true
 }
 
-run_pair control   "$CONTROL_URL"   "$CONTROL_MODEL"
-run_pair candidate "$CANDIDATE_URL" "$CANDIDATE_MODEL"
+for e in $ENGINES; do
+  case "$e" in
+    control)   run_pair control   "$CONTROL_URL"   "$CONTROL_MODEL" ;;
+    candidate) run_pair candidate "$CANDIDATE_URL" "$CANDIDATE_MODEL" ;;
+    *) echo "unknown engine: $e"; exit 1 ;;
+  esac
+done
 
 echo
 printf "%-18s %8s %8s %10s %10s %8s %8s\n" run prompt compl ttft_s decode_tps e2e_s status
 for f in control-cold control-warm candidate-cold candidate-warm; do
+  [ -f "$OUT/$f.json" ] || continue
   python3 - "$OUT/$f.json" "$f" <<'EOF'
 import json, sys
 d = json.load(open(sys.argv[1])); u = d.get("usage") or {}

--- a/docs/domains/ai-gpu/gpu-scale-swap.md
+++ b/docs/domains/ai-gpu/gpu-scale-swap.md
@@ -28,9 +28,14 @@ Two things make this safe by construction:
 |---|---|---|---|
 | **vLLM** (Qwen 3.8 W4A16, active) | **1** | `1` | `my-apps/ai/vllm/deployment.yaml` |
 | **llama-cpp** (Qwen 3.8 GGUF, parked) | 1 | `0` | `my-apps/ai/llama-cpp/deployment.yaml` |
+| **NInfer-3090** (Qwen 3.8 .ninfer, parked candidate under evaluation) | 1 | `0` | `my-apps/ai/ninfer/deployment.yaml` |
 | **ComfyUI** (image gen — see note below) | 1 | `0` | `my-apps/ai/comfyui/deployment.yaml` |
 | **SwarmUI** (image gen — see note below) | 1 | `0` | `my-apps/ai/swarmui/deployment.yaml` |
 | llmfit (batch benchmark **Jobs**, not always-on) | 1 or 2 | n/a | `my-apps/ai/llmfit/` |
+
+> **Single-card reality (2026-08-21, permanent):** the chassis now holds ONE
+> RTX 3090 — the second card is not coming back. Until the table below is
+> rewritten, read every "≤ 2 cards" rule as **exactly one `replicas: 1` row**.
 
 A valid target state is any set of `replicas: 1` rows whose **card total ≤ 2**.
 Working combos: vLLM (1 card) + one other single-card app · vLLM alone ·

--- a/my-apps/ai/ninfer/README.md
+++ b/my-apps/ai/ninfer/README.md
@@ -1,8 +1,12 @@
-# NInfer-3090 — experimental candidate backend
+# NInfer-3090 — experimental candidate backend (parked, scale-swap)
 
-Side-by-side evaluation of [Don-Chad/ninfer-3090](https://github.com/Don-Chad/ninfer-3090)
-against the production vLLM control, on the second (otherwise free) RTX 3090.
-The vLLM Deployment (`my-apps/ai/vllm/`) is the control and is not touched.
+Evaluation of [Don-Chad/ninfer-3090](https://github.com/Don-Chad/ninfer-3090)
+against the production vLLM control on **the single RTX 3090** (one card is a
+permanent decision). Both engines are measured **sequentially on the identical
+card** by scale-swapping per
+[`gpu-scale-swap.md`](../../../docs/domains/ai-gpu/gpu-scale-swap.md): for a
+test window set this Deployment to `replicas: 1` and `vllm-server` to `0` in
+one commit; reverse it to end the window. Committed default here is `0`.
 **Rollback = revert/delete this directory.** Nothing else references it.
 
 ## Pinned versions

--- a/my-apps/ai/ninfer/deployment.yaml
+++ b/my-apps/ai/ninfer/deployment.yaml
@@ -8,9 +8,10 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"   # after the wave-0 download hook completes
 spec:
-  # Experimental candidate backend (side-by-side vs the vLLM control). Consumes
-  # the second, currently free 3090; delete/revert this app to roll back.
-  replicas: 1
+  # Parked candidate backend. The chassis holds ONE 3090 (permanent decision) —
+  # NInfer is evaluated by scale-swapping with vLLM per gpu-scale-swap.md:
+  # set this to 1 AND vllm-server to 0 in the same commit for a test window.
+  replicas: 0
   strategy:
     type: Recreate            # whole-card GPU workload; never two pods on the cards at once
   revisionHistoryLimit: 1


### PR DESCRIPTION
Operator decision: the chassis stays at **one RTX 3090 permanently**, so the side-by-side premise is void.

- `ninfer-server` parks at `replicas: 0` and joins the scale-swap truth table (`gpu-scale-swap.md` gains its row plus a single-card reality note). A test window = one commit flipping `vllm: 1/ninfer: 0` → `0/1`; reverse to end it.
- The A/B becomes **sequential windows on the identical card** — same silicon, same 200 W cap, and each swap restarts the engine so every window starts with a provably cold prefix cache. Arguably cleaner than the two-card plan.
- `ab-smallload.sh` now runs per engine (`control` / `candidate`) with `AB_RUN=` to join both windows into one run dir; the benchmark README's order-of-operations is rewritten around swap windows (and notes that in-cluster consumers are down during a NInfer window — inherent to single-card swap).

Merging this also clears the currently Pending `ninfer-server` pod (it was waiting on a GPU that doesn't exist).

Related: #2022 (download-Job OOM fix) is still open and independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)