### PR TITLE
open-webui: format usage metrics for humans

### DIFF
--- a/my-apps/ai/open-webui/README.md
+++ b/my-apps/ai/open-webui/README.md
@@ -125,6 +125,7 @@ Applied by ArgoCD automatically (directory = Application). Files:
 | `namespace.yaml`          | `open-webui` namespace                                           |
 | `open-webui-configmap.env`| **All** env-based config. Source of truth for behavior.          |
 | `deployment.yaml`         | Open WebUI main Deployment (stateful via PVC below)              |
+| `loader.js`               | Formats llama.cpp usage telemetry for the response tooltip       |
 | `pvc.yaml`                | SQLite + uploaded files persist here                             |
 | `service.yaml`            | ClusterIP for HTTPRoute                                          |
 | `httproute.yaml`          | External HTTPRoute to `open-webui.vanillax.me`                   |

--- a/my-apps/ai/open-webui/deployment.yaml
+++ b/my-apps/ai/open-webui/deployment.yaml
@@ -15,9 +15,8 @@ spec:
       labels:
         app: open-webui
     spec:
-      # Open WebUI delegates LLM inference to vLLM; RAG embeddings run locally
-      # on CPU in-pod. PREFER a non-GPU node (keeps 3090s vLLM-only) but soft so
-      # it still schedules on the GPU node when it's the only worker available.
+      # RAG embeddings run in-pod on CPU; inference stays in llama.cpp.
+      # Prefer non-GPU nodes to reserve the sole 3090, but allow fallback.
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -49,8 +48,15 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /app/backend/data
+        - name: frontend-loader
+          mountPath: /app/build/static/loader.js
+          subPath: loader.js
+          readOnly: true
         # Health probes disabled - backend model loading can take several minutes
       volumes:
       - name: data
         persistentVolumeClaim:
           claimName: storage
+      - name: frontend-loader
+        configMap:
+          name: open-webui-loader

--- a/my-apps/ai/open-webui/kustomization.yaml
+++ b/my-apps/ai/open-webui/kustomization.yaml
@@ -19,6 +19,9 @@ components:
   - ../../common/kopiur-backup
 
 configMapGenerator:
+- name: open-webui-loader
+  files:
+  - loader.js
 - name: har-analyzer-function
   files:
   - har-analyzer-function.py

--- a/my-apps/ai/open-webui/loader.js
+++ b/my-apps/ai/open-webui/loader.js
@@ -1,0 +1,88 @@
+(() => {
+  const formatNumber = (value, maximumFractionDigits = 0) =>
+    new Intl.NumberFormat(undefined, { maximumFractionDigits }).format(value);
+
+  const parseUsage = (text) => {
+    const usage = {};
+
+    for (const line of text.split('\n')) {
+      const match = line.trim().match(/^([A-Za-z_][A-Za-z0-9_]*):\s*(-?\d+(?:\.\d+)?)$/);
+      if (match) usage[match[1]] = Number(match[2]);
+    }
+
+    if (!Number.isFinite(usage.prompt_n) || !Number.isFinite(usage.predicted_n)) return null;
+    return usage;
+  };
+
+  const formatUsage = (usage) => {
+    const inputTokens = usage.input_tokens ?? usage.prompt_n;
+    const outputTokens = usage.output_tokens ?? usage.predicted_n;
+    const totalTokens = usage.total_tokens ?? inputTokens + outputTokens;
+    const promptSeconds = usage.prompt_ms / 1000;
+    const outputSeconds = usage.predicted_ms / 1000;
+    const lines = [];
+
+    lines.push(
+      `Input:  ${formatNumber(inputTokens)} tokens · ${formatNumber(promptSeconds, 2)} s` +
+        (Number.isFinite(usage.prompt_per_second)
+          ? ` · ${formatNumber(usage.prompt_per_second, 1)} tok/s`
+          : '')
+    );
+    lines.push(
+      `Output: ${formatNumber(outputTokens)} tokens · ${formatNumber(outputSeconds, 2)} s` +
+        (Number.isFinite(usage.predicted_per_second)
+          ? ` · ${formatNumber(usage.predicted_per_second, 1)} tok/s`
+          : '')
+    );
+
+    if (Number.isFinite(usage.draft_n) && usage.draft_n > 0) {
+      const accepted = usage.draft_n_accepted ?? 0;
+      lines.push(
+        `MTP:    ${formatNumber(accepted)}/${formatNumber(usage.draft_n)} accepted · ${formatNumber(
+          (accepted / usage.draft_n) * 100,
+          1
+        )}%`
+      );
+    }
+
+    const totalSeconds =
+      Number.isFinite(usage.prompt_ms) && Number.isFinite(usage.predicted_ms)
+        ? (usage.prompt_ms + usage.predicted_ms) / 1000
+        : null;
+    lines.push(
+      `Total:  ${formatNumber(totalTokens)} tokens` +
+        (totalSeconds !== null ? ` · ${formatNumber(totalSeconds, 2)} s` : '') +
+        (Number.isFinite(usage.cache_n)
+          ? ` · ${usage.cache_n > 0 ? `${formatNumber(usage.cache_n)} cached` : 'uncached'}`
+          : '')
+    );
+
+    return lines.join('\n');
+  };
+
+  const formatPre = (pre) => {
+    if (pre.dataset.friendlyUsageMetrics === 'true') return;
+
+    const usage = parseUsage(pre.textContent ?? '');
+    if (!usage) return;
+
+    pre.textContent = formatUsage(usage);
+    pre.dataset.friendlyUsageMetrics = 'true';
+  };
+
+  const scan = (node) => {
+    if (!(node instanceof Element)) return;
+    if (node.matches('pre')) formatPre(node);
+    node.querySelectorAll('pre').forEach(formatPre);
+  };
+
+  new MutationObserver((records) => {
+    for (const record of records) record.addedNodes.forEach(scan);
+  }).observe(document.documentElement, { childList: true, subtree: true });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => scan(document.body), { once: true });
+  } else {
+    scan(document.body);
+  }
+})();


### PR DESCRIPTION
## Summary

- replace llama.cpp's raw response-usage tooltip dump with compact Input, Output, MTP, and Total rows
- show token counts, seconds, throughput, MTP acceptance, and cache state with human-friendly precision
- mount the formatter through Open WebUI's stock `/static/loader.js` extension hook, avoiding a custom image
- leave non-llama.cpp usage tooltips unchanged

## Validation

- `node --check my-apps/ai/open-webui/loader.js`
- DOM fixture reproducing the live Qwen3.8 usage payload and expected four-line output
- unrelated-tooltip fixture remains unchanged
- `kubectl kustomize my-apps/ai/open-webui`
- `kubectl apply --dry-run=client -f <rendered manifests>`
- `git diff --check -- my-apps/ai/open-webui`