### PR TITLE
home-assistant: remove migrated http: YAML block

### DIFF
--- a/my-apps/home/home-assistant/configuration.yaml
+++ b/my-apps/home/home-assistant/configuration.yaml
@@ -32,16 +32,6 @@ automation: !include automations.yaml
 script: !include scripts.yaml
 scene: !include scenes.yaml
 
-# HTTP configuration for reverse proxy
-http:
-  use_x_forwarded_for: true
-  trusted_proxies:
-    - 10.0.0.0/8
-    - 172.16.0.0/12
-    - 192.168.0.0/16
-    - 192.168.10.32/27 # Cilium IP Pool
-    - 192.168.10.50 # Gateway IP
-
 # rssi/lqi excluded: they churn every update and bloat SQLite; long-term statistics are unaffected.
 recorder:
   db_url: sqlite:////config/home-assistant_v2.db


### PR DESCRIPTION
HA's 'HTTP YAML configuration is ignored after migration' repair (3 weeks old) — the `http:` block in configuration.yaml was auto-migrated into UI storage and is now ignored; support is removed in 2027.2.0.

Removes only the comment + http: section (use_x_forwarded_for + trusted_proxies). Nothing else touched.

**After merge + ArgoCD sync:** open Settings → Devices & services → HTTP and confirm `use_x_forwarded_for` is enabled and all five trusted proxies are present (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 192.168.10.32/27, 192.168.10.50). If any are missing, add them in the UI — they were not independently verified before this deletion.