### PR TITLE
ai: add parked syv-ai Qwen3.8 single-3090 candidate

### DIFF
--- a/benchmarks/ai-realworld-load/README.md
+++ b/benchmarks/ai-realworld-load/README.md
@@ -296,8 +296,14 @@ BENCH_NS=qwen38-3090 BENCH_APP=qwen38-3090-server \
 BENCH_DEPLOY=qwen38-3090-server BENCH_PORT=18020 ./tools/collect.sh start qwen38-window
 ```
 
-Same swap-window procedure as below with `CANDIDATE_URL=https://qwen38.vanillax.me/v1
-CANDIDATE_MODEL=qwen3.8-27b` for `ab-smallload.sh candidate`. Two comparison
+The target identity is persisted in the run's `context.env`, so the ordinary
+`./tools/collect.sh stop` finalizes the same candidate without repeating the
+`BENCH_*` overrides. The capture also records the resolved image digest and
+the Deployment env because this candidate's real launcher knobs live in env.
+
+Same swap-window procedure as below with
+`CANDIDATE_URL=https://qwen38.vanillax.me/v1 CANDIDATE_MODEL=qwen3.8-27b`
+for `ab-smallload.sh candidate`. Two comparison
 caveats stated up front: this candidate is **text-only** (`--language-model-only`
 is hardcoded upstream — vision rows are N/A), and upstream's published numbers
 were measured at **250 W** against our 200 W cap.

--- a/benchmarks/ai-realworld-load/README.md
+++ b/benchmarks/ai-realworld-load/README.md
@@ -285,6 +285,23 @@ application bug stands.
 The card is power-limited to 200 W by the powerlimit DaemonSet; do not change
 that between the two windows of an A/B without recording it in `context.env`.
 
+### Candidate #2 — qwen38-3090 (syv-ai patched vLLM)
+
+`my-apps/ai/qwen38-3090/` (pinned commit `e00bc1b7`) is **vLLM 0.27.1 with
+upstream patches** — so unlike NInfer it speaks normal vLLM Prometheus, and the
+CONTROL tooling collects it directly:
+
+```bash
+BENCH_NS=qwen38-3090 BENCH_APP=qwen38-3090-server \
+BENCH_DEPLOY=qwen38-3090-server BENCH_PORT=18020 ./tools/collect.sh start qwen38-window
+```
+
+Same swap-window procedure as below with `CANDIDATE_URL=https://qwen38.vanillax.me/v1
+CANDIDATE_MODEL=qwen3.8-27b` for `ab-smallload.sh candidate`. Two comparison
+caveats stated up front: this candidate is **text-only** (`--language-model-only`
+is hardcoded upstream — vision rows are N/A), and upstream's published numbers
+were measured at **250 W** against our 200 W cap.
+
 ### Candidate tooling (parallel, not replacing)
 
 | | Control (vLLM) | Candidate (NInfer) |

--- a/benchmarks/ai-realworld-load/tools/collect.sh
+++ b/benchmarks/ai-realworld-load/tools/collect.sh
@@ -20,12 +20,19 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUNS="$ROOT/runs"
 STATE="$ROOT/.current-run"
-NS=vllm
+# Defaults target the production vLLM control. The qwen38-3090 candidate is
+# ALSO vLLM (syv-ai patched stack, same /metrics), so candidate runs reuse this
+# collector via: BENCH_NS=qwen38-3090 BENCH_APP=qwen38-3090-server \
+#   BENCH_DEPLOY=qwen38-3090-server BENCH_PORT=18020 collect.sh start <label>
+NS=${BENCH_NS:-vllm}
+APP=${BENCH_APP:-vllm-server}
+DEPLOY=${BENCH_DEPLOY:-vllm-server}
+PORT=${BENCH_PORT:-8000}
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
 vllm_pod() {
-  kubectl -n "$NS" get pod -l app=vllm-server \
+  kubectl -n "$NS" get pod -l app=$APP \
     -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
 }
 
@@ -35,7 +42,7 @@ cmd_start() {
 
   local pod; pod="$(vllm_pod)"
   [ -n "$pod" ] || die "no vllm-server pod found"
-  kubectl -n "$NS" exec "$pod" -- curl -sf -o /dev/null http://localhost:8000/health \
+  kubectl -n "$NS" exec "$pod" -- curl -sf -o /dev/null http://localhost:$PORT/health \
     || die "vLLM /health not OK — refusing to start a run against an unhealthy server"
 
   local ts run
@@ -54,13 +61,13 @@ cmd_start() {
     echo "git_head=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null)"
   } > "$run/context.env"
 
-  kubectl -n "$NS" get deploy vllm-server -o jsonpath='{.spec.template.spec.containers[0].args}' \
+  kubectl -n "$NS" get deploy "$DEPLOY" -o jsonpath='{.spec.template.spec.containers[0].args}' \
     > "$run/vllm-args.json" 2>/dev/null
-  kubectl -n "$NS" exec "$pod" -- curl -s http://localhost:8000/v1/models \
+  kubectl -n "$NS" exec "$pod" -- curl -s http://localhost:$PORT/v1/models \
     > "$run/models.json" 2>/dev/null
   # KV capacity ceiling is read from the live engine, never hardcoded — the
   # report divides by this to turn kv_cache_usage_perc into resident tokens.
-  kubectl -n "$NS" exec "$pod" -- curl -s http://localhost:8000/metrics 2>/dev/null \
+  kubectl -n "$NS" exec "$pod" -- curl -s http://localhost:$PORT/metrics 2>/dev/null \
     | grep 'cache_config_info' > "$run/cache-config.txt"
 
   # ---- Stream 1: vLLM metrics, 2s, filtered inside the pod ------------------
@@ -70,7 +77,7 @@ cmd_start() {
   nohup kubectl -n "$NS" exec "$pod" -- sh -c '
     while true; do
       echo "===TICK $(date -u +%Y-%m-%dT%H:%M:%SZ) $(date +%s)"
-      curl -s http://localhost:8000/metrics | grep -E "^vllm:" | grep -vE "_created|estimated_"
+      curl -s http://localhost:'$PORT'/metrics | grep -E "^vllm:" | grep -vE "_created|estimated_"
       sleep 2
     done' > "$run/metrics.stream" 2>"$run/metrics.err" &
   echo $! > "$run/.pid.metrics"
@@ -131,13 +138,13 @@ cmd_stop() {
     rm -f "$f"
   done
   sleep 1
-  pkill -f "kubectl -n $NS exec.*8000/metrics" 2>/dev/null
+  pkill -f "kubectl -n $NS exec.*$PORT/metrics" 2>/dev/null
   pkill -f "nvidia-smi --query-gpu=timestamp" 2>/dev/null
 
   local pod; pod="$(vllm_pod)"
   echo "run_ended_utc=$(date -u +%Y%m%dT%H%M%SZ)" >> "$run/context.env"
   # Final absolute counters — the run's totals are (final - first tick).
-  kubectl -n "$NS" exec "$pod" -- curl -s http://localhost:8000/metrics 2>/dev/null \
+  kubectl -n "$NS" exec "$pod" -- curl -s http://localhost:$PORT/metrics 2>/dev/null \
     | grep -E '^vllm:' > "$run/metrics.final"
   kubectl -n "$NS" get events --sort-by=.lastTimestamp > "$run/events.txt" 2>/dev/null
 

--- a/benchmarks/ai-realworld-load/tools/collect.sh
+++ b/benchmarks/ai-realworld-load/tools/collect.sh
@@ -32,7 +32,7 @@ PORT=${BENCH_PORT:-8000}
 die() { echo "ERROR: $*" >&2; exit 1; }
 
 vllm_pod() {
-  kubectl -n "$NS" get pod -l app=$APP \
+  kubectl -n "$NS" get pod -l "app=$APP" \
     -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
 }
 
@@ -41,8 +41,8 @@ cmd_start() {
   [ -f "$STATE" ] && die "a run is already active ($(cat "$STATE")). Run: collect.sh stop"
 
   local pod; pod="$(vllm_pod)"
-  [ -n "$pod" ] || die "no vllm-server pod found"
-  kubectl -n "$NS" exec "$pod" -- curl -sf -o /dev/null http://localhost:$PORT/health \
+  [ -n "$pod" ] || die "no $APP pod found in $NS"
+  kubectl -n "$NS" exec "$pod" -- curl -sf -o /dev/null "http://localhost:$PORT/health" \
     || die "vLLM /health not OK — refusing to start a run against an unhealthy server"
 
   local ts run
@@ -55,29 +55,37 @@ cmd_start() {
   {
     echo "run_started_utc=$ts"
     echo "label=$label"
+    echo "bench_ns=$NS"
+    echo "bench_app=$APP"
+    echo "bench_deploy=$DEPLOY"
+    echo "bench_port=$PORT"
     echo "pod=$pod"
-    echo "image=$(kubectl -n $NS get pod "$pod" -o jsonpath='{.spec.containers[0].image}')"
-    echo "node=$(kubectl -n $NS get pod "$pod" -o jsonpath='{.spec.nodeName}')"
+    echo "image=$(kubectl -n "$NS" get pod "$pod" -o jsonpath='{.spec.containers[0].image}')"
+    echo "image_id=$(kubectl -n "$NS" get pod "$pod" -o jsonpath='{.status.containerStatuses[0].imageID}')"
+    echo "node=$(kubectl -n "$NS" get pod "$pod" -o jsonpath='{.spec.nodeName}')"
     echo "git_head=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null)"
   } > "$run/context.env"
 
   kubectl -n "$NS" get deploy "$DEPLOY" -o jsonpath='{.spec.template.spec.containers[0].args}' \
     > "$run/vllm-args.json" 2>/dev/null
-  kubectl -n "$NS" exec "$pod" -- curl -s http://localhost:$PORT/v1/models \
+  kubectl -n "$NS" get deploy "$DEPLOY" -o jsonpath='{.spec.template.spec.containers[0].env}' \
+    > "$run/vllm-env.json" 2>/dev/null
+  kubectl -n "$NS" exec "$pod" -- curl -s "http://localhost:$PORT/v1/models" \
     > "$run/models.json" 2>/dev/null
   # KV capacity ceiling is read from the live engine, never hardcoded — the
   # report divides by this to turn kv_cache_usage_perc into resident tokens.
-  kubectl -n "$NS" exec "$pod" -- curl -s http://localhost:$PORT/metrics 2>/dev/null \
+  kubectl -n "$NS" exec "$pod" -- curl -s "http://localhost:$PORT/metrics" 2>/dev/null \
     | grep 'cache_config_info' > "$run/cache-config.txt"
 
   # ---- Stream 1: vLLM metrics, 2s, filtered inside the pod ------------------
   # Full /metrics is ~40KB; grepping pod-side keeps this to a few hundred bytes
   # per tick. Histogram *buckets* are kept in full: when a request finishes,
   # exactly one bucket increments, which is how per-request sizes get attributed.
+  # shellcheck disable=SC2016
   nohup kubectl -n "$NS" exec "$pod" -- sh -c '
     while true; do
       echo "===TICK $(date -u +%Y-%m-%dT%H:%M:%SZ) $(date +%s)"
-      curl -s http://localhost:'$PORT'/metrics | grep -E "^vllm:" | grep -vE "_created|estimated_"
+      curl -s "http://localhost:'"$PORT"'/metrics" | grep -E "^vllm:" | grep -vE "_created|estimated_"
       sleep 2
     done' > "$run/metrics.stream" 2>"$run/metrics.err" &
   echo $! > "$run/.pid.metrics"
@@ -114,6 +122,7 @@ cmd_start() {
   echo $! > "$run/.pid.logs"
 
   # ---- Stream 4: pod resource + restart state, 10s ------------------------
+  # shellcheck disable=SC2016
   nohup bash -c '
     while true; do
       printf "%s," "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -131,6 +140,12 @@ cmd_start() {
 cmd_stop() {
   [ -f "$STATE" ] || die "no active run"
   local run; run="$(cat "$STATE")"
+  NS="$(sed -n 's/^bench_ns=//p' "$run/context.env")"
+  APP="$(sed -n 's/^bench_app=//p' "$run/context.env")"
+  DEPLOY="$(sed -n 's/^bench_deploy=//p' "$run/context.env")"
+  PORT="$(sed -n 's/^bench_port=//p' "$run/context.env")"
+  [ -n "$NS" ] && [ -n "$APP" ] && [ -n "$DEPLOY" ] && [ -n "$PORT" ] \
+    || die "active run is missing its target identity: $run/context.env"
 
   for f in "$run"/.pid.*; do
     [ -e "$f" ] || continue
@@ -144,7 +159,7 @@ cmd_stop() {
   local pod; pod="$(vllm_pod)"
   echo "run_ended_utc=$(date -u +%Y%m%dT%H%M%SZ)" >> "$run/context.env"
   # Final absolute counters — the run's totals are (final - first tick).
-  kubectl -n "$NS" exec "$pod" -- curl -s http://localhost:$PORT/metrics 2>/dev/null \
+  kubectl -n "$NS" exec "$pod" -- curl -s "http://localhost:$PORT/metrics" 2>/dev/null \
     | grep -E '^vllm:' > "$run/metrics.final"
   kubectl -n "$NS" get events --sort-by=.lastTimestamp > "$run/events.txt" 2>/dev/null
 

--- a/docs/domains/ai-gpu/gpu-scale-swap.md
+++ b/docs/domains/ai-gpu/gpu-scale-swap.md
@@ -28,7 +28,8 @@ Two things make this safe by construction:
 |---|---|---|---|
 | **vLLM** (Qwen 3.8 W4A16, active) | **1** | `1` | `my-apps/ai/vllm/deployment.yaml` |
 | **llama-cpp** (Qwen 3.8 GGUF, parked) | 1 | `0` | `my-apps/ai/llama-cpp/deployment.yaml` |
-| **NInfer-3090** (Qwen 3.8 .ninfer, parked candidate under evaluation) | 1 | `0` | `my-apps/ai/ninfer/deployment.yaml` |
+| **NInfer-3090** (Qwen 3.8 .ninfer, parked candidate) | 1 | `0` | `my-apps/ai/ninfer/deployment.yaml` |
+| **qwen38-3090** (syv-ai patched-vLLM stack, parked candidate under evaluation) | 1 | `0` | `my-apps/ai/qwen38-3090/deployment.yaml` |
 | **ComfyUI** (image gen — see note below) | 1 | `0` | `my-apps/ai/comfyui/deployment.yaml` |
 | **SwarmUI** (image gen — see note below) | 1 | `0` | `my-apps/ai/swarmui/deployment.yaml` |
 | llmfit (batch benchmark **Jobs**, not always-on) | 1 or 2 | n/a | `my-apps/ai/llmfit/` |

--- a/my-apps/ai/qwen38-3090/README.md
+++ b/my-apps/ai/qwen38-3090/README.md
@@ -1,0 +1,54 @@
+# qwen38-3090 — candidate backend (parked, scale-swap)
+
+Candidate serving stack from
+[syv-ai/qwen38-27b-rtx3090](https://github.com/syv-ai/qwen38-27b-rtx3090):
+**vLLM 0.27.1 — the same engine version as production** — plus its `patches/`
+applied into site-packages, the KVarN KV cache, requantized model artifacts,
+and tuned single-user/batch launch profiles for one RTX 3090. Evaluated
+**sequentially on the single card** by scale-swapping with `vllm-server`
+(`gpu-scale-swap.md`); committed default here is `replicas: 0`.
+**Rollback = revert/delete this directory.**
+
+## Pinned versions
+
+| What | Value |
+|---|---|
+| Upstream commit | `e00bc1b7301faed3737783379cace5fa37416e8a` (no release tags; repo moves daily — bumps are deliberate, via `build.sh` + the image tag together) |
+| Image | `ghcr.io/mitchross/qwen38-27b-3090:e00bc1b7` (built by `build.sh` from the repo's Dockerfile: CUDA 13.0.1-base, vLLM 0.27.1/torch 2.13 cu130, patches applied at build) |
+| Base model | `dbirks/Qwen3.8-27B-W4A16-AutoRound` (~19.5 GB) — same checkpoint lineage as production; the CPU-only `prepare` step requantizes lm_head/embed/MTP to int8, builds the 40k draft vocab, and fetches the int4 `-fast` variant + the W4A16 DFlash2 drafter (~1 GB each) |
+
+## Verified facts (read from the pinned commit, not the README hype)
+
+- `prepare` is **CPU-only and idempotent** — it runs as an initContainer here;
+  no GPU window needed to stage the model.
+- The serve command hardcodes **`--language-model-only`: this candidate is
+  text-only.** Vision comparisons vs the control are N/A — state that in every
+  result.
+- `--served-model-name` is hardcoded **`qwen3.8-27b`** — same id as production.
+  The endpoint is the identity: `https://qwen38.vanillax.me/v1` (LAN) /
+  `http://qwen38-3090-service.qwen38-3090.svc.cluster.local:8080/v1`.
+- It exposes normal vLLM Prometheus `/metrics` on the serve port, so the
+  benchmark harness's **control tooling works on it** (`collect.sh` with
+  `BENCH_NS/BENCH_APP/BENCH_PORT` overrides).
+- Upstream documents the trap for exactly our topology: **under VM GPU
+  passthrough, uncaptured (PIECEWISE) verify steps cost 2–3×** (launch-bound).
+  The initial profile below stays on captured paths. Also their gotcha 37:
+  `CUDAGRAPH_MODE=FULL_AND_PIECEWISE` corrupts one prompt length in 128 —
+  never set it.
+- Upstream numbers were measured at **250 W**; our card is capped at **200 W**
+  (house circuit — do not raise it). Expect proportionally lower numbers and
+  record the cap with every run.
+
+## Initial runtime profile (correctness-first, control parity)
+
+`single` mode, upstream defaults: **SPEC=mtp** (Qwen's own MTP head,
+probabilistic drafts — speculation is exact), **CTX=fast** (bf16 KV,
+`max-model-len` 64k ≈ the control's 65,536), **PREFIX_CACHE=1** (control also
+runs prefix caching), GPU_UTIL 0.93, 8 slots, port 18020. `verify.sh` gates
+startup. The `-fast` model variant (int4 lm_head/MTP + own-output draft vocab)
+is auto-selected once `prepare` has staged it.
+
+Later ladder steps (one git change at a time, measured before the next):
+`CTX=long` (fp8 KV, 150k — the Pi working-set test), `SPEC=dflash2`
+(+`DFLASH_TOKENS=15`), `CTX=huge` (KVarN, 200k+). The upstream claims for these
+are their Windows/bare-metal-Linux numbers, not ours, until measured here.

--- a/my-apps/ai/qwen38-3090/README.md
+++ b/my-apps/ai/qwen38-3090/README.md
@@ -14,13 +14,13 @@ and tuned single-user/batch launch profiles for one RTX 3090. Evaluated
 | What | Value |
 |---|---|
 | Upstream commit | `e00bc1b7301faed3737783379cace5fa37416e8a` (no release tags; repo moves daily — bumps are deliberate, via `build.sh` + the image tag together) |
-| Image | `ghcr.io/mitchross/qwen38-27b-3090:e00bc1b7` (built by `build.sh` from the repo's Dockerfile: CUDA 13.0.1-base, vLLM 0.27.1/torch 2.13 cu130, patches applied at build) |
+| Image | `ghcr.io/mitchross/qwen38-27b-3090:e00bc1b7@sha256:b27437a66e1870a8b9caec7cc148eaad52a127f815a6222d3d032e0c71da35a8` (built and published by `build.sh` from the pinned source) |
 | Base model | `dbirks/Qwen3.8-27B-W4A16-AutoRound` (~19.5 GB) — same checkpoint lineage as production; the CPU-only `prepare` step requantizes lm_head/embed/MTP to int8, builds the 40k draft vocab, and fetches the int4 `-fast` variant + the W4A16 DFlash2 drafter (~1 GB each) |
 
 ## Verified facts (read from the pinned commit, not the README hype)
 
-- `prepare` is **CPU-only and idempotent** — it runs as an initContainer here;
-  no GPU window needed to stage the model.
+- `prepare` is **CPU-only and idempotent**. A wave-0 Sync hook Job stages the
+  model before the wave-1 Deployment, without reserving the only GPU.
 - The serve command hardcodes **`--language-model-only`: this candidate is
   text-only.** Vision comparisons vs the control are N/A — state that in every
   result.
@@ -30,6 +30,8 @@ and tuned single-user/batch launch profiles for one RTX 3090. Evaluated
 - It exposes normal vLLM Prometheus `/metrics` on the serve port, so the
   benchmark harness's **control tooling works on it** (`collect.sh` with
   `BENCH_NS/BENCH_APP/BENCH_PORT` overrides).
+- `EXTRA_ARGS` restores the production API contract: `qwen3_coder` automatic
+  tools, thinking off by default, Qwen's non-thinking sampling, and stream usage.
 - Upstream documents the trap for exactly our topology: **under VM GPU
   passthrough, uncaptured (PIECEWISE) verify steps cost 2–3×** (launch-bound).
   The initial profile below stays on captured paths. Also their gotcha 37:
@@ -47,6 +49,11 @@ probabilistic drafts — speculation is exact), **CTX=fast** (bf16 KV,
 runs prefix caching), GPU_UTIL 0.93, 8 slots, port 18020. `verify.sh` gates
 startup. The `-fast` model variant (int4 lm_head/MTP + own-output draft vocab)
 is auto-selected once `prepare` has staged it.
+
+The prep Job mounts the established RWX llama.cpp model share at `/app/models`;
+upstream's uniquely named directories live at that share root. The serving
+container mounts the same PVC read-only. Do not move preparation back into an
+init container: a scaled-up pod reserves the GPU while init containers run.
 
 Later ladder steps (one git change at a time, measured before the next):
 `CTX=long` (fp8 KV, 150k — the Pi working-set test), `SPEC=dflash2`

--- a/my-apps/ai/qwen38-3090/build.sh
+++ b/my-apps/ai/qwen38-3090/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Reproducible qwen38-27b-3090 image build. NOT deployed by kustomize — run from
+# a workstation with docker + push access to ghcr (registry.vanillax.me cannot
+# take the multi-GB layers — RustFS s3aws append limitation).
+#
+# The repo has no release tags and moves fast: this pins a raw commit. Bumping
+# it is a deliberate act — update COMMIT here AND the image tag in
+# deployment.yaml together.
+set -euo pipefail
+
+COMMIT="e00bc1b7301faed3737783379cace5fa37416e8a"
+IMAGE="${IMAGE:-ghcr.io/mitchross/qwen38-27b-3090:${COMMIT:0:8}}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+git clone https://github.com/syv-ai/qwen38-27b-rtx3090 "$WORK/src"
+git -C "$WORK/src" checkout "$COMMIT"
+
+docker build -t "$IMAGE" "$WORK/src"
+docker push "$IMAGE"
+docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE"
+echo "Pin the printed digest into deployment.yaml (image: ...@sha256:...)."

--- a/my-apps/ai/qwen38-3090/build.sh
+++ b/my-apps/ai/qwen38-3090/build.sh
@@ -4,8 +4,7 @@
 # take the multi-GB layers — RustFS s3aws append limitation).
 #
 # The repo has no release tags and moves fast: this pins a raw commit. Bumping
-# it is a deliberate act — update COMMIT here AND the image tag in
-# deployment.yaml together.
+# it is a deliberate act — update COMMIT here and both manifest image pins.
 set -euo pipefail
 
 COMMIT="e00bc1b7301faed3737783379cace5fa37416e8a"
@@ -20,4 +19,4 @@ git -C "$WORK/src" checkout "$COMMIT"
 docker build -t "$IMAGE" "$WORK/src"
 docker push "$IMAGE"
 docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE"
-echo "Pin the printed digest into deployment.yaml (image: ...@sha256:...)."
+echo "Pin the printed digest into deployment.yaml and model-prep-job.yaml."

--- a/my-apps/ai/qwen38-3090/deployment.yaml
+++ b/my-apps/ai/qwen38-3090/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: qwen38-3090
   labels:
     app: qwen38-3090-server
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   # Parked candidate (syv-ai patched-vLLM stack). Single-card chassis: evaluate
   # by scale-swapping with vllm-server per gpu-scale-swap.md — set this to 1 AND
@@ -34,33 +36,9 @@ spec:
         - key: "nvidia.com/gpu"
           operator: "Exists"
           effect: "NoSchedule"
-      initContainers:
-        # CPU-only download (~19.5 GB, resumable) + requantization into
-        # /app/models; idempotent — fast no-op once the artifacts exist.
-        - name: prepare
-          image: ghcr.io/mitchross/qwen38-27b-3090:e00bc1b7
-          imagePullPolicy: IfNotPresent
-          args: ["prepare"]
-          env:
-            - name: HOME
-              value: /cache
-          resources:
-            requests:
-              cpu: "2"
-              memory: 2Gi
-            limits:
-              # NFS write page cache is charged to the cgroup (learned the hard
-              # way on the ninfer download Job) — keep real headroom.
-              memory: 16Gi
-          volumeMounts:
-            - name: models
-              mountPath: /app/models
-              subPath: qwen38-3090/models
-            - name: cache
-              mountPath: /cache
       containers:
         - name: qwen38-3090-server
-          image: ghcr.io/mitchross/qwen38-27b-3090:e00bc1b7
+          image: ghcr.io/mitchross/qwen38-27b-3090:e00bc1b7@sha256:b27437a66e1870a8b9caec7cc148eaad52a127f815a6222d3d032e0c71da35a8
           imagePullPolicy: IfNotPresent
           # entrypoint mode: single-user (MTP speculative decoding). verify.sh
           # gates startup unless VERIFY=0.
@@ -82,6 +60,13 @@ spec:
               value: "fast"
             - name: PREFIX_CACHE
               value: "1"
+            - name: EXTRA_ARGS
+              value: >-
+                --enable-auto-tool-choice
+                --tool-call-parser qwen3_coder
+                --default-chat-template-kwargs {"enable_thinking":false}
+                --override-generation-config {"temperature":0.7,"top_p":0.8,"top_k":20,"presence_penalty":1.5}
+                --enable-force-include-usage
             - name: PORT
               value: "18020"
           ports:
@@ -123,7 +108,7 @@ spec:
           volumeMounts:
             - name: models
               mountPath: /app/models
-              subPath: qwen38-3090/models
+              readOnly: true
             - name: cache
               mountPath: /cache
             - name: dshm

--- a/my-apps/ai/qwen38-3090/deployment.yaml
+++ b/my-apps/ai/qwen38-3090/deployment.yaml
@@ -1,0 +1,141 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qwen38-3090-server
+  namespace: qwen38-3090
+  labels:
+    app: qwen38-3090-server
+spec:
+  # Parked candidate (syv-ai patched-vLLM stack). Single-card chassis: evaluate
+  # by scale-swapping with vllm-server per gpu-scale-swap.md — set this to 1 AND
+  # vllm-server to 0 in the same commit for a test window.
+  replicas: 0
+  strategy:
+    type: Recreate            # whole-card GPU workload; never two pods on the cards at once
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: qwen38-3090-server
+  template:
+    metadata:
+      labels:
+        app: qwen38-3090-server
+    spec:
+      # It IS vLLM underneath — service-link env vars trip its VLLM_* env scan.
+      enableServiceLinks: false
+      restartPolicy: Always
+      runtimeClassName: nvidia
+      priorityClassName: gpu-workload-preemptible
+      terminationGracePeriodSeconds: 120
+      nodeSelector:
+        feature.node.kubernetes.io/pci-0300_10de.present: "true"
+        gpu-worker: "true"
+      tolerations:
+        - key: "nvidia.com/gpu"
+          operator: "Exists"
+          effect: "NoSchedule"
+      initContainers:
+        # CPU-only download (~19.5 GB, resumable) + requantization into
+        # /app/models; idempotent — fast no-op once the artifacts exist.
+        - name: prepare
+          image: ghcr.io/mitchross/qwen38-27b-3090:e00bc1b7
+          imagePullPolicy: IfNotPresent
+          args: ["prepare"]
+          env:
+            - name: HOME
+              value: /cache
+          resources:
+            requests:
+              cpu: "2"
+              memory: 2Gi
+            limits:
+              # NFS write page cache is charged to the cgroup (learned the hard
+              # way on the ninfer download Job) — keep real headroom.
+              memory: 16Gi
+          volumeMounts:
+            - name: models
+              mountPath: /app/models
+              subPath: qwen38-3090/models
+            - name: cache
+              mountPath: /cache
+      containers:
+        - name: qwen38-3090-server
+          image: ghcr.io/mitchross/qwen38-27b-3090:e00bc1b7
+          imagePullPolicy: IfNotPresent
+          # entrypoint mode: single-user (MTP speculative decoding). verify.sh
+          # gates startup unless VERIFY=0.
+          args: ["single"]
+          env:
+            # GPU selection is handled by the device plugin + CDI (whole-card).
+            # Do NOT set NVIDIA_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES.
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: "compute,utility"
+            - name: HOME
+              value: /cache               # torch.compile + JIT caches persist here
+            # Initial profile = upstream single-user defaults at control parity:
+            # SPEC=mtp, CTX=fast (bf16 KV, 64k ≈ the control's 65,536),
+            # PREFIX_CACHE=1 (control also runs prefix caching). CTX=long (150k)
+            # and SPEC=dflash2 are later ladder steps — see README.md.
+            - name: SPEC
+              value: "mtp"
+            - name: CTX
+              value: "fast"
+            - name: PREFIX_CACHE
+              value: "1"
+            - name: PORT
+              value: "18020"
+          ports:
+            - name: http
+              containerPort: 18020
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 120        # first boot JIT-compiles (upstream start_period is 900s)
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              nvidia.com/gpu: "1"
+              cpu: "2"
+              memory: 8Gi
+            limits:
+              nvidia.com/gpu: "1"
+              memory: 48Gi
+          volumeMounts:
+            - name: models
+              mountPath: /app/models
+              subPath: qwen38-3090/models
+            - name: cache
+              mountPath: /cache
+            - name: dshm
+              mountPath: /dev/shm        # compose runs ipc:host; a big shm is the pod equivalent
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: qwen38-3090-models-pvc
+        - name: cache
+          persistentVolumeClaim:
+            claimName: qwen38-3090-compile-cache
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi

--- a/my-apps/ai/qwen38-3090/httproute.yaml
+++ b/my-apps/ai/qwen38-3090/httproute.yaml
@@ -1,0 +1,29 @@
+# INTERNAL route (local network only, via gateway-internal-technitium) — mirrors vllm.
+# The technitium external-dns instance creates the LAN record automatically.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: qwen38-3090-route
+  namespace: qwen38-3090
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway-internal-technitium
+    namespace: gateway
+  hostnames:
+  - "qwen38.vanillax.me"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      request: 30m            # long generations
+      backendRequest: 30m
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: qwen38-3090-service
+      port: 8080
+      weight: 1

--- a/my-apps/ai/qwen38-3090/kustomization.yaml
+++ b/my-apps/ai/qwen38-3090/kustomization.yaml
@@ -5,7 +5,9 @@ namespace: qwen38-3090
 resources:
 - namespace.yaml
 - pvc.yaml
+- model-prep-job.yaml
 - deployment.yaml
 - service.yaml
 - httproute.yaml
+- servicemonitor.yaml
 - vpa.yaml

--- a/my-apps/ai/qwen38-3090/kustomization.yaml
+++ b/my-apps/ai/qwen38-3090/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: qwen38-3090
+
+resources:
+- namespace.yaml
+- pvc.yaml
+- deployment.yaml
+- service.yaml
+- httproute.yaml
+- vpa.yaml

--- a/my-apps/ai/qwen38-3090/model-prep-job.yaml
+++ b/my-apps/ai/qwen38-3090/model-prep-job.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: qwen38-3090-model-prep
+  namespace: qwen38-3090
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 3
+  activeDeadlineSeconds: 21600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: prepare
+          image: ghcr.io/mitchross/qwen38-27b-3090:e00bc1b7@sha256:b27437a66e1870a8b9caec7cc148eaad52a127f815a6222d3d032e0c71da35a8
+          imagePullPolicy: IfNotPresent
+          args: ["prepare"]
+          env:
+            - name: HOME
+              value: /cache
+          resources:
+            requests:
+              cpu: "2"
+              memory: 4Gi
+              ephemeral-storage: 4Gi
+            limits:
+              cpu: "8"
+              memory: 32Gi
+              ephemeral-storage: 12Gi
+          volumeMounts:
+            - name: models
+              mountPath: /app/models
+            - name: cache
+              mountPath: /cache
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: qwen38-3090-models-pvc
+        - name: cache
+          emptyDir:
+            sizeLimit: 12Gi

--- a/my-apps/ai/qwen38-3090/namespace.yaml
+++ b/my-apps/ai/qwen38-3090/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: qwen38-3090

--- a/my-apps/ai/qwen38-3090/pvc.yaml
+++ b/my-apps/ai/qwen38-3090/pvc.yaml
@@ -1,6 +1,5 @@
 # Static PV — same TrueNAS ai-pool/llama-cpp RWX model share the other AI apps
-# use, own volumeHandle. The prepare initContainer downloads + requantizes
-# ~22 GB into qwen38-3090/models on this share (CPU-only, idempotent).
+# use, own volumeHandle. The prep Job writes uniquely named model directories.
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/my-apps/ai/qwen38-3090/pvc.yaml
+++ b/my-apps/ai/qwen38-3090/pvc.yaml
@@ -1,0 +1,66 @@
+# Static PV — same TrueNAS ai-pool/llama-cpp RWX model share the other AI apps
+# use, own volumeHandle. The prepare initContainer downloads + requantizes
+# ~22 GB into qwen38-3090/models on this share (CPU-only, idempotent).
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: qwen38-3090-nfs-pv
+spec:
+  capacity:
+    storage: 150Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - nolock
+    - tcp
+    - noatime
+    - rsize=1048576
+    - wsize=1048576
+    - nconnect=16
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: qwen38-3090-nfs-pv
+    volumeAttributes:
+      server: "192.168.10.133"
+      share: "/mnt/ai-pool/llama-cpp"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qwen38-3090-models-pvc
+  namespace: qwen38-3090
+  labels:
+    backup-exempt: "true"
+  annotations:
+    # MUST be the fully-qualified key — bare `backup-exempt-reason` is silently ignored.
+    storage.vanillax.dev/backup-exempt-reason: "NFS-backed model + requant artifacts; non-snapshottable, rebuilt by the idempotent prepare step (hf download + requant scripts)"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 150Gi
+  storageClassName: ""
+  volumeName: qwen38-3090-nfs-pv
+---
+# torch.compile + FlashInfer/Triton JIT caches — without this every boot repeats
+# the ~15 min first-start compile (compose start_period is 900s for this reason).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qwen38-3090-compile-cache
+  namespace: qwen38-3090
+  labels:
+    backup-exempt: "true"
+  annotations:
+    storage.vanillax.dev/backup-exempt-reason: "Regenerable torch.compile/JIT kernel cache; rebuilt automatically on first boot after loss"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: longhorn

--- a/my-apps/ai/qwen38-3090/service.yaml
+++ b/my-apps/ai/qwen38-3090/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: qwen38-3090-service
+  namespace: qwen38-3090
+  labels:
+    app: qwen38-3090-server
+spec:
+  selector:
+    app: qwen38-3090-server
+  ports:
+    - name: http              # CRITICAL — HTTPRoute matches by port name; fails silently without it
+      protocol: TCP
+      port: 8080              # cluster-facing port (matches the vllm/llama-cpp convention)
+      targetPort: http        # → container port 18020
+  type: ClusterIP

--- a/my-apps/ai/qwen38-3090/servicemonitor.yaml
+++ b/my-apps/ai/qwen38-3090/servicemonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: qwen38-3090
+  namespace: qwen38-3090
+  labels:
+    app: qwen38-3090-server
+spec:
+  selector:
+    matchLabels:
+      app: qwen38-3090-server
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s

--- a/my-apps/ai/qwen38-3090/vpa.yaml
+++ b/my-apps/ai/qwen38-3090/vpa.yaml
@@ -1,0 +1,20 @@
+# VPA policy is owned with this application so Argo prunes it with the target.
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: qwen38-3090-server
+  namespace: qwen38-3090
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: qwen38-3090-server
+  updatePolicy:
+    # Whole-card scale-swap workload under active benchmarking: learn
+    # recommendations without mutating the pod mid-measurement.
+    updateMode: "Off"
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly


### PR DESCRIPTION
## Summary

- add the parked `qwen38-3090` ArgoCD application based on `syv-ai/qwen38-27b-rtx3090` at commit `e00bc1b7301faed3737783379cace5fa37416e8a`
- publish and digest-pin the patched vLLM 0.27.1 image at `ghcr.io/mitchross/qwen38-27b-3090:e00bc1b7@sha256:b27437a66e1870a8b9caec7cc148eaad52a127f815a6222d3d032e0c71da35a8`
- stage/requantize model artifacts with a CPU-only wave-0 Sync hook Job, then serve read-only from the existing RWX model share
- preserve the production API contract for tools, non-thinking defaults, sampling, and streamed usage metrics
- add ServiceMonitor coverage and make the real-world collector target/persist candidate backend identity

## Rollout safety

- candidate remains parked at `replicas: 0`
- active production vLLM remains unchanged
- the model-prep Job requests no GPU, so syncing this PR does not steal the sole RTX 3090
- candidate is text-only because upstream hardcodes `--language-model-only`
- keep the cluster GPU cap at 200 W; upstream performance claims were measured at 250 W

## Validation

- `kustomize build my-apps/ai/qwen38-3090`
- strict kubeconform: candidate 10/10 valid
- aggregate kubeconform: 1,649 resources; 1,417 valid; 0 invalid; 0 errors; 232 skipped CRDs
- ArgoCD application validation
- aggregate VPA policy validation
- aggregate kopiur backup validation
- `bash -n` and ShellCheck for changed shell scripts
- immutable image manifest inspection
- `git diff --check`

## Follow-up

After the model-prep hook succeeds, use the documented scale-swap window and candidate #2 benchmark target before any promotion.