### PR TITLE
deal-scout: publish deals.vanillax.me read-only

### DIFF
--- a/my-apps/utility/deal-scout/httproute.yaml
+++ b/my-apps/utility/deal-scout/httproute.yaml
@@ -1,4 +1,4 @@
-# Internal-only: dashboard read endpoints are unauthenticated — add auth before moving to gateway-external.
+# Internal route: full read/write. The public route below is GET-only because the writes are unauthenticated.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -17,6 +17,45 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: deal-scout
+          port: 8000
+          weight: 1
+---
+# Public read-only: GET/HEAD only. PUT /api/config, DELETE /api/learned/*,
+# POST /api/{scan-request,digest/generate,feedback} are unauthenticated, so the
+# internet gets the dashboard and none of the writes. Ingest/scan-job POSTs are
+# token-gated but stay internal too; workers use the in-cluster Service.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: deal-scout-public
+  namespace: deal-scout
+  labels:
+    external-dns: "true"
+  annotations:
+    external-dns.alpha.kubernetes.io/target: vanillax.me
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-external
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - "deals.vanillax.me"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+          method: GET
+        - path:
+            type: PathPrefix
+            value: /
+          method: HEAD
       backendRefs:
         - group: ""
           kind: Service


### PR DESCRIPTION
Makes the deal dashboard browsable from the internet while keeping all processing and every mutation local.

## What

A second HTTPRoute on \`gateway-external\` for \`deals.vanillax.me\`, matching **GET and HEAD only**. The existing internal route on \`gateway-internal-technitium\` is unchanged (full read/write from the LAN).

## Why GET-only

An endpoint audit found five mutating routes with **no auth**:

| Endpoint | Anonymous visitor could |
|---|---|
| \`PUT /api/config\` | rewrite queries, thresholds, deal ratio, sources |
| \`DELETE /api/learned/{term}\` | delete learned classifier terms |
| \`POST /api/scan-request\` | queue scans (eBay API quota) |
| \`POST /api/digest/generate\` | trigger local-Qwen inference |
| \`POST /api/feedback\` | poison training data |

Read endpoints expose no secrets (\`GET /api/config\` returns queries/thresholds only), so publishing the view is safe; the writes are not. Gateway-level method matching fixes this with no app change.

## Processing is unaffected

Nothing in the pipeline uses the public hostname — verified:
- workers → dashboard: \`http://deal-scout:8000\` (in-cluster Service)
- dashboard → AI: \`http://llama-cpp-service.llama-cpp.svc.cluster.local:8080\` (local Qwen)

Facebook/eBay scanning continues to run entirely in-cluster on the Temporal workers.

Carries the three required external-route pieces: \`external-dns: "true"\` label, \`external-dns.alpha.kubernetes.io/target: vanillax.me\`, and \`sectionName: https\`.

## Follow-up option

If you later want public write features (feedback voting etc.), the durable fix is adding auth to those five endpoints in the deal-scout repo — then the method restriction can be relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUvfySAKmnJhKXc2iHjGLV