### PR TITLE
omni: GPU worker passes through one RTX 3090

### DIFF
--- a/omni/docs/threadripper-gpu-cluster.md
+++ b/omni/docs/threadripper-gpu-cluster.md
@@ -5,7 +5,7 @@
 - `threadripper-control-plane`: 4 vCPU, 12 GiB RAM, 100 GiB disk.
 - `threadripper-worker`: 8 vCPU, 24 GiB RAM, 64 GiB `local-lvm` boot disk.
 - `threadripper-gpu-worker`: 24 vCPU, 64 GiB RAM, two 450 GiB disks, one
-  300 GiB flash disk, and two RTX 3090s.
+  300 GiB flash disk, and one RTX 3090 (mapping `gpu-1`).
 
 The split keeps Kubernetes control-plane services away from GPU and app
 workloads. It improves stability and scheduler headroom, but it is still not HA

--- a/omni/machine-classes/threadripper-gpu-worker.yaml
+++ b/omni/machine-classes/threadripper-gpu-worker.yaml
@@ -57,8 +57,7 @@ spec:
       vga: std
       numa: true
       balloon: false
+      # One RTX 3090 (mapping gpu-1); the second card left for the OpenShift lab.
       pci_devices:
         - mapping: gpu-1
-          pcie: true
-        - mapping: gpu-2
           pcie: true


### PR DESCRIPTION
The second card left for the OpenShift lab and its Proxmox mapping (`gpu-2`) is gone; a class that still lists it leaves the GPU VM unstartable (VM 100 on the Threadripper sat `stopped` during the v2 rebuild until `hostpci1` was dropped by hand). Class already re-applied in Omni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MD6hYWMfYaaHx8Y4FESZp