### PR TITLE
dcgm-exporter: give probes a 5s timeout

### DIFF
--- a/monitoring/prometheus-stack/dcgm-exporter.yaml
+++ b/monitoring/prometheus-stack/dcgm-exporter.yaml
@@ -70,18 +70,21 @@ spec:
               memory: 128Mi
             limits:
               memory: 512Mi
+          # DCGM /health stalls past the 1s default while the GPU is under load; 1s probes = restart loops.
           livenessProbe:
             httpGet:
               path: /health
               port: 9400
             initialDelaySeconds: 45
             periodSeconds: 30
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
               port: 9400
             initialDelaySeconds: 15
             periodSeconds: 15
+            timeoutSeconds: 5
       volumes:
         - name: proc
           hostPath:


### PR DESCRIPTION
DCGM's \`/health\` goes slow while the GPU is under real load (llama.cpp), and both probes ran with the kubelet default \`timeoutSeconds: 1\` — liveness killed the exporter **9 times in 21h** (\`Readiness probe failed: context deadline exceeded\` on \`:9400\`). Surfaced by the coroot trial.

Fix: \`timeoutSeconds: 5\` on both probes. Periods/delays unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUvfySAKmnJhKXc2iHjGLV