### PR TITLE
cilium: 1.20.0-rc.0 → 1.20.1, pin split xDS in the bootstrap seed

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -94,11 +94,10 @@
       prCreation: 'immediate',
     },
     {
-      description: 'Cilium: 1.20.x patches allowed (1.20.1 fixed the ADS livelock cilium/cilium#47624). The split-xDS stale NetworkPolicy NACK is still unfixed upstream — hold 1.21 until final ships delta-split. Cilium never automerges: a CNI bump is major-risk.',
+      description: 'Cilium never automerges — read the release notes and roll it deliberately.',
       matchPackageNames: [
         'cilium',
       ],
-      allowedVersions: '<1.21.0',
       automerge: false,
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -94,11 +94,11 @@
       prCreation: 'immediate',
     },
     {
-      description: 'Cilium pinned to 1.20.0-rc.0: 1.20.0 final has two CNI-breaking xDS bugs (ADS livelock cilium/cilium#47624, split-mode stale NetworkPolicy NACK that wedged the hp node 2026-08-16). Hold every update until a 1.20.x fixes BOTH; cilium never automerges — a CNI minor is major-risk.',
+      description: 'Cilium: 1.20.x patches allowed (1.20.1 fixed the ADS livelock cilium/cilium#47624). The split-xDS stale NetworkPolicy NACK is still unfixed upstream — hold 1.21 until final ships delta-split. Cilium never automerges: a CNI bump is major-risk.',
       matchPackageNames: [
         'cilium',
       ],
-      allowedVersions: '<1.20.0',
+      allowedVersions: '<1.21.0',
       automerge: false,
     },
     {

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ else
 fi
 
 "$CILIUM_CMD" install \
-    --version 1.20.0-rc.0 \
+    --version 1.20.1 \
     --set cluster.name=talos-prod-cluster-v2 \
     --set ipam.mode=kubernetes \
     --set kubeProxyReplacement=true \
@@ -222,7 +222,8 @@ fi
     --set hubble.ui.enabled=false \
     --set gatewayAPI.enabled=true \
     --set gatewayAPI.enableAlpn=true \
-    --set gatewayAPI.enableAppProtocol=true
+    --set gatewayAPI.enableAppProtocol=true \
+    --set envoy.xdsMode=split
 "$CILIUM_CMD" status --wait --wait-duration 5m
 kubectl get nodes
 ```
@@ -232,7 +233,8 @@ what ArgoCD renders at Wave 0 (`infrastructure/networking/cilium/`), or Wave 0
 will immediately reconfigure the seed install:
 
 > - **Routing mode matches by default**: the CLI's default (`tunnel`/vxlan) equals `values.yaml`'s `routingMode: tunnel`. If the managed values ever change routing mode, add the matching `--set routingMode=...` here or Wave 0 restarts every agent mid-bootstrap.
-> - **`--version 1.20.0-rc.0`** must match `infrastructure/networking/cilium/kustomization.yaml` (rc.0 is pinned on purpose: 1.20.0 final and 1.20.1 still carry the split-xDS stale-policy replay, see that file). A mismatch makes ArgoCD upgrade Cilium at Wave 0, regenerating some Hubble certs but not others → `x509: certificate signed by unknown authority` blocks every later wave.
+> - **`--version 1.20.1`** must match `infrastructure/networking/cilium/kustomization.yaml`. A mismatch makes ArgoCD upgrade Cilium at Wave 0, regenerating some Hubble certs but not others → `x509: certificate signed by unknown authority` blocks every later wave.
+> - **`--set envoy.xdsMode=split`** must match `values.yaml`. Seeding without it leaves envoy on the ADS default while Wave 0 flips the agents to split — envoy then holds zero listeners (every Gateway VIP refuses TCP) until `cilium-envoy` is restarted (2026-08-24 rebuild outage).
 > - **`cluster.name`** must match `values.yaml` (Hubble cert SANs). Run without it and certs are issued for `default`/`kind-kind` → TLS failures.
 > - **Hubble stays disabled at bootstrap on purpose** — ArgoCD enables it at Wave 0 so it's the sole owner of the Hubble TLS certs (no CLI-vs-ArgoCD cert mismatch).
 

--- a/infrastructure/networking/cilium/kustomization.yaml
+++ b/infrastructure/networking/cilium/kustomization.yaml
@@ -15,9 +15,9 @@ resources:
 helmCharts:
 - name: cilium
   repo: https://helm.cilium.io
-  # Pinned to rc.0: 1.20.0 final split-xDS replays stale NetworkPolicy resources on new
-  # streams (Envoy NACK wedged hp's CNI 2026-08-16); betting the regression landed after rc.0.
-  version: 1.20.0-rc.0
+  # Split-xDS stale-policy replay (Envoy NACK on new stream) is unfixed in ALL 1.20.x incl.
+  # rc.0 — recovery: restart cilium-agent FIRST, then that node's cilium-envoy.
+  version: 1.20.1
   releaseName: cilium
   includeCRDs: true
   namespace: kube-system

--- a/infrastructure/networking/cilium/kustomization.yaml
+++ b/infrastructure/networking/cilium/kustomization.yaml
@@ -15,8 +15,7 @@ resources:
 helmCharts:
 - name: cilium
   repo: https://helm.cilium.io
-  # Split-xDS stale-policy replay (Envoy NACK on new stream) is unfixed in ALL 1.20.x incl.
-  # rc.0 — recovery: restart cilium-agent FIRST, then that node's cilium-envoy.
+  # If a node 403s after a roll: restart cilium-agent first, then that node's cilium-envoy.
   version: 1.20.1
   releaseName: cilium
   includeCRDs: true

--- a/infrastructure/networking/cilium/values.yaml
+++ b/infrastructure/networking/cilium/values.yaml
@@ -102,8 +102,7 @@ k8sClientRateLimit:
 extraConfig:
   api-rate-limit: "endpoint-create=rate-limit:2/s,rate-burst:16,parallel-requests:8,max-wait-duration:30s"
 
-# Stay on split: the stale-policy replay NACK is mode-agnostic and unfixed, so we keep the
-# mode with a proven recovery; revisit at 1.21 (delta-split). Must match the README seed flag.
+# Must match the README seed flag, or a fresh bootstrap leaves envoy holding zero listeners.
 envoy:
   xdsMode: split
 

--- a/infrastructure/networking/cilium/values.yaml
+++ b/infrastructure/networking/cilium/values.yaml
@@ -102,8 +102,8 @@ k8sClientRateLimit:
 extraConfig:
   api-rate-limit: "endpoint-create=rate-limit:2/s,rate-burst:16,parallel-requests:8,max-wait-duration:30s"
 
-# 1.20 ADS mode livelocks after the last L7 listener drains (cilium/cilium#47624,
-# Gateways all 403) — stay on split xDS for the whole 1.20 line.
+# Stay on split: the stale-policy replay NACK is mode-agnostic and unfixed, so we keep the
+# mode with a proven recovery; revisit at 1.21 (delta-split). Must match the README seed flag.
 envoy:
   xdsMode: split
 


### PR DESCRIPTION
## Why

- **1.20.1 ships the ADS-livelock fix** the rc.0 pin was waiting on: cilium/proxy#1982 (merged 08-10) is in envoy image `v1.37.5-1786810558` (built 08-15), closing cilium/cilium#47624. The old pin comment said 1.20.1 shipped no fix — it misread the closed-unmerged cilium/cilium#47895 (closed because Renovate had already bumped the image on the v1.20 branch).
- **The rc.0 pin's bet is disproven**: the split-xDS stale-policy replay (`duplicate resource key ... on a new stream` → envoy NACKs the full snapshot → empty default-deny policy table → node-wide 403s) hit **rc.0** on 2026-08-24, same signature as 1.20.0 final on 2026-08-16. It's agent-cache-side, mode-agnostic, unfixed in every release — rc.0 protects nothing. Recovery unchanged: restart cilium-agent first, then that node's cilium-envoy.
- **Seed drift guard**: the 2026-08-24 rebuild seeded ADS (CLI default) while Wave 0 rendered split; every envoy held zero listeners and all Gateway VIPs refused TCP until cilium-envoy was restarted. The README seed command now pins `--set envoy.xdsMode=split`.

## Changes

| File | Change |
|---|---|
| `infrastructure/networking/cilium/kustomization.yaml` | `1.20.0-rc.0` → `1.20.1`; one-line comment: the agent-then-envoy recovery order |
| `infrastructure/networking/cilium/values.yaml` | keep `xdsMode: split`; one-line comment: must match the README seed flag |
| `README.md` | seed `--version 1.20.1` + `--set envoy.xdsMode=split`, new drift-outage bullet |
| `.github/renovate.json5` | version ceiling removed entirely — a `allowedVersions` hold is a landmine nobody remembers to lift, and it strands us on an old CNI. `automerge: false` stays: every cilium PR gets human eyes, which is the protection that works. |

## Verification

- `kustomize build --enable-helm` renders clean: `cilium:v1.20.1`, `cilium-envoy:v1.37.5-1786810558` (contains the #47624 fix), `envoy-xds-mode: split`.

## Rollout notes

Wave 0 rolls both DaemonSets node-by-node. The new envoy streams are exactly the replay bug's trigger — if a node comes back serving 403s, run the agent-then-envoy restart on that node:

```bash
for n in 192.168.10.97 192.168.10.80 192.168.10.150 192.168.10.156 192.168.10.162; do
  curl -sk -o /dev/null -w "$n %{http_code}\n" --resolve argocd.vanillax.me:30502:$n https://argocd.vanillax.me:30502/
done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUvfySAKmnJhKXc2iHjGLV
