### PR TITLE
radar-ng: worker v1.1.23 — self-healing schedule seeder

### DIFF
--- a/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
@@ -49,7 +49,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.22
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.23
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Rotates the temporal worker to \`v1.1.23\` (built by radar-ng CI from the merged [radar-ng#31](https://github.com/mitchross/radar-ng/pull/31)).

What the new image carries: startup schedule seeding now applies each schedule with a 15s \`rpc_timeout\` and, after 3 consecutive timeouts on the same schedule, treats its backing \`temporal-sys-scheduler\` workflow as wedged and **deletes + recreates it automatically** — the manual surgery from the 2026-08-25 \`nowcast\` incident (100+ worker restarts), now self-healing.

On merge the WorkerDeployment controller runs its Progressive rollout (10% → 2m pause → 50% → 5m pause → 100%), with the old build sunsetting after drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUvfySAKmnJhKXc2iHjGLV