### PR TITLE
llama-cpp: run model download on wired workers

### DIFF
--- a/my-apps/ai/llama-cpp/download-model-job.yaml
+++ b/my-apps/ai/llama-cpp/download-model-job.yaml
@@ -14,6 +14,16 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - talos-threadripper-gpu-workers-hp-workers-gkfrw8
+                      - talos-threadripper-gpu-workers-workers-97cs4s
       containers:
         - name: download
           image: alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce


### PR DESCRIPTION
## Summary

- constrain the Qwen3.8 model download/checksum hook to the two wired Talos workers
- preserve the GPU-serving selector so inference still lands on the only node advertising the RTX 3090
- rely on the shared NFS `.part` file so the restarted hook resumes instead of downloading from zero

## Validation

- `git diff --check`
- `kubectl kustomize my-apps/ai/llama-cpp`
- `kubectl apply --dry-run=client -f <rendered llama-cpp manifests>`