### PR TITLE
home-assistant: follow the Zigbee dongle via NFD label

### DIFF
--- a/infrastructure/controllers/node-feature-discovery/kustomization.yaml
+++ b/infrastructure/controllers/node-feature-discovery/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ns.yaml
   - coral-tpu-rule.yaml
+  - zigbee-dongle-rule.yaml
   # The Intel-specific rules are not needed for NVIDIA GPU discovery
   # and have been removed. NFD's default PCI source handles NVIDIA.
 # https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/deployment/helm.html

--- a/infrastructure/controllers/node-feature-discovery/zigbee-dongle-rule.yaml
+++ b/infrastructure/controllers/node-feature-discovery/zigbee-dongle-rule.yaml
@@ -1,0 +1,23 @@
+# SONOFF Zigbee coordinator (CP2102N bridge, USB 10c4:ea60). Labels whichever
+# node the dongle is USB-passed to; home-assistant schedules on this label.
+# Creates label: feature.node.kubernetes.io/custom-usb.zigbee-coordinator=true
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: zigbee-dongle-rule
+spec:
+  rules:
+  - name: "sonoff-zigbee-usb"
+    labels:
+      "custom-usb.zigbee-coordinator": "true"
+    matchFeatures:
+    - feature: usb.device
+      matchExpressions:
+        vendor:
+          op: In
+          value:
+          - "10c4"
+        device:
+          op: In
+          value:
+          - "ea60"

--- a/my-apps/home/home-assistant/deployment.yaml
+++ b/my-apps/home/home-assistant/deployment.yaml
@@ -29,11 +29,10 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       # Add restart policy for better reliability
       restartPolicy: Always
-      # Pin to the general worker (VM 101), where the SONOFF Zigbee dongle is
-      # USB-passed and cp210x exposes /dev/ttyUSB0. The hostPath device mount
-      # below only resolves on this node.
+      # Follow the Zigbee dongle: NFD labels whichever node it is USB-passed to
+      # (zigbee-dongle-rule). A hardcoded node class breaks when the dongle moves VMs.
       nodeSelector:
-        node.vanillax.dev/class: general-worker
+        feature.node.kubernetes.io/custom-usb.zigbee-coordinator: "true"
       initContainers:
         - name: copy-config
           image: alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
@@ -140,10 +139,8 @@ spec:
         - name: config-files
           configMap:
             name: config
-        # SONOFF Zigbee dongle char device on the general-worker node. cp210x must
-        # be loaded (Talos single-node-gpu.yaml) for this to exist. If the path
-        # ever shifts (e.g. a second serial device), switch to the stable
-        # /dev/serial/by-id/usb-… symlink target.
+        # SONOFF Zigbee dongle char device (cp210x). If a second serial device ever
+        # appears, switch to the stable /dev/serial/by-id/usb-… symlink target.
         - name: zigbee-dongle
           hostPath:
             path: /dev/ttyUSB0


### PR DESCRIPTION
## Problem
The SONOFF Zigbee dongle (USB `10c4:ea60`) is passed through to VM 100 (`hp-workers`), but `home-assistant` was pinned to `node.vanillax.dev/class: general-worker` (VM 101). The pod landed on a node with no `/dev/ttyUSB0` and stuck `Pending`:

`MountVolume.SetUp failed for volume "zigbee-dongle": hostPath type check failed: /dev/ttyUSB0 is not a character device`

## Fix
- New `NodeFeatureRule` `zigbee-dongle-rule` (same pattern as `coral-tpu-rule`) matching `usb.device vendor=10c4 device=ea60` → `feature.node.kubernetes.io/custom-usb.zigbee-coordinator=true`.
- `home-assistant` nodeSelector now uses that label, so it follows the dongle to whichever VM it's `qm set` onto after a rebuild.

## Verified
- `hp-workers`: `/dev/ttyUSB0` present, `cp210x` loaded (udev autoload — no Talos machine-config change needed); NFD usb feature shows exactly `vendor=10c4 device=ea60`, no other node matches.
- `kubectl apply --dry-run=server` accepts the rule; HA kustomize render shows the new selector.

After sync: `kubectl get nodes -L feature.node.kubernetes.io/custom-usb.zigbee-coordinator` should show `true` only on hp-workers, then HA reschedules there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)