### PR TITLE
chore(worldmonitor): roll out upstream sync

### DIFF
--- a/my-apps/media/worldmonitor/deployment-app.yaml
+++ b/my-apps/media/worldmonitor/deployment-app.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: worldmonitor
-          image: ghcr.io/mitchross/worldmonitor:sha-7f0ba26
+          image: ghcr.io/mitchross/worldmonitor:sha-c08ffcf
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -37,6 +37,11 @@ spec:
                 secretKeyRef:
                   name: worldmonitor-secrets
                   key: REDIS_TOKEN
+            - name: WM_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: worldmonitor-secrets
+                  key: WM_SESSION_SECRET
           ports:
             - name: http
               containerPort: 8080

--- a/my-apps/media/worldmonitor/deployment-redis-rest.yaml
+++ b/my-apps/media/worldmonitor/deployment-redis-rest.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: redis-rest
-          image: ghcr.io/mitchross/worldmonitor-redis-rest:sha-7f0ba26
+          image: ghcr.io/mitchross/worldmonitor-redis-rest:sha-c08ffcf
           imagePullPolicy: IfNotPresent
           env:
             - name: SRH_TOKEN

--- a/my-apps/media/worldmonitor/deployment-relay.yaml
+++ b/my-apps/media/worldmonitor/deployment-relay.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: ais-relay
-          image: ghcr.io/mitchross/worldmonitor-relay:sha-7f0ba26
+          image: ghcr.io/mitchross/worldmonitor-relay:sha-c08ffcf
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/my-apps/media/worldmonitor/externalsecret.yaml
+++ b/my-apps/media/worldmonitor/externalsecret.yaml
@@ -41,3 +41,8 @@ spec:
       remoteRef:
         key: worldmonitor
         property: aisstream_api_key
+    # REQUIRED: Signs self-hosted session state; the app rejects startup without it.
+    - secretKey: WM_SESSION_SECRET
+      remoteRef:
+        key: worldmonitor
+        property: wm_session_secret


### PR DESCRIPTION
## Summary
- pin the app, AIS relay, and Redis REST images to `sha-c08ffcf`
- sync `WM_SESSION_SECRET` from the existing 1Password `worldmonitor` item
- inject the session secret into the app deployment

## Validation
- `kustomize build my-apps/media/worldmonitor --enable-helm`
- rendered-image and secret-wiring assertions
- `bash ./scripts/validate-argocd-apps.sh`
- `git diff --check`

Upstream image fix: mitchross/worldmonitor#7