### PR TITLE
cilium: 1.20.1 + drop the split xDS override

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -94,11 +94,11 @@
       prCreation: 'immediate',
     },
     {
-      description: 'Cilium pinned to 1.20.0-rc.0: 1.20.0 final has two CNI-breaking xDS bugs (ADS livelock cilium/cilium#47624, split-mode stale NetworkPolicy NACK that wedged the hp node 2026-08-16). Hold every update until a 1.20.x fixes BOTH; cilium never automerges — a CNI minor is major-risk.',
+      description: 'Cilium never automerges — a CNI minor is major-risk, and 1.20.0 walked in unreviewed that way. Hold below 1.21.0: 1.20.1 fixes the ADS livelock (cilium/cilium#47624) but the split-xDS stale-NetworkPolicy NACK is still unreported upstream, so the rollback ladder is 1.20.0-rc.0 + split, then 1.19.6.',
       matchPackageNames: [
         'cilium',
       ],
-      allowedVersions: '<1.20.0',
+      allowedVersions: '<1.21.0',
       automerge: false,
     },
     {

--- a/infrastructure/networking/cilium/kustomization.yaml
+++ b/infrastructure/networking/cilium/kustomization.yaml
@@ -15,9 +15,9 @@ resources:
 helmCharts:
 - name: cilium
   repo: https://helm.cilium.io
-  # Pinned to rc.0: 1.20.0 final split-xDS replays stale NetworkPolicy resources on new
-  # streams (Envoy NACK wedged hp's CNI 2026-08-16); betting the regression landed after rc.0.
-  version: 1.20.0-rc.0
+  # Never set envoy.xdsMode: split on 1.20.x — it replays stale NetworkPolicy resources and
+  # NACK-wedges a node's CNI (unfixed upstream); ADS is fixed as of 1.20.1.
+  version: 1.20.1
   releaseName: cilium
   includeCRDs: true
   namespace: kube-system

--- a/infrastructure/networking/cilium/values.yaml
+++ b/infrastructure/networking/cilium/values.yaml
@@ -102,11 +102,6 @@ k8sClientRateLimit:
 extraConfig:
   api-rate-limit: "endpoint-create=rate-limit:2/s,rate-burst:16,parallel-requests:8,max-wait-duration:30s"
 
-# 1.20 ADS mode livelocks after the last L7 listener drains (cilium/cilium#47624,
-# Gateways all 403) — stay on split xDS for the whole 1.20 line.
-envoy:
-  xdsMode: split
-
 # Gateway API Support
 gatewayAPI:
   enabled: true


### PR DESCRIPTION
Unpins Cilium from `1.20.0-rc.0` and returns Envoy to the chart-default ADS xDS mode. These two changes only make sense together.

## Why now

`1.20.0-rc.0` was pinned because **both** 1.20.0 xDS modes were broken:

| Bug | Status |
|---|---|
| ADS livelock after the last L7 listener drains ([cilium/cilium#47624](https://github.com/cilium/cilium/issues/47624)) — Gateways all 403 | **Fixed in 1.20.1.** Closed as completed, milestone v1.20.1, fixed by PR #47899 (the cilium-envoy image bump); reporter verified, maintainer confirmed 2026-08-18. |
| split-mode replay of stale NetworkPolicy resources on a new Envoy stream → `duplicate resource key` NACK → node CNI wedged | **Not fixed.** Absent from the 1.20.1 changelog, still no upstream issue. |

So the forward fix exists for exactly one of them — the one that split mode was working around. Taking 1.20.1 while *keeping* `xdsMode: split` would leave us on the unfixed path that wedged hp-workers for 25h on 2026-08-16 (1,018 sandbox failures, longhorn-manager down, 12 kopiur backup Jobs stuck up to 31h). ADS is the path that now has a fix, so the override goes.

## Changes

- `infrastructure/networking/cilium/kustomization.yaml` — `1.20.0-rc.0` → `1.20.1`. `charts/` is gitignored, so the version string is the whole chart change. The comment is now the standing trap: never re-add `xdsMode: split` on 1.20.x.
- `infrastructure/networking/cilium/values.yaml` — `envoy.xdsMode: split` removed.
- `.github/renovate.json5` — `allowedVersions` `<1.20.0` → `<1.21.0`. Still `automerge: false`; a CNI minor is major-risk and 1.20.0 walked in unreviewed through the blanket minor automerge.

## Verified by rendering

`kustomize build --enable-helm infrastructure/networking/cilium/` exits 0 and produces:

- `envoy-xds-mode: ads` in the cilium ConfigMap
- agent / operator / hubble-relay at `v1.20.1`
- `quay.io/cilium/cilium-envoy:v1.37.5-1786810558-766ccfb3…` — the image carrying the #47624 fix (rc.0 shipped `v1.37.5-1782911245`)

## Rollout risk & verification

ADS is the mode that 403'd every Gateway on 2026-08-11, so this trusts an upstream fix on the path that burned us first. After Argo syncs:

1. Gateways serve rather than 403.
2. Zero `NACK received` in `cilium-agent` logs on hp-workers during endpoint churn.

Rollback ladder: `1.20.0-rc.0` + split, then `1.19.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
