### PR TITLE
radar-ng: worker CPU request 1 → 250m so progressive rollouts can schedule

### DIFF
--- a/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
@@ -81,7 +81,8 @@ spec:
             - { name: state,  mountPath: /data/state }
           resources:
             # CPU-bound (pysteps nowcast + MRMS reproject) — a tight CPU limit makes nowcast_run time out.
-            requests: { cpu: "1", memory: "3Gi" }   # single-node: 1 replica; request low, bursts to 12-core limit
+            # 250m: Progressive rollout runs old+new side by side on tile-server's node (RWO affinity); 2×1-CPU requests can't schedule there.
+            requests: { cpu: "250m", memory: "3Gi" }
             limits:   { cpu: "12", memory: "12Gi" }
       volumes:
         - name: tiles


### PR DESCRIPTION
The v1.1.23 canary is stuck **Pending**: the Progressive rollout runs old + new worker builds side by side, both forced onto tile-server's node by the RWO-volume podAffinity — and hp-sff sits at **95% CPU requests** (5679m/5950m, 271m free). A second 1-CPU request can never schedule there, on this or any future rollout.

Fix: request `250m` (two workers = 500m, fits with slack). Burst capacity unchanged — the 12-CPU limit is what matters for nowcast/MRMS crunch; the request only reserves scheduler headroom for a single-replica workload.

On merge, the controller stamps a new build from the changed template, the stuck `v1.1.23-df5c` deployment supersedes, and the rollout proceeds (10% → 2m → 50% → 5m → 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUvfySAKmnJhKXc2iHjGLV