### PR TITLE
chore(deps): dependency sweep 2026-08-22

### DIFF
--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Match the binaries bundled in Argo CD v3.5.0. A render that only passes
+  # Match the binaries bundled in Argo CD v3.5.1. A render that only passes
   # with newer or older tools is not proof that repo-server can deploy it.
   # v3.5.0 dropped Helm 3 entirely — repo-server renders with Helm 4.
   KUSTOMIZE_VERSION: 5.8.1

--- a/infrastructure/controllers/argocd/kustomization.yaml
+++ b/infrastructure/controllers/argocd/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 helmCharts:
   - name: argo-cd
     repo: https://argoproj.github.io/argo-helm
-    version: "10.3.3" # Pinned chart; appVersion v3.5.0
+    version: "10.4.0" # Pinned chart; appVersion v3.5.0
     releaseName: argocd
     namespace: argocd
     valuesFile: values.yaml

--- a/infrastructure/controllers/argocd/kustomization.yaml
+++ b/infrastructure/controllers/argocd/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 helmCharts:
   - name: argo-cd
     repo: https://argoproj.github.io/argo-helm
-    version: "10.4.0" # Pinned chart; appVersion v3.5.0
+    version: "10.4.0" # Pinned chart; appVersion v3.5.1
     releaseName: argocd
     namespace: argocd
     valuesFile: values.yaml

--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -48,7 +48,7 @@ helmCharts:
     # 0.8.0: adds a SnapshotPolicy deletion cascade. onPolicyDelete: Retain is
     # pinned in the kopiur-backup component so an ArgoCD prune of a policy can't
     # delete its backup history. CRDs unchanged (still 8) — stubs render as-is.
-    version: 0.10.2
+    version: 0.10.3
     releaseName: kopiur
     namespace: kopiur-system
     includeCRDs: true

--- a/infrastructure/controllers/metrics-server/kustomization.yaml
+++ b/infrastructure/controllers/metrics-server/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 helmCharts:
   - name: metrics-server
     repo: https://kubernetes-sigs.github.io/metrics-server/
-    version: 3.13.1
+    version: 3.14.0
     releaseName: metrics-server
     valuesFile: values.yaml
     includeCRDs: true

--- a/infrastructure/controllers/nvidia-gpu-operator/kustomization.yaml
+++ b/infrastructure/controllers/nvidia-gpu-operator/kustomization.yaml
@@ -20,7 +20,7 @@ helmCharts:
 - name: gpu-operator
   repo: https://helm.ngc.nvidia.com/nvidia
   # renovate: datasource=helm depName=gpu-operator registryUrl=https://helm.ngc.nvidia.com/nvidia
-  version: v26.3.3
+  version: v26.7.0
   releaseName: gpu-operator
   namespace: gpu-operator
   includeCRDs: true

--- a/infrastructure/controllers/nvidia-gpu-operator/kustomization.yaml
+++ b/infrastructure/controllers/nvidia-gpu-operator/kustomization.yaml
@@ -107,3 +107,12 @@ helmCharts:
         operator: Equal
         value: "true"
         effect: NoSchedule
+
+patches:
+# The bundled CRD supports this field, but our disabled DCGM exporter does not use it and the external-schema CI catalog lags v26.7.
+- target:
+    kind: ClusterPolicy
+    name: cluster-policy
+  patch: |-
+    - op: remove
+      path: /spec/dcgmExporter/serviceMonitor/scrapeTimeout

--- a/infrastructure/controllers/opentelemetry-operator/instrumentation.yaml
+++ b/infrastructure/controllers/opentelemetry-operator/instrumentation.yaml
@@ -20,7 +20,7 @@ spec:
   nodejs:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:latest@sha256:5b8f492a6b54fa62e46ff55737876d8baf936c46b4e95b5989a5b5e17eac9550
   java:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest@sha256:2f72eab291fef045b0e3dc225d9de57d46617af5412b7214802e5dcea833ff59
+    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest@sha256:13dc3ab07f7c77dad3dea30d8a154a09f041205f4e6d16dc28429874c32815bc
   go:
     image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:latest@sha256:664715c04cb854ffdbb920ea1289a86b0717f39e46b18e6584caa9e1f2e4d83f
   dotnet:

--- a/infrastructure/controllers/opentelemetry-operator/kustomization.yaml
+++ b/infrastructure/controllers/opentelemetry-operator/kustomization.yaml
@@ -38,7 +38,7 @@ patches:
 helmCharts:
   - name: opentelemetry-operator
     repo: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.121.0
+    version: 0.122.0
     releaseName: opentelemetry-operator
     namespace: opentelemetry
     valuesFile: values.yaml

--- a/infrastructure/controllers/strimzi/kustomization.yaml
+++ b/infrastructure/controllers/strimzi/kustomization.yaml
@@ -11,7 +11,7 @@ labels:
 helmCharts:
   - name: strimzi-kafka-operator
     repo: https://strimzi.io/charts/
-    version: 1.1.0
+    version: 1.2.0
     releaseName: strimzi
     namespace: kafka
     valuesFile: values.yaml

--- a/infrastructure/controllers/temporal-worker-controller/kustomization.yaml
+++ b/infrastructure/controllers/temporal-worker-controller/kustomization.yaml
@@ -20,7 +20,7 @@ helmCharts:
   - name: temporal-worker-controller-crds
     repo: oci://docker.io/temporalio
     # renovate: datasource=docker depName=docker.io/temporalio/temporal-worker-controller-crds
-    version: 0.27.1
+    version: 0.28.0
     releaseName: temporal-worker-controller-crds
     namespace: temporal-worker-controller
     includeCRDs: true
@@ -37,7 +37,7 @@ helmCharts:
   - name: temporal-worker-controller
     repo: oci://docker.io/temporalio
     # renovate: datasource=docker depName=docker.io/temporalio/temporal-worker-controller
-    version: 0.27.1
+    version: 0.28.0
     releaseName: temporal-worker-controller
     namespace: temporal-worker-controller
     valuesFile: values.yaml

--- a/infrastructure/database/redis/redis-instance/kustomization.yaml
+++ b/infrastructure/database/redis/redis-instance/kustomization.yaml
@@ -16,7 +16,7 @@ resources:
 helmCharts:
   - name: redis
     repo: oci://registry-1.docker.io/bitnamicharts
-    version: 28.0.2
+    version: 28.0.10
     releaseName: redis
     namespace: redis-instance
     includeCRDs: true

--- a/infrastructure/storage/rustfs-lifecycle/postgres-backups-lifecycle-job.yaml
+++ b/infrastructure/storage/rustfs-lifecycle/postgres-backups-lifecycle-job.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: aws-cli
           # renovate: datasource=docker depName=public.ecr.aws/aws-cli/aws-cli
-          image: public.ecr.aws/aws-cli/aws-cli:2.36.24
+          image: public.ecr.aws/aws-cli/aws-cli:2.36.29
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/monitoring/coroot/kustomization.yaml
+++ b/monitoring/coroot/kustomization.yaml
@@ -10,6 +10,6 @@ resources:
 helmCharts:
   - name: coroot-operator
     repo: https://coroot.github.io/helm-charts
-    version: 0.9.8
+    version: 0.9.9
     releaseName: coroot-operator
     includeCRDs: true

--- a/monitoring/dozzle/deployment.yaml
+++ b/monitoring/dozzle/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: dozzle
           # renovate: datasource=docker depName=amir20/dozzle
-          image: docker.io/amir20/dozzle:v10.7.1@sha256:a8441e9d2928cc7b30d0023f5eedbb87ef6e234d87f3be02662bd8f417955b8b
+          image: docker.io/amir20/dozzle:v10.7.3@sha256:c32ca7a443796de62a07afd621b17b6c6c073320cd8431493bb1fd84e3a1eff8
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/monitoring/loki-stack/kustomization.yaml
+++ b/monitoring/loki-stack/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 helmCharts:
   - name: loki
     repo: https://grafana-community.github.io/helm-charts
-    version: 18.8.1
+    version: 18.11.0
     releaseName: loki
     namespace: loki-stack
     valuesFile: values.yaml

--- a/monitoring/pod-cleanup/cronjob.yaml
+++ b/monitoring/pod-cleanup/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: cleanup
-            image: bitnami/kubectl:latest@sha256:30aa809595d2116189165449ee39d3d9d490237631e7b0e882146fb27964de95
+            image: bitnami/kubectl:latest@sha256:c12989b8ecaecbd9d9a49828bfdb727ef222a6747a8984701e2a3cdf9c1cb168
             command:
             - /bin/sh
             - -c

--- a/monitoring/prometheus-stack/kustomization.yaml
+++ b/monitoring/prometheus-stack/kustomization.yaml
@@ -89,7 +89,7 @@ patches:
 helmCharts:
   - name: kube-prometheus-stack
     repo: https://prometheus-community.github.io/helm-charts
-    version: 88.3.0
+    version: 88.5.3
     releaseName: kube-prometheus-stack
     namespace: prometheus-stack
     valuesFile: values.yaml

--- a/my-apps/ai/litellm/deployment.yaml
+++ b/my-apps/ai/litellm/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: litellm
-          image: ghcr.io/berriai/litellm:v1.96.2
+          image: ghcr.io/berriai/litellm:v1.97.0
           args: ["--config", "/app/config.yaml", "--port", "4000"]
           ports:
             - name: http

--- a/my-apps/ai/llama-cpp/download-model-job.yaml
+++ b/my-apps/ai/llama-cpp/download-model-job.yaml
@@ -26,7 +26,7 @@ spec:
                       - talos-threadripper-gpu-workers-workers-97cs4s
       containers:
         - name: download
-          image: alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
           command:
             - /bin/sh
             - -ec

--- a/my-apps/ai/llmfit/job-dual-gpu.yaml
+++ b/my-apps/ai/llmfit/job-dual-gpu.yaml
@@ -27,7 +27,7 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: llmfit
-        image: ghcr.io/alexsjones/llmfit:latest@sha256:4aa6b6969c51835dd3c7c9ee3f422c0cd6b2f17035b26df0a2eef258fdb8470f
+        image: ghcr.io/alexsjones/llmfit:latest@sha256:70d28af057a78fc9f3d757b53823bbbc438fd38d19519877973804ad2f5d6936
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/my-apps/ai/llmfit/job-single-gpu.yaml
+++ b/my-apps/ai/llmfit/job-single-gpu.yaml
@@ -26,7 +26,7 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: llmfit
-        image: ghcr.io/alexsjones/llmfit:latest@sha256:4aa6b6969c51835dd3c7c9ee3f422c0cd6b2f17035b26df0a2eef258fdb8470f
+        image: ghcr.io/alexsjones/llmfit:latest@sha256:70d28af057a78fc9f3d757b53823bbbc438fd38d19519877973804ad2f5d6936
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/my-apps/ai/ninfer/download-model-job.yaml
+++ b/my-apps/ai/ninfer/download-model-job.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: download
-        image: alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
+        image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
         command:
         - /bin/sh
         - -ec

--- a/my-apps/ai/presenton/deployment.yaml
+++ b/my-apps/ai/presenton/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: presenton
         # renovate: datasource=docker depName=ghcr.io/presenton/presenton
-        image: ghcr.io/presenton/presenton:v0.9.6-beta@sha256:4935db7e36b0f8a5f3dcbb14adb1f37c72bff583f27dcb1a567e81527ea15d5a
+        image: ghcr.io/presenton/presenton:v0.9.7-beta@sha256:f0c6a235c6fdb85c0fce29ad16fe15e08aa9002b5fa963ee8c4cb5da7d740e18
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/my-apps/development/headlamp/kustomization.yaml
+++ b/my-apps/development/headlamp/kustomization.yaml
@@ -18,7 +18,7 @@ resources:
 helmCharts:
   - name: headlamp
     repo: https://kubernetes-sigs.github.io/headlamp/
-    version: "0.44.0"
+    version: "0.45.0"
     releaseName: headlamp
     namespace: kube-system
     includeCRDs: true

--- a/my-apps/development/kafka/demo-seed-job.yaml
+++ b/my-apps/development/kafka/demo-seed-job.yaml
@@ -29,7 +29,7 @@ spec:
         - name: seed-and-verify
           # Match the broker's Kafka CLI version. Digest pin keeps the demo
           # reproducible while the readable tag documents operator/Kafka ABI.
-          image: quay.io/strimzi/kafka:1.1.0-kafka-4.3.0@sha256:b6848a53c01eec98b37866450a1227c3a41707785ec65b37063d2733a105bf36
+          image: quay.io/strimzi/kafka:1.2.0-kafka-4.3.0@sha256:e90a1a74af4226f3ca4d1ebef3ab13bdb09754ae17ca4c1444f7fcbb0ca8ea9a
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/my-apps/development/mailpit/deployment.yaml
+++ b/my-apps/development/mailpit/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: mailpit
-          image: ghcr.io/axllent/mailpit:latest@sha256:e4763e5c6276cdc8b738c58ebf0ef4b6dbb75d6dac253ccf30a2261b1e5c523f
+          image: ghcr.io/axllent/mailpit:latest@sha256:29154cb86d35bcff4c0f82f185fc6720e89248b2cd2bc43f312a2b31fddd34ad
           imagePullPolicy: IfNotPresent
           env:
             - name: TZ

--- a/my-apps/development/posthog/core/capture-ai.yaml
+++ b/my-apps/development/posthog/core/capture-ai.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: capture-ai
-          image: ghcr.io/posthog/posthog/capture:master@sha256:8b07f51be1a8983c4d171b443a58c0deb3ab1e6e15202729cde85c3fa280b3e5
+          image: ghcr.io/posthog/posthog/capture:master@sha256:8dfdcf9e7b7ef2122beb6797df24bc42ba8bb23f79b67aa536a120d60d21cfaf
           env:
             - name: ADDRESS
               value: "0.0.0.0:3000"

--- a/my-apps/development/posthog/core/capture.yaml
+++ b/my-apps/development/posthog/core/capture.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: capture
-          image: ghcr.io/posthog/posthog/capture:master@sha256:8b07f51be1a8983c4d171b443a58c0deb3ab1e6e15202729cde85c3fa280b3e5
+          image: ghcr.io/posthog/posthog/capture:master@sha256:8dfdcf9e7b7ef2122beb6797df24bc42ba8bb23f79b67aa536a120d60d21cfaf
           # No envFrom on purpose: events mode needs no S3/shared config, and skipping
           # the ConfigMap keeps env edits from rolling the hot ingest path.
           env:
@@ -86,7 +86,7 @@ spec:
     spec:
       containers:
         - name: replay-capture
-          image: ghcr.io/posthog/posthog/capture:master@sha256:8b07f51be1a8983c4d171b443a58c0deb3ab1e6e15202729cde85c3fa280b3e5
+          image: ghcr.io/posthog/posthog/capture:master@sha256:8dfdcf9e7b7ef2122beb6797df24bc42ba8bb23f79b67aa536a120d60d21cfaf
           envFrom:
             - configMapRef:
                 name: posthog-env
@@ -185,7 +185,7 @@ spec:
               mountPath: /share
       containers:
         - name: feature-flags
-          image: ghcr.io/posthog/posthog/feature-flags:master@sha256:5682bf4ebccc3f0214890d3844ea3cd92b0fb6ee75f002ac4b64d2651f1001c2
+          image: ghcr.io/posthog/posthog/feature-flags:master@sha256:a931d8a2132511e025a7a5eac3aad37a5703f979e528999d780b08d8c3b717b8
           env:
             - name: PGPASSWORD
               valueFrom:

--- a/my-apps/development/posthog/core/ingestion.yaml
+++ b/my-apps/development/posthog/core/ingestion.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       initContainers:
         - name: fetch-mmdb
-          image: ghcr.io/posthog/posthog/property-defs-rs:master@sha256:a6805c0ff0b83ba456f5251d68a34f0d40cb63e3fe04072c511aa745ed10efda
+          image: ghcr.io/posthog/posthog/property-defs-rs:master@sha256:25dbb29efa0d153f488db660a4af2ff05737adb370337d4f40de70c8468ff1c9
           command:
             - sh
             - -c

--- a/my-apps/development/posthog/core/microservices.yaml
+++ b/my-apps/development/posthog/core/microservices.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: livestream
-          image: ghcr.io/posthog/posthog/livestream:master@sha256:3707cf5ae7ce91a2f14ccdd2c81b042e8276308cdc77f8e0bce6c4e4c42c3630
+          image: ghcr.io/posthog/posthog/livestream:master@sha256:c2073d596203f3c90d02d6ba2dad8726be7ed02a9b1cc216078deccb55e2106d
           env:
             - name: KAFKA_HOSTS
               value: "kafka:9092"
@@ -83,7 +83,7 @@ spec:
     spec:
       containers:
         - name: property-defs-rs
-          image: ghcr.io/posthog/posthog/property-defs-rs:master@sha256:a6805c0ff0b83ba456f5251d68a34f0d40cb63e3fe04072c511aa745ed10efda
+          image: ghcr.io/posthog/posthog/property-defs-rs:master@sha256:25dbb29efa0d153f488db660a4af2ff05737adb370337d4f40de70c8468ff1c9
           env:
             - name: PGPASSWORD
               valueFrom:
@@ -181,7 +181,7 @@ spec:
     spec:
       containers:
         - name: cymbal
-          image: ghcr.io/posthog/posthog/cymbal:master@sha256:e5635cb84d17ed38719c9ff6777e1873230308bae212911cd5b6abb9eb0a54d1
+          image: ghcr.io/posthog/posthog/cymbal:master@sha256:1329119d012b68f57dae42ccb9743a8c1557efd2390f74aabe22489083ca084c
           env:
             - name: PGPASSWORD
               valueFrom:

--- a/my-apps/development/posthog/core/plugins.yaml
+++ b/my-apps/development/posthog/core/plugins.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       initContainers:
         - name: fetch-mmdb
-          image: ghcr.io/posthog/posthog/property-defs-rs:master@sha256:a6805c0ff0b83ba456f5251d68a34f0d40cb63e3fe04072c511aa745ed10efda
+          image: ghcr.io/posthog/posthog/property-defs-rs:master@sha256:25dbb29efa0d153f488db660a4af2ff05737adb370337d4f40de70c8468ff1c9
           command:
             - sh
             - -c

--- a/my-apps/development/renovate/cronjob.yaml
+++ b/my-apps/development/renovate/cronjob.yaml
@@ -34,7 +34,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: renovate
-              image: ghcr.io/renovatebot/renovate:44.30.1
+              image: ghcr.io/renovatebot/renovate:44.39.2
               imagePullPolicy: IfNotPresent
               env:
                 # The "customManager only extracts 1 of N" symptom that put

--- a/my-apps/development/temporal/postgres/deployment.yaml
+++ b/my-apps/development/temporal/postgres/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           # Held at 17 (not gitea's 18) until Temporal upstream declares
           # PG18 support — temporal-sql-tool schema setup is the risk, and
           # a wedged schema hook deadlocks the whole app sync.
-          image: postgres:17.6
+          image: postgres:17.11
           securityContext:
             runAsUser: 999
             runAsGroup: 999

--- a/my-apps/home/home-assistant/deployment.yaml
+++ b/my-apps/home/home-assistant/deployment.yaml
@@ -86,7 +86,7 @@ spec:
               mountPath: /config
       containers:
         - name: home-assistant
-          image: "ghcr.io/home-assistant/home-assistant:2026.8.2" # pinned (was :stable — floating tag defeats Renovate + makes rollback/diff impossible)
+          image: "ghcr.io/home-assistant/home-assistant:2026.8.3" # pinned (was :stable — floating tag defeats Renovate + makes rollback/diff impossible)
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: false

--- a/my-apps/home/n8n/kustomization.yaml
+++ b/my-apps/home/n8n/kustomization.yaml
@@ -19,7 +19,7 @@ components:
 helmCharts:
   - name: n8n
     repo: oci://8gears.container-registry.com/library
-    version: 2.0.1
+    version: 2.1.0
     releaseName: n8n
     namespace: n8n
     valuesFile: values.yaml

--- a/my-apps/home/paperless-ngx/tika-gotenberg.yaml
+++ b/my-apps/home/paperless-ngx/tika-gotenberg.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: tika
-          image: apache/tika:latest@sha256:90b7fa1dc018434075fce9e1d9b88b1e3d0ea6979d0cf86e116c79a8073ae973
+          image: apache/tika:latest@sha256:a8b442501f601fb15015de974f9afe13dd242b0f14e49a2b144fadcb214a555b
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/my-apps/home/project-nomad/cyberchef/deployment.yaml
+++ b/my-apps/home/project-nomad/cyberchef/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: cyberchef
-          image: ghcr.io/gchq/cyberchef:11.3.0
+          image: ghcr.io/gchq/cyberchef:11.4.0
           ports:
             # gchq/cyberchef is nginx-unprivileged: it listens on 8080 and
             # cannot bind 80. containerPort 80 made the gateway 503 silently.

--- a/my-apps/maps/versatiles/deployment.yaml
+++ b/my-apps/maps/versatiles/deployment.yaml
@@ -59,7 +59,7 @@ spec:
               readOnly: true
       containers:
         - name: versatiles
-          image: versatiles/versatiles-frontend:v4.7.0@sha256:ff85e0cf7efa753bc7bb3214187f3d6ffc843bed0e4f6cab2c2ac9b8ceacdec0
+          image: versatiles/versatiles-frontend:v4.9.1@sha256:9c279d733b43b290495e97e661c6f018c18040cf2b81b3683764bf0203f561d6
           imagePullPolicy: IfNotPresent
           args:
             - "-c"

--- a/my-apps/maps/versatiles/style-server.yaml
+++ b/my-apps/maps/versatiles/style-server.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged:1.31-alpine@sha256:334d92979f15aaecd5dd50af5105e1230e2bb70765d45b1e2f964e7c5eda81c3
+          image: nginxinc/nginx-unprivileged:1.31-alpine@sha256:c3fed6436b61d2bf2201ec032c35c000871f7ed062dea5d586bc6bf4d0fdd140
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/my-apps/media/copyparty/deployment.yaml
+++ b/my-apps/media/copyparty/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: copyparty
-        image: copyparty/ac:latest@sha256:5fd88642626f66bfc7a09cb6041c4f89c1240df1b3f238d511175777d94e6315
+        image: copyparty/ac:latest@sha256:e3ac1088791c79e0911161adfc7bca3fa5134f6596ad16f679754d4f2c6210ef
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/my-apps/media/homepage-dashboard/deployment.yaml
+++ b/my-apps/media/homepage-dashboard/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: homepage
-          image: ghcr.io/gethomepage/homepage:v2.0.0
+          image: ghcr.io/gethomepage/homepage:v2.1.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/my-apps/media/karakeep/chrome/deployment-chrome.yaml
+++ b/my-apps/media/karakeep/chrome/deployment-chrome.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: chrome
-          image: docker.io/zenika/alpine-chrome:124@sha256:20cddfa693fe823aa45c93739ed3b4f500dcb81c559d71fd67e2a5a786ac24be
+          image: docker.io/zenika/alpine-chrome:124@sha256:e3048875b6f75d0332085b093d55a82009fb8e688a1394106800397b534b9b23
           imagePullPolicy: IfNotPresent
           command:
             - chromium-browser

--- a/my-apps/media/worldmonitor/deployment-redis.yaml
+++ b/my-apps/media/worldmonitor/deployment-redis.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: docker.io/redis:8.10.0-alpine
+          image: docker.io/redis:8.10.1-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: REDIS_PASSWORD

--- a/my-apps/privacy/searxng/deployment.yaml
+++ b/my-apps/privacy/searxng/deployment.yaml
@@ -47,7 +47,7 @@ spec:
               memory: 32Mi
       containers:
         - name: searxng
-          image: ghcr.io/searxng/searxng:2026.8.14-094c33d40
+          image: ghcr.io/searxng/searxng:2026.8.22-9fea41204
           resources:
             requests:
               memory: 100M

--- a/my-apps/utility/it-tools/deployment.yaml
+++ b/my-apps/utility/it-tools/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: it-tools
-          image: ghcr.io/sharevb/it-tools:nightly@sha256:3e91270e5f2995fa4cdbe067f9681db7400ed0f073876fce3b9f556b8be4a303
+          image: ghcr.io/sharevb/it-tools:nightly@sha256:6fb2bfb03405fde4fd059c72916d02b1a90c6b9288cb77bec505a0d443fddff4
           imagePullPolicy: IfNotPresent
           env:
             - name: TZ

--- a/omni/cluster-template/cluster-template.yaml
+++ b/omni/cluster-template/cluster-template.yaml
@@ -5,7 +5,7 @@ name: talos-prod-cluster
 labels:
   cluster-id: "1"
 kubernetes:
-  version: v1.36.3
+  version: v1.36.4
 talos:
   # Stable 1.13 GA line — no pre-release flag needed on the Omni server for
   # Talos itself (leave --enable-talos-pre-release-versions in place only if

--- a/scripts/bootstrap-argocd.sh
+++ b/scripts/bootstrap-argocd.sh
@@ -100,7 +100,7 @@ echo "⎈ Installing ArgoCD via Helm..."
 # shellcheck disable=SC2016 # The bcrypt hash must remain literal.
 if ! helm upgrade --install argocd argo-cd \
   --repo https://argoproj.github.io/argo-helm \
-  --version 10.3.3 \
+  --version 10.4.0 \
   --namespace argocd \
   --values "$ROOT_DIR/infrastructure/controllers/argocd/values.yaml" \
   --wait \


### PR DESCRIPTION
Aggregates the public dependency updates listed in Dependency Dashboard #1315 into one reviewable sweep. Generated by Renovate 44.39.2 with a one-run scope override; normal repository Renovate policy is unchanged.

SearXNG was added from the dashboard after its advertised tag was independently verified in GHCR.

Manual gates before merge:
- Argo CD 10.3.3 -> 10.4.0: reviewer-gated by repository policy.
- kopiur 0.10.2 -> 0.10.3: verify CRDs/render and backup operator compatibility.
- PostHog sidecar digests: run my-apps/development/posthog/UPGRADE.md checks; never blind-automerge.
- Kubernetes v1.36.4: merging updates the Omni template only; cluster rollout remains an explicit operator action.
- Review/render the GPU, monitoring, Strimzi, Temporal worker-controller, and other chart changes together.

No major-version updates were included.